### PR TITLE
Introduce reusable button composables

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppButtons.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppButtons.kt
@@ -1,0 +1,49 @@
+package pl.cuyer.rusthub.android.designsystem
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+
+@Composable
+fun AppButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    colors: ButtonDefaults.ButtonColors = ButtonDefaults.buttonColors(),
+    content: @Composable RowScope.() -> Unit
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = RectangleShape,
+        colors = colors,
+        content = content
+    )
+}
+
+@Composable
+fun AppTextButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    colors: ButtonDefaults.ButtonColors = ButtonDefaults.textButtonColors(
+        contentColor = MaterialTheme.colorScheme.onSurface
+    ),
+    content: @Composable RowScope.() -> Unit
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        shape = RectangleShape,
+        colors = colors,
+        content = content
+    )
+}
+

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSearchTopBar.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSearchTopBar.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExpandedFullScreenSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -52,6 +51,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.designsystem.AppButton
 import pl.cuyer.rusthub.presentation.model.SearchQueryUi
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
@@ -211,7 +211,7 @@ fun RustSearchBarTopAppBar(
                             .padding(spacing.medium),
                         horizontalArrangement = Arrangement.Center
                     ) {
-                        Button(
+                        AppButton(
                             onClick = {
                                 onDelete("")
                                 coroutineScope.launch {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/FilterBottomSheet.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/FilterBottomSheet.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.maxLength
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
@@ -28,7 +27,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -42,7 +40,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -51,6 +48,8 @@ import kotlinx.serialization.json.Json
 import org.koin.compose.koinInject
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import pl.cuyer.rusthub.presentation.features.server.ServerAction
 import pl.cuyer.rusthub.presentation.features.server.ServerState
 import pl.cuyer.rusthub.presentation.model.FilterUi
@@ -138,8 +137,7 @@ fun FilterBottomSheet(
                                 onFiltersChange = { newFilters = it }
                             )
                             Spacer(Modifier.height(spacing.medium))
-                            Button(
-                                shape = RectangleShape,
+                            AppButton(
                                 onClick = {
                                     onAction(ServerAction.OnSaveFilters(filters = it.toDomain()))
                                     onDismissAndRefresh()
@@ -150,8 +148,7 @@ fun FilterBottomSheet(
                             ) {
                                 Text("Apply Filters")
                             }
-                            TextButton(
-                                shape = RectangleShape,
+                            AppTextButton(
                                 onClick = {
                                     onAction(ServerAction.OnClearFilters)
                                     onDismissAndRefresh()
@@ -162,7 +159,6 @@ fun FilterBottomSheet(
                             ) {
                                 Text(
                                     text = "Reset Filters",
-                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
                             }
                         }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/SignProviderButton.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/SignProviderButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -14,7 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import pl.cuyer.rusthub.android.designsystem.AppButton
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -32,7 +31,7 @@ fun SignProviderButton(
     tint: Color? = null,
     onClick: () -> Unit
 ) {
-    Button(
+    AppButton(
         onClick = onClick,
         modifier = modifier
             .fillMaxWidth(),
@@ -40,7 +39,6 @@ fun SignProviderButton(
             containerColor = backgroundColor,
             contentColor = contentColor
         ),
-        shape = RectangleShape,
     ) {
         tint?.let {
             Icon(

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/LoginScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/LoginScreen.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,6 +17,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
@@ -38,16 +38,15 @@ fun LoginScreen(
     ) {
         Text(text = "Login", style = MaterialTheme.typography.headlineMedium)
         Spacer(modifier = Modifier.height(spacing.large))
-        Button(onClick = { onNavigate(ServerList) }) {
+        AppButton(onClick = { onNavigate(ServerList) }) {
             Text("Login")
         }
         Spacer(modifier = Modifier.height(spacing.medium))
-        TextButton(
+        AppTextButton(
             onClick = onBack
         ) {
             Text(
                 text = "Back",
-                color = MaterialTheme.colorScheme.onSurface
             )
         }
     }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
@@ -12,11 +12,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -25,7 +23,8 @@ import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -143,10 +142,9 @@ private fun RegisterScreenCompact(
             modifier = Modifier.fillMaxWidth()
         )
 
-        Button(
+        AppButton(
             onClick = { onRegister(username, password) },
-            modifier = Modifier.fillMaxWidth(),
-            shape = RectangleShape
+            modifier = Modifier.fillMaxWidth()
         ) {
             Text("Register")
         }
@@ -197,12 +195,10 @@ private fun RegisterScreenCompact(
 
         }
 
-        TextButton(
-            onClick = onBack,
-            shape = RectangleShape
+        AppTextButton(
+            onClick = onBack
         ) {
             Text(
-                color = MaterialTheme.colorScheme.onSurface,
                 text = "Back"
             )
         }
@@ -275,10 +271,9 @@ private fun RegisterScreenExpanded(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Button(
+            AppButton(
                 onClick = { onRegister(username, password) },
-                modifier = Modifier.fillMaxWidth(),
-                shape = RectangleShape
+                modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Register")
             }
@@ -329,13 +324,11 @@ private fun RegisterScreenExpanded(
 
             }
 
-            TextButton(
+            AppTextButton(
                 onClick = onBack
-            )
-            {
+            ) {
                 Text(
                     text = "Back",
-                    color = MaterialTheme.colorScheme.onSurface,
                 )
             }
         }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/onboarding/OnboardingScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/onboarding/OnboardingScreen.kt
@@ -20,11 +20,9 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -33,7 +31,8 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.RectangleShape
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -199,29 +198,25 @@ private fun FeatureList() {
 
 @Composable
 private fun ActionButtons(onAction: (OnboardingAction) -> Unit) {
-    Button(
+    AppButton(
         onClick = { onAction(OnboardingAction.OnLoginClick) },
-        shape = RectangleShape,
         modifier = Modifier.fillMaxWidth()
     ) {
         Text("Log In")
     }
 
-    Button(
+    AppButton(
         onClick = { onAction(OnboardingAction.OnRegisterClick) },
-        shape = RectangleShape,
         modifier = Modifier.fillMaxWidth()
     ) {
         Text("Register")
     }
 
-    TextButton(
-        shape = RectangleShape,
+    AppTextButton(
         onClick = { onAction(OnboardingAction.OnContinueAsGuest) }
     ) {
         Text(
             text = "Continue as Guest",
-            color = MaterialTheme.colorScheme.onSurface,
         )
     }
 }


### PR DESCRIPTION
## Summary
- add `AppButton` and `AppTextButton` composables
- refactor existing screens to use the new generic buttons

## Testing
- `./gradlew -q tasks --all`
- `./gradlew -q test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ec1aeecc832180377c5d93a1b402