### PR TITLE
Use FiltersEntity for server paging filters

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
@@ -5,10 +5,10 @@ import app.cash.sqldelight.paging3.QueryPagingSource
 import database.ServerEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import pl.cuyer.rusthub.common.Constants.DEFAULT_KEY
 import pl.cuyer.rusthub.data.local.Queries
 import pl.cuyer.rusthub.data.local.mapper.toEntity
 import pl.cuyer.rusthub.database.RustHubDatabase
-import pl.cuyer.rusthub.domain.model.Order
 import pl.cuyer.rusthub.domain.model.ServerInfo
 import pl.cuyer.rusthub.domain.model.ServerQuery
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
@@ -49,36 +49,14 @@ class ServerDataSourceImpl(
 
     override fun getServersPagingSource(query: ServerQuery?): PagingSource<Int, ServerEntity> {
         val pagingSource: PagingSource<Int, ServerEntity> = QueryPagingSource(
-            countQuery = queries.countPagedServersFiltered(
-                wipe = query?.wipe?.toString(),
-                ranking = query?.ranking,
-                modded = if (query?.modded == true) 1 else null,
-                player_count = query?.playerCount,
-                map_name = query?.map?.toEntity(),
-                server_flag = query?.flag?.toEntity(),
-                region = query?.region?.toEntity(),
-                group_limit = query?.groupLimit,
-                difficulty = query?.difficulty?.toEntity(),
-                wipe_schedule = query?.wipeSchedule?.toEntity(),
-                is_official = if (query?.official == true) 1 else null
-            ),
+            countQuery = queries.countPagedServersFiltered(id = DEFAULT_KEY),
             transacter = queries,
             context = Dispatchers.IO,
             queryProvider = { limit: Long, offset: Long ->
                 queries.findServersPagedFiltered(
+                    id = DEFAULT_KEY,
                     limit = limit,
-                    offset = offset,
-                    ranking = query?.ranking,
-                    modded = if (query?.modded == true) 1 else null,
-                    player_count = query?.playerCount,
-                    map_name = query?.map?.toEntity(),
-                    server_flag = query?.flag?.toEntity(),
-                    region = query?.region?.toEntity(),
-                    group_limit = query?.groupLimit,
-                    difficulty = query?.difficulty?.toEntity(),
-                    wipe_schedule = query?.wipeSchedule?.toEntity(),
-                    is_official = if (query?.official == true) 1 else null,
-                    order = query?.order?.name ?: Order.WIPE.name
+                    offset = offset
                 )
             }
         )

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -39,40 +39,42 @@ CREATE TABLE serverEntity (
 -- =============================================================================
 -- Returns a page of servers
 findServersPagedFiltered:
-SELECT *
+SELECT serverEntity.*
 FROM serverEntity
+    CROSS JOIN filtersEntity ON filtersEntity.id = :id
 WHERE
-  (:ranking IS NULL OR ranking <= :ranking)
-  AND (:modded IS NULL OR modded = :modded)
-  AND (:player_count IS NULL OR player_count <= :player_count)
-  AND(:map_name IS NULL OR map_name = :map_name)
-  AND (:server_flag IS NULL OR server_flag = :server_flag)
-  AND (:region IS NULL OR region = :region)
-  AND (:group_limit IS NULL OR max_group <= :group_limit)
-  AND (:difficulty IS NULL OR difficulty = :difficulty)
-  AND (:wipe_schedule IS NULL OR wipe_schedule = :wipe_schedule)
-  AND (:is_official IS NULL OR is_official = :is_official)
+  (filtersEntity.ranking IS NULL OR ranking <= filtersEntity.ranking)
+  AND (filtersEntity.modded IS NULL OR modded = filtersEntity.modded)
+  AND (filtersEntity.player_count IS NULL OR player_count <= filtersEntity.player_count)
+  AND (filtersEntity.map_name IS NULL OR map_name = filtersEntity.map_name)
+  AND (filtersEntity.server_flag IS NULL OR server_flag = filtersEntity.server_flag)
+  AND (filtersEntity.region IS NULL OR region = filtersEntity.region)
+  AND (filtersEntity.group_limit IS NULL OR max_group <= filtersEntity.group_limit)
+  AND (filtersEntity.difficulty IS NULL OR difficulty = filtersEntity.difficulty)
+  AND (filtersEntity.wipe_schedule IS NULL OR wipe_schedule = filtersEntity.wipe_schedule)
+  AND (filtersEntity.is_official IS NULL OR is_official = filtersEntity.is_official)
   ORDER BY
-    CASE WHEN :order = 'WIPE' THEN wipe END DESC,
-    CASE WHEN :order = 'PLAYER_COUNT' THEN player_count END DESC,
-    CASE WHEN :order = 'RANK' THEN ranking END ASC
+    CASE WHEN filtersEntity.sort_order = 'WIPE' THEN wipe END DESC,
+    CASE WHEN filtersEntity.sort_order = 'PLAYER_COUNT' THEN player_count END DESC,
+    CASE WHEN filtersEntity.sort_order = 'RANK' THEN ranking END ASC
 LIMIT :limit OFFSET :offset;
 
 countPagedServersFiltered:
 SELECT COUNT(*)
 FROM serverEntity
+    CROSS JOIN filtersEntity ON filtersEntity.id = :id
 WHERE
-  (:wipe IS NULL OR date(wipe) >= date(:wipe))
-  AND (:ranking IS NULL OR ranking <= :ranking)
-  AND (:modded IS NULL OR modded = :modded)
-  AND (:player_count IS NULL OR player_count <= :player_count)
-  AND(:map_name IS NULL OR map_name = :map_name)
-  AND (:server_flag IS NULL OR server_flag = :server_flag)
-  AND (:region IS NULL OR region = :region)
-  AND (:group_limit IS NULL OR max_group <= :group_limit)
-  AND (:difficulty IS NULL OR difficulty = :difficulty)
-  AND (:wipe_schedule IS NULL OR wipe_schedule = :wipe_schedule)
-  AND (:is_official IS NULL OR is_official = :is_official);
+  (filtersEntity.wipe IS NULL OR date(wipe) >= date(filtersEntity.wipe))
+  AND (filtersEntity.ranking IS NULL OR ranking <= filtersEntity.ranking)
+  AND (filtersEntity.modded IS NULL OR modded = filtersEntity.modded)
+  AND (filtersEntity.player_count IS NULL OR player_count <= filtersEntity.player_count)
+  AND (filtersEntity.map_name IS NULL OR map_name = filtersEntity.map_name)
+  AND (filtersEntity.server_flag IS NULL OR server_flag = filtersEntity.server_flag)
+  AND (filtersEntity.region IS NULL OR region = filtersEntity.region)
+  AND (filtersEntity.group_limit IS NULL OR max_group <= filtersEntity.group_limit)
+  AND (filtersEntity.difficulty IS NULL OR difficulty = filtersEntity.difficulty)
+  AND (filtersEntity.wipe_schedule IS NULL OR wipe_schedule = filtersEntity.wipe_schedule)
+  AND (filtersEntity.is_official IS NULL OR is_official = filtersEntity.is_official);
 
 -- =============================================================================
 -- Upsert (Insert or Update on id conflict)


### PR DESCRIPTION
## Summary
- update `findServersPagedFiltered` and `countPagedServersFiltered` SQL queries to read filters from `FiltersEntity`
- update `ServerDataSourceImpl` to use new queries and pass default filters id

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: starting build but aborted due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68553ba7465c8321aa753aaa7d2ec011