### PR TITLE
Fix offline filtering for Paging3

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
@@ -9,6 +9,7 @@ import pl.cuyer.rusthub.data.local.Queries
 import pl.cuyer.rusthub.data.local.mapper.toEntity
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.domain.model.ServerInfo
+import pl.cuyer.rusthub.domain.model.ServerQuery
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 
 class ServerDataSourceImpl(
@@ -43,15 +44,38 @@ class ServerDataSourceImpl(
         }
     }
 
-    override fun getServersPagingSource(): PagingSource<Int, ServerEntity> {
+    override fun getServersPagingSource(query: ServerQuery?): PagingSource<Int, ServerEntity> {
         val pagingSource: PagingSource<Int, ServerEntity> = QueryPagingSource(
-            countQuery = queries.countPagedServers(),
+            countQuery = queries.countPagedServersFiltered(
+                wipe = query?.wipe?.toString(),
+                ranking = query?.ranking,
+                modded = query?.modded,
+                player_count = query?.playerCount,
+                map_name = query?.map?.toEntity(),
+                server_flag = query?.flag?.toEntity(),
+                region = query?.region?.toEntity(),
+                group_limit = query?.groupLimit,
+                difficulty = query?.difficulty?.toEntity(),
+                wipe_schedule = query?.wipeSchedule?.toEntity(),
+                is_official = query?.official
+            ),
             transacter = queries,
             context = Dispatchers.IO,
             queryProvider = { limit: Long, offset: Long ->
-                queries.findServersPaged(
+                queries.findServersPagedFiltered(
                     limit = limit,
-                    offset = offset
+                    offset = offset,
+                    wipe = query?.wipe?.toString(),
+                    ranking = query?.ranking,
+                    modded = query?.modded,
+                    player_count = query?.playerCount,
+                    map_name = query?.map?.toEntity(),
+                    server_flag = query?.flag?.toEntity(),
+                    region = query?.region?.toEntity(),
+                    group_limit = query?.groupLimit,
+                    difficulty = query?.difficulty?.toEntity(),
+                    wipe_schedule = query?.wipeSchedule?.toEntity(),
+                    is_official = query?.official
                 )
             }
         )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/server/ServerDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/server/ServerDataSource.kt
@@ -6,6 +6,6 @@ import pl.cuyer.rusthub.domain.model.ServerInfo
 
 interface ServerDataSource {
     fun upsertServers(servers: List<ServerInfo>)
-    fun getServersPagingSource(): PagingSource<Int, ServerEntity>
+    fun getServersPagingSource(query: ServerQuery?): PagingSource<Int, ServerEntity>
     fun deleteServers()
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetPagedServersUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetPagedServersUseCase.kt
@@ -6,6 +6,8 @@ import app.cash.paging.PagingConfig
 import app.cash.paging.PagingData
 import database.ServerEntity
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import pl.cuyer.rusthub.domain.repository.RemoteKeyDataSource
 import pl.cuyer.rusthub.domain.repository.filters.FiltersDataSource
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
@@ -31,7 +33,10 @@ class GetPagedServersUseCase(
                 filters,
                 remoteKeys
             ),
-            pagingSourceFactory = { dataSource.getServersPagingSource() }
+            pagingSourceFactory = {
+                val query = runBlocking { filters.getFilters().first() }
+                dataSource.getServersPagingSource(query)
+            }
         ).flow
     }
 }

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -40,10 +40,42 @@ FROM serverEntity
 ORDER BY wipe DESC
 LIMIT :limit OFFSET :offset;
 
+findServersPagedFiltered:
+SELECT *
+FROM serverEntity
+WHERE (:wipe IS NULL OR wipe >= :wipe)
+  AND (:ranking IS NULL OR ranking >= :ranking)
+  AND (:modded IS NULL OR modded = CASE WHEN :modded THEN 1 ELSE 0 END)
+  AND (:player_count IS NULL OR player_count >= :player_count)
+  AND (:map_name IS NULL OR map_name = :map_name)
+  AND (:server_flag IS NULL OR server_flag = :server_flag)
+  AND (:region IS NULL OR region = :region)
+  AND (:group_limit IS NULL OR max_group <= :group_limit)
+  AND (:difficulty IS NULL OR difficulty = :difficulty)
+  AND (:wipe_schedule IS NULL OR wipe_schedule = :wipe_schedule)
+  AND (:is_official IS NULL OR is_official = CASE WHEN :is_official THEN 1 ELSE 0 END)
+ORDER BY wipe DESC
+LIMIT :limit OFFSET :offset;
+
 countPagedServers:
 SELECT
   COUNT(*)
 FROM serverEntity;
+
+countPagedServersFiltered:
+SELECT COUNT(*)
+FROM serverEntity
+WHERE (:wipe IS NULL OR wipe >= :wipe)
+  AND (:ranking IS NULL OR ranking >= :ranking)
+  AND (:modded IS NULL OR modded = CASE WHEN :modded THEN 1 ELSE 0 END)
+  AND (:player_count IS NULL OR player_count >= :player_count)
+  AND (:map_name IS NULL OR map_name = :map_name)
+  AND (:server_flag IS NULL OR server_flag = :server_flag)
+  AND (:region IS NULL OR region = :region)
+  AND (:group_limit IS NULL OR max_group <= :group_limit)
+  AND (:difficulty IS NULL OR difficulty = :difficulty)
+  AND (:wipe_schedule IS NULL OR wipe_schedule = :wipe_schedule)
+  AND (:is_official IS NULL OR is_official = CASE WHEN :is_official THEN 1 ELSE 0 END);
 
 -- =============================================================================
 -- Upsert (Insert or Update on id conflict)


### PR DESCRIPTION
## Summary
- allow `ServerDataSource` to provide paging source based on a query
- add local SQL queries for filtered paging
- use filters when creating pager so offline filtering works

## Testing
- `./gradlew :shared:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685423b8b57c8321ba9a12ae2953da23