### PR TITLE
Add onboarding navigation

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -28,16 +28,24 @@ import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
 import app.cash.paging.compose.collectAsLazyPagingItems
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
+import pl.cuyer.rusthub.android.feature.onboarding.OnboardingScreen
+import pl.cuyer.rusthub.android.feature.auth.LoginScreen
+import pl.cuyer.rusthub.android.feature.auth.RegisterScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.presentation.features.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.ServerViewModel
+import pl.cuyer.rusthub.presentation.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.Login
+import pl.cuyer.rusthub.presentation.navigation.Register
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 
@@ -76,7 +84,7 @@ fun NavigationRoot() {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { innerPadding ->
-            val backStack = rememberNavBackStack(ServerList)
+            val backStack = rememberNavBackStack(Onboarding)
             val listDetailStrategy = rememberListDetailSceneStrategy<Any>()
             NavDisplay(
                 entryDecorators = listOf(
@@ -92,6 +100,30 @@ fun NavigationRoot() {
                 onBack = { keysToRemove -> repeat(keysToRemove) { backStack.removeLastOrNull() } },
                 sceneStrategy = listDetailStrategy,
                 entryProvider = entryProvider {
+                    entry<Onboarding> {
+                        val viewModel = koinViewModel<OnboardingViewModel>()
+                        val state = viewModel.state.collectAsStateWithLifecycle()
+                        OnboardingScreen(
+                            stateProvider = { state },
+                            onAction = viewModel::onAction,
+                            uiEvent = viewModel.uiEvent,
+                            onNavigate = { destination -> backStack.add(destination) }
+                        )
+                    }
+                    entry<Login> {
+                        LoginScreen(
+                            onNavigate = { destination -> backStack.add(destination) },
+                            uiEvent = flowOf(),
+                            onBack = { backStack.removeLastOrNull() }
+                        )
+                    }
+                    entry<Register> {
+                        RegisterScreen(
+                            onNavigate = { destination -> backStack.add(destination) },
+                            uiEvent = flowOf(),
+                            onBack = { backStack.removeLastOrNull() }
+                        )
+                    }
                     entry<ServerList>(
                         metadata = ListDetailSceneStrategy.listPane()
                     ) {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/LoginScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/LoginScreen.kt
@@ -1,0 +1,59 @@
+package pl.cuyer.rusthub.android.feature.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+@Composable
+fun LoginScreen(
+    onNavigate: (NavKey) -> Unit,
+    uiEvent: Flow<UiEvent>,
+    onBack: () -> Unit
+) {
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = "Login", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(spacing.large))
+        Button(onClick = { onNavigate(ServerList) }) {
+            Text("Login")
+        }
+        Spacer(modifier = Modifier.height(spacing.medium))
+        TextButton(onClick = onBack) { Text("Back") }
+    }
+}
+
+@Preview
+@Composable
+private fun LoginPrev() {
+    RustHubTheme {
+        LoginScreen(
+            onNavigate = {},
+            uiEvent = MutableStateFlow(UiEvent.Navigate(ServerList)),
+            onBack = {}
+        )
+    }
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
@@ -1,0 +1,59 @@
+package pl.cuyer.rusthub.android.feature.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+@Composable
+fun RegisterScreen(
+    onNavigate: (NavKey) -> Unit,
+    uiEvent: Flow<UiEvent>,
+    onBack: () -> Unit
+) {
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = "Register", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(spacing.large))
+        Button(onClick = { onNavigate(ServerList) }) {
+            Text("Register")
+        }
+        Spacer(modifier = Modifier.height(spacing.medium))
+        TextButton(onClick = onBack) { Text("Back") }
+    }
+}
+
+@Preview
+@Composable
+private fun RegisterPrev() {
+    RustHubTheme {
+        RegisterScreen(
+            onNavigate = {},
+            uiEvent = MutableStateFlow(UiEvent.Navigate(ServerList)),
+            onBack = {}
+        )
+    }
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/onboarding/OnboardingScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/onboarding/OnboardingScreen.kt
@@ -1,0 +1,73 @@
+package pl.cuyer.rusthub.android.feature.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.onboarding.OnboardingAction
+import pl.cuyer.rusthub.presentation.onboarding.OnboardingState
+
+@Composable
+fun OnboardingScreen(
+    onNavigate: (NavKey) -> Unit,
+    stateProvider: () -> State<OnboardingState>,
+    onAction: (OnboardingAction) -> Unit,
+    uiEvent: Flow<UiEvent>
+) {
+    val state = stateProvider()
+
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(text = "Welcome to RustHub", style = MaterialTheme.typography.headlineMedium)
+        Spacer(modifier = Modifier.height(spacing.large))
+        Button(onClick = { onAction(OnboardingAction.OnLoginClick) }) {
+            Text("Log In")
+        }
+        Spacer(modifier = Modifier.height(spacing.medium))
+        Button(onClick = { onAction(OnboardingAction.OnRegisterClick) }) {
+            Text("Register")
+        }
+        Spacer(modifier = Modifier.height(spacing.medium))
+        TextButton(onClick = { onAction(OnboardingAction.OnContinueAsGuest) }) {
+            Text("Continue as Guest")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OnboardingPrev() {
+    RustHubTheme {
+        OnboardingScreen(
+            onNavigate = {},
+            stateProvider = { mutableStateOf(OnboardingState()) },
+            onAction = {},
+            uiEvent = MutableStateFlow(UiEvent.Navigate(object : NavKey {}))
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -9,12 +9,16 @@ import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.presentation.features.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.ServerViewModel
+import pl.cuyer.rusthub.presentation.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory(androidContext()).create() }
     single { HttpClientFactory(get()).create() }
     single { ClipboardHandler(get()) }
+    viewModel {
+        OnboardingViewModel()
+    }
     viewModel {
         ServerViewModel(
             clipboardHandler = get(),

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -4,6 +4,15 @@ import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 @Serializable
+data object Onboarding : NavKey
+
+@Serializable
+data object Login : NavKey
+
+@Serializable
+data object Register : NavKey
+
+@Serializable
 data object ServerList : NavKey
 
 @Serializable

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/onboarding/OnboardingAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/onboarding/OnboardingAction.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.presentation.onboarding
+
+sealed interface OnboardingAction {
+    data object OnLoginClick : OnboardingAction
+    data object OnRegisterClick : OnboardingAction
+    data object OnContinueAsGuest : OnboardingAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/onboarding/OnboardingState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/onboarding/OnboardingState.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.presentation.onboarding
+
+data class OnboardingState(
+    val isLoading: Boolean = false
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/onboarding/OnboardingViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,40 @@
+package pl.cuyer.rusthub.presentation.onboarding
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.presentation.navigation.Login
+import pl.cuyer.rusthub.presentation.navigation.Register
+import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+class OnboardingViewModel : BaseViewModel() {
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(OnboardingState())
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = OnboardingState()
+    )
+
+    fun onAction(action: OnboardingAction) {
+        when (action) {
+            OnboardingAction.OnLoginClick -> navigate(Login)
+            OnboardingAction.OnRegisterClick -> navigate(Register)
+            OnboardingAction.OnContinueAsGuest -> navigate(ServerList)
+        }
+    }
+
+    private fun navigate(destination: Any) {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(destination))
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -6,9 +6,11 @@ import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.util.ClipboardHandler
+import pl.cuyer.rusthub.presentation.onboarding.OnboardingViewModel
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
     single { HttpClientFactory(get()).create() }
     single { ClipboardHandler() }
+    factory { OnboardingViewModel() }
 }


### PR DESCRIPTION
## Summary
- add simple onboarding module with login/register screens
- implement OnboardingViewModel and actions
- wire onboarding flow into Koin modules and navigation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685717c616c48321bed2858c0d8fb599