### PR TITLE
Apply clean architecture package structure

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application
         android:allowBackup="false"
         android:supportsRtl="true"
-        android:name="pl.cuyer.rusthub.di.RustHubApplication"
+        android:name="pl.cuyer.rusthub.presentation.di.RustHubApplication"
         android:theme="@style/AppTheme">
         <activity
             android:name="pl.cuyer.rusthub.android.MainActivity"

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/RustHubApp.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/RustHubApp.kt
@@ -27,10 +27,10 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
-import pl.cuyer.rusthub.navigation.Destination
-import pl.cuyer.rusthub.navigation.NavOptionsBuilder
-import pl.cuyer.rusthub.navigation.NavigationAction
-import pl.cuyer.rusthub.navigation.Navigator
+import pl.cuyer.rusthub.presentation.navigation.Destination
+import pl.cuyer.rusthub.presentation.navigation.NavOptionsBuilder
+import pl.cuyer.rusthub.presentation.navigation.NavigationAction
+import pl.cuyer.rusthub.presentation.navigation.Navigator
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -1,14 +1,13 @@
-package pl.cuyer.rusthub.di
+package pl.cuyer.rusthub.presentation.di
 
 import app.cash.sqldelight.db.SqlDriver
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
-import org.koin.dsl.bind
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 
 actual val platformModule: Module = module {
-    single<SqlDriver> { DatabaseDriverFactory().create() }
+    single<SqlDriver> { DatabaseDriverFactory(androidContext()).create() }
     single { HttpClientFactory(get()).create() }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.di
+package pl.cuyer.rusthub.presentation.di
 
 import android.app.Application
 import org.koin.android.ext.koin.androidContext

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavDestinationMapper.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavDestinationMapper.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 
 import androidx.navigation.NavDestination
 

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationAction.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationAction.android.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 import androidx.navigation.NavOptions as AndroidNavOptions
 
 // Map our common NavOptions to Android's NavOptions.

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/AppModule.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/AppModule.kt
@@ -1,8 +1,8 @@
-package pl.cuyer.rusthub.di
+package pl.cuyer.rusthub.presentation.di
 
-import pl.cuyer.rusthub.navigation.DefaultNavigator
-import pl.cuyer.rusthub.navigation.Destination
-import pl.cuyer.rusthub.navigation.Navigator
+import pl.cuyer.rusthub.presentation.navigation.DefaultNavigator
+import pl.cuyer.rusthub.presentation.navigation.Destination
+import pl.cuyer.rusthub.presentation.navigation.Navigator
 
 interface AppModule {
     val navigator: Navigator

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.di
+package pl.cuyer.rusthub.presentation.di
 
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
@@ -14,9 +14,9 @@ import pl.cuyer.rusthub.data.network.rustmap.RustmapsClientImpl
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.domain.repository.battlemetrics.BattlemetricsClient
 import pl.cuyer.rusthub.domain.repository.rustmap.RustmapsClient
-import pl.cuyer.rusthub.navigation.DefaultNavigator
-import pl.cuyer.rusthub.navigation.Destination
-import pl.cuyer.rusthub.navigation.Navigator
+import pl.cuyer.rusthub.presentation.navigation.DefaultNavigator
+import pl.cuyer.rusthub.presentation.navigation.Destination
+import pl.cuyer.rusthub.presentation.navigation.Navigator
 
 val appModule = module {
     single { RustHubDatabase(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationAction.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 
 sealed interface NavigationAction {
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationOptions.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationOptions.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 
 interface NavigationOptions {
     val popUpTo: Destination?

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Navigator.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Navigator.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -1,13 +1,14 @@
-package pl.cuyer.rusthub.di
+package pl.cuyer.rusthub.presentation.di
 
 import app.cash.sqldelight.db.SqlDriver
-import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
+import org.koin.dsl.bind
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 
 actual val platformModule: Module = module {
-    single<SqlDriver> { DatabaseDriverFactory(androidContext()).create() }
+    single<SqlDriver> { DatabaseDriverFactory().create() }
     single { HttpClientFactory(get()).create() }
 }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationAction.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/navigation/NavigationAction.ios.kt
@@ -1,4 +1,4 @@
-package pl.cuyer.rusthub.navigation
+package pl.cuyer.rusthub.presentation.navigation
 
 data class IosNavOptions(
     val launchSingleTop: Boolean,


### PR DESCRIPTION
## Summary
- move navigation classes under presentation package
- move DI classes under presentation package
- update Android manifest for new RustHubApplication package
- update RustHubApp imports

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd3a1fd6c8321887e636cb1acdaca