### PR TITLE
Improve wipe date localization

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.android.kt
@@ -1,0 +1,13 @@
+package pl.cuyer.rusthub.util
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.toJavaLocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+actual fun formatLocalDate(date: LocalDate): String {
+    val formatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+        .withLocale(Locale.getDefault())
+    return formatter.format(date.toJavaLocalDate())
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import pl.cuyer.rusthub.util.formatLocalDate
 import pl.cuyer.rusthub.domain.model.ServerInfo
 
 fun ServerInfo.toUi(): ServerInfoUi {
@@ -49,6 +50,7 @@ fun formatLastWipe(wipeInstant: Instant): String {
     val now = Clock.System.now()
     val duration = now - wipeInstant
     val localDate = wipeInstant.toLocalDateTime(TimeZone.currentSystemDefault()).date
+    val formattedDate = formatLocalDate(localDate)
 
     val timeAgo = when {
         duration.inWholeDays >= 1 -> "${duration.inWholeDays} days ago"
@@ -56,5 +58,5 @@ fun formatLastWipe(wipeInstant: Instant): String {
         else -> "${duration.inWholeMinutes} minutes ago"
     }
 
-    return "$localDate ($timeAgo)"
+    return "$formattedDate ($timeAgo)"
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+import kotlinx.datetime.LocalDate
+
+expect fun formatLocalDate(date: LocalDate): String

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.ios.kt
@@ -1,0 +1,21 @@
+package pl.cuyer.rusthub.util
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toNSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSDateFormatterMediumStyle
+import platform.Foundation.NSDateFormatterNoStyle
+import platform.Foundation.NSLocale
+import platform.Foundation.currentLocale
+
+actual fun formatLocalDate(date: LocalDate): String {
+    val formatter = NSDateFormatter()
+    formatter.dateStyle = NSDateFormatterMediumStyle
+    formatter.timeStyle = NSDateFormatterNoStyle
+    formatter.locale = NSLocale.currentLocale
+    val instant = date.atStartOfDayIn(TimeZone.currentSystemDefault())
+    val nsDate = instant.toNSDate()
+    return formatter.stringFromDate(nsDate)
+}


### PR DESCRIPTION
## Summary
- add `formatLocalDate` expect/actual implementations
- use `formatLocalDate` in `formatLastWipe` to provide locale-aware date strings

## Testing
- `./gradlew :shared:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca6ec04c8321af19175f35fcf270