### PR TITLE
Improve wipe date localization

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.android.kt
@@ -1,0 +1,15 @@
+package pl.cuyer.rusthub.util
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+actual fun formatLocalDateTime(dateTime: LocalDateTime): String {
+    val formatter = DateTimeFormatter.ofLocalizedDateTime(
+        FormatStyle.MEDIUM,
+        FormatStyle.SHORT
+    ).withLocale(Locale.getDefault())
+    return formatter.format(dateTime.toJavaLocalDateTime())
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import pl.cuyer.rusthub.util.formatLocalDateTime
 import pl.cuyer.rusthub.domain.model.ServerInfo
 
 fun ServerInfo.toUi(): ServerInfoUi {
@@ -48,7 +49,8 @@ fun ServerInfo.toUi(): ServerInfoUi {
 fun formatLastWipe(wipeInstant: Instant): String {
     val now = Clock.System.now()
     val duration = now - wipeInstant
-    val localDate = wipeInstant.toLocalDateTime(TimeZone.currentSystemDefault()).date
+    val localDateTime = wipeInstant.toLocalDateTime(TimeZone.currentSystemDefault())
+    val formattedDate = formatLocalDateTime(localDateTime)
 
     val timeAgo = when {
         duration.inWholeDays >= 1 -> "${duration.inWholeDays} days ago"
@@ -56,5 +58,5 @@ fun formatLastWipe(wipeInstant: Instant): String {
         else -> "${duration.inWholeMinutes} minutes ago"
     }
 
-    return "$localDate ($timeAgo)"
+    return "$formattedDate ($timeAgo)"
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+import kotlinx.datetime.LocalDateTime
+
+expect fun formatLocalDateTime(dateTime: LocalDateTime): String

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/DateFormatter.ios.kt
@@ -1,0 +1,20 @@
+package pl.cuyer.rusthub.util
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toNSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSDateFormatterMediumStyle
+import platform.Foundation.NSLocale
+import platform.Foundation.currentLocale
+
+actual fun formatLocalDateTime(dateTime: LocalDateTime): String {
+    val formatter = NSDateFormatter()
+    formatter.dateStyle = NSDateFormatterMediumStyle
+    formatter.timeStyle = NSDateFormatterShortStyle
+    formatter.locale = NSLocale.currentLocale
+    val instant = dateTime.toInstant(TimeZone.currentSystemDefault())
+    val nsDate = instant.toNSDate()
+    return formatter.stringFromDate(nsDate)
+}


### PR DESCRIPTION
## Summary
- add `formatLocalDateTime` expect/actual implementations with time support
- use `formatLocalDateTime` in `formatLastWipe`

## Testing
- `./gradlew :shared:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca6ec04c8321af19175f35fcf270