### PR TITLE
Separate data layer and ui layer models

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
@@ -1,0 +1,39 @@
+package pl.cuyer.rusthub.data.network.server.mapper
+
+import pl.cuyer.rusthub.data.network.server.model.dto.PagedServerInfoDto
+import pl.cuyer.rusthub.data.network.server.model.dto.ServerInfoDto
+import pl.cuyer.rusthub.domain.model.PagedServerInfo
+import pl.cuyer.rusthub.domain.model.ServerInfo
+
+fun ServerInfoDto.toDomain(): ServerInfo {
+    return ServerInfo(
+        id = id,
+        name = name,
+        wipe = wipe,
+        ranking = ranking,
+        modded = modded,
+        playerCount = playerCount,
+        serverCapacity = serverCapacity,
+        mapName = mapName,
+        cycle = cycle,
+        serverFlag = serverFlag,
+        region = region,
+        maxGroup = maxGroup,
+        difficulty = difficulty,
+        wipeSchedule = wipeSchedule,
+        isOfficial = isOfficial,
+        serverIp = serverIp,
+        mapImage = mapImage,
+        description = description,
+        mapId = mapId,
+    )
+}
+
+fun PagedServerInfoDto.toDomain(): PagedServerInfo {
+    return PagedServerInfo(
+        servers = servers.map { it.toDomain() },
+        size = size,
+        totalPages = totalPages,
+        totalItems = totalItems,
+    )
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/dto/PagedServerInfoDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/dto/PagedServerInfoDto.kt
@@ -1,0 +1,16 @@
+package pl.cuyer.rusthub.data.network.server.model.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagedServerInfoDto(
+    @SerialName("servers")
+    val servers: List<ServerInfoDto>,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("total_pages")
+    val totalPages: Int,
+    @SerialName("total_items")
+    val totalItems: Int,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/dto/ServerInfoDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/dto/ServerInfoDto.kt
@@ -1,0 +1,40 @@
+package pl.cuyer.rusthub.data.network.server.model.dto
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import pl.cuyer.rusthub.domain.model.Difficulty
+import pl.cuyer.rusthub.domain.model.Flag
+import pl.cuyer.rusthub.domain.model.Maps
+import pl.cuyer.rusthub.domain.model.Region
+import pl.cuyer.rusthub.domain.model.WipeSchedule
+
+@Serializable
+data class ServerInfoDto(
+    val id: Long? = null,
+    val name: String? = null,
+    val wipe: Instant? = null,
+    val ranking: Double? = null,
+    val modded: Boolean? = null,
+    @SerialName("player_count")
+    val playerCount: Long? = null,
+    @SerialName("server_capacity")
+    val serverCapacity: Long? = null,
+    @SerialName("map_name")
+    val mapName: Maps? = null,
+    val cycle: Double? = null,
+    @SerialName("server_flag")
+    val serverFlag: Flag? = null,
+    val region: Region? = null,
+    @SerialName("max_group")
+    val maxGroup: Long? = null,
+    val difficulty: Difficulty? = null,
+    @SerialName("wipe_schedule")
+    val wipeSchedule: WipeSchedule? = null,
+    val isOfficial: Boolean? = null,
+    val serverIp: String? = null,
+    @SerialName("map_image")
+    val mapImage: String? = null,
+    val description: String? = null,
+    val mapId: String? = null,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/PagedServerInfo.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/PagedServerInfo.kt
@@ -1,0 +1,16 @@
+package pl.cuyer.rusthub.domain.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagedServerInfo(
+    @SerialName("servers")
+    val servers: List<ServerInfo>,
+    @SerialName("size")
+    val size: Int,
+    @SerialName("total_pages")
+    val totalPages: Int,
+    @SerialName("total_items")
+    val totalItems: Int,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/server/ServerRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/server/ServerRepository.kt
@@ -2,7 +2,7 @@ package pl.cuyer.rusthub.domain.repository.server
 
 import kotlinx.coroutines.flow.Flow
 import pl.cuyer.rusthub.common.Result
-import pl.cuyer.rusthub.data.network.server.model.PagedServerInfo
+import pl.cuyer.rusthub.domain.model.PagedServerInfo
 import pl.cuyer.rusthub.domain.model.ServerQuery
 
 interface ServerRepository {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/ServerViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/ServerViewModel.kt
@@ -21,6 +21,8 @@ import pl.cuyer.rusthub.domain.mapper.toServerInfo
 import pl.cuyer.rusthub.domain.model.ServerInfo
 import pl.cuyer.rusthub.domain.model.ServerQuery
 import pl.cuyer.rusthub.domain.usecase.GetPagedServersUseCase
+import pl.cuyer.rusthub.presentation.model.ServerInfoUi
+import pl.cuyer.rusthub.presentation.model.toUi
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarAction
@@ -35,9 +37,9 @@ class ServerViewModel(
     private val queryFlow = MutableStateFlow(ServerQuery())
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    var paging: Flow<PagingData<ServerInfo>> = queryFlow
+    var paging: Flow<PagingData<ServerInfoUi>> = queryFlow
         .flatMapLatest { query ->
-            getPagedServersUseCase(query).map { it.map { it.toServerInfo() } }
+            getPagedServersUseCase(query).map { it.map { it.toServerInfo().toUi() } }
         }
         .cachedIn(coroutineScope)
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
@@ -1,0 +1,40 @@
+package pl.cuyer.rusthub.presentation.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import pl.cuyer.rusthub.domain.model.Difficulty
+import pl.cuyer.rusthub.domain.model.Flag
+import pl.cuyer.rusthub.domain.model.Maps
+import pl.cuyer.rusthub.domain.model.Region
+import pl.cuyer.rusthub.domain.model.WipeSchedule
+
+@Serializable
+data class ServerInfoUi(
+    val id: Long? = null,
+    val name: String? = null,
+    val wipe: Instant? = null,
+    val ranking: Double? = null,
+    val modded: Boolean? = null,
+    @SerialName("player_count")
+    val playerCount: Long? = null,
+    @SerialName("server_capacity")
+    val serverCapacity: Long? = null,
+    @SerialName("map_name")
+    val mapName: Maps? = null,
+    val cycle: Double? = null,
+    @SerialName("server_flag")
+    val serverFlag: Flag? = null,
+    val region: Region? = null,
+    @SerialName("max_group")
+    val maxGroup: Long? = null,
+    val difficulty: Difficulty? = null,
+    @SerialName("wipe_schedule")
+    val wipeSchedule: WipeSchedule? = null,
+    val isOfficial: Boolean? = null,
+    val serverIp: String? = null,
+    @SerialName("map_image")
+    val mapImage: String? = null,
+    val description: String? = null,
+    val mapId: String? = null,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
@@ -1,0 +1,27 @@
+package pl.cuyer.rusthub.presentation.model
+
+import pl.cuyer.rusthub.domain.model.ServerInfo
+
+fun ServerInfo.toUi(): ServerInfoUi {
+    return ServerInfoUi(
+        id = id,
+        name = name,
+        wipe = wipe,
+        ranking = ranking,
+        modded = modded,
+        playerCount = playerCount,
+        serverCapacity = serverCapacity,
+        mapName = mapName,
+        cycle = cycle,
+        serverFlag = serverFlag,
+        region = region,
+        maxGroup = maxGroup,
+        difficulty = difficulty,
+        wipeSchedule = wipeSchedule,
+        isOfficial = isOfficial,
+        serverIp = serverIp,
+        mapImage = mapImage,
+        description = description,
+        mapId = mapId,
+    )
+}


### PR DESCRIPTION
## Summary
- add `PagedServerInfo` domain model
- introduce data layer DTOs for network
- map network DTOs to domain
- create ui models and mappers
- use ui models in `ServerViewModel`

## Testing
- `./gradlew :shared:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528ef9e0d483218cdb64c7fd98272c