### PR TITLE
Fix lost search query after details navigation

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.ui.text.google.fonts)
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.compose)
+    implementation(libs.koin.androidx.compose)
     implementation(libs.coil.compose)
     implementation(libs.coil.network)
     implementation(libs.androidx.navigation)

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -26,7 +26,7 @@ import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import app.cash.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.launch
-import org.koin.compose.koinInject
+import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
@@ -96,7 +96,7 @@ fun NavigationRoot() {
                     entry<ServerList>(
                         metadata = TwoPaneScene.twoPane()
                     ) {
-                        val viewModel = koinInject<ServerViewModel>()
+                        val viewModel = koinViewModel<ServerViewModel>()
                         val state = viewModel.state.collectAsStateWithLifecycle()
                         val paging = viewModel.paging.collectAsLazyPagingItems()
 
@@ -113,7 +113,7 @@ fun NavigationRoot() {
                     entry<ServerDetails>(
                         metadata = TwoPaneScene.twoPane()
                     ) { key ->
-                        val viewModel = koinInject<ServerDetailsViewModel>() {
+                        val viewModel = koinViewModel<ServerDetailsViewModel>() {
                             parametersOf(
                                 key.id,
                                 key.name

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android" }
 koin-core = { module = "io.insert-koin:koin-core" }
 koin-compose = { module = "io.insert-koin:koin-compose" }
+koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose" }
 
 #KTOR
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -1,15 +1,39 @@
 package pl.cuyer.rusthub.presentation.di
 
 import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
 import org.koin.dsl.module
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.util.ClipboardHandler
+import pl.cuyer.rusthub.presentation.features.ServerDetailsViewModel
+import pl.cuyer.rusthub.presentation.features.ServerViewModel
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory(androidContext()).create() }
     single { HttpClientFactory(get()).create() }
     single { ClipboardHandler(get()) }
+    viewModel {
+        ServerViewModel(
+            clipboardHandler = get(),
+            snackbarController = get(),
+            getPagedServersUseCase = get(),
+            getFiltersUseCase = get(),
+            getFiltersOptions = get(),
+            saveFiltersUseCase = get(),
+            clearFiltersUseCase = get(),
+            saveSearchQueryUseCase = get(),
+            getSearchQueriesUseCase = get(),
+            deleteSearchQueriesUseCase = get()
+        )
+    }
+    viewModel { (serverId: Long, serverName: String?) ->
+        ServerDetailsViewModel(
+            getServerDetailsUseCase = get(),
+            serverName = serverName,
+            serverId = serverId
+        )
+    }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -1,15 +1,15 @@
 package pl.cuyer.rusthub.presentation.di
 
 import org.koin.android.ext.koin.androidContext
-import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
-import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.presentation.features.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.ServerViewModel
+import pl.cuyer.rusthub.util.ClipboardHandler
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory(androidContext()).create() }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -63,14 +63,6 @@ val appModule = module {
     single { GetSearchQueriesUseCase(get()) }
     single { DeleteSearchQueriesUseCase(get()) }
     single { GetServerDetailsUseCase(get()) }
-    factoryOf(::ServerViewModel)
-    factory { (serverId: Long, serverName: String?) ->
-        ServerDetailsViewModel(
-            getServerDetailsUseCase = get(),
-            serverId = serverId,
-            serverName = serverName
-        )
-    }
 }
 
 expect val platformModule: Module


### PR DESCRIPTION
## Summary
- keep the server list ViewModel in Android's ViewModelStore
- use the ViewModelStore when obtaining ViewModels in navigation

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685691300f7c8321a42f137d7b07914f