### PR TITLE
Add SecureTextField component

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/SecureTextField.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/SecureTextField.kt
@@ -1,0 +1,139 @@
+package pl.cuyer.rusthub.android.designsystem
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicSecureTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.TextObfuscationMode
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TextFieldLabelPosition
+import androidx.compose.material3.TextFieldLabelScope
+import androidx.compose.material3.internal.Strings
+import androidx.compose.material3.internal.defaultErrorSemantics
+import androidx.compose.material3.internal.getString
+import androidx.compose.material3.internal.minimizedLabelHalfHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.Density
+
+/**
+ * Password text field based on [BasicSecureTextField].
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun SecureTextField(
+    state: TextFieldState,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    textStyle: TextStyle = LocalTextStyle.current,
+    labelPosition: TextFieldLabelPosition = TextFieldLabelPosition.Attached(),
+    label: @Composable (TextFieldLabelScope.() -> Unit)? = null,
+    placeholder: @Composable (() -> Unit)? = null,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    trailingIcon: @Composable (() -> Unit)? = null,
+    prefix: @Composable (() -> Unit)? = null,
+    suffix: @Composable (() -> Unit)? = null,
+    supportingText: @Composable (() -> Unit)? = null,
+    isError: Boolean = false,
+    inputTransformation: InputTransformation? = null,
+    textObfuscationMode: TextObfuscationMode = TextObfuscationMode.RevealLastTyped,
+    textObfuscationCharacter: Char = DefaultObfuscationCharacter,
+    keyboardOptions: KeyboardOptions = SecureTextFieldKeyboardOptions,
+    onKeyboardAction: KeyboardActionHandler? = null,
+    onTextLayout: (Density.(getResult: () -> TextLayoutResult?) -> Unit)? = null,
+    shape: Shape = OutlinedTextFieldDefaults.shape,
+    colors: TextFieldColors = OutlinedTextFieldDefaults.colors(),
+    contentPadding: PaddingValues = OutlinedTextFieldDefaults.contentPadding(),
+    interactionSource: MutableInteractionSource? = null,
+) {
+    @Suppress("NAME_SHADOWING")
+    val interactionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val textColor = textStyle.color.takeOrElse {
+        val focused = interactionSource.collectIsFocusedAsState().value
+        colors.textColor(enabled, isError, focused)
+    }
+    val mergedTextStyle = textStyle.merge(TextStyle(color = textColor))
+
+    CompositionLocalProvider(LocalTextSelectionColors provides colors.textSelectionColors) {
+        BasicSecureTextField(
+            state = state,
+            modifier = modifier
+                .then(if (label != null && labelPosition !is TextFieldLabelPosition.Above) {
+                    Modifier
+                        .semantics(mergeDescendants = true) {}
+                        .padding(top = minimizedLabelHalfHeight())
+                } else Modifier)
+                .defaultErrorSemantics(isError, getString(Strings.DefaultErrorMessage))
+                .defaultMinSize(
+                    minWidth = OutlinedTextFieldDefaults.MinWidth,
+                    minHeight = OutlinedTextFieldDefaults.MinHeight,
+                ),
+            enabled = enabled,
+            textStyle = mergedTextStyle,
+            cursorBrush = SolidColor(colors.cursorColor(isError)),
+            keyboardOptions = keyboardOptions,
+            onKeyboardAction = onKeyboardAction,
+            onTextLayout = onTextLayout,
+            interactionSource = interactionSource,
+            inputTransformation = inputTransformation,
+            textObfuscationMode = textObfuscationMode,
+            textObfuscationCharacter = textObfuscationCharacter,
+            decorator =
+                OutlinedTextFieldDefaults.decorator(
+                    state = state,
+                    enabled = enabled,
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                    outputTransformation = null,
+                    interactionSource = interactionSource,
+                    labelPosition = labelPosition,
+                    label = label,
+                    placeholder = placeholder,
+                    leadingIcon = leadingIcon,
+                    trailingIcon = trailingIcon,
+                    prefix = prefix,
+                    suffix = suffix,
+                    supportingText = supportingText,
+                    isError = isError,
+                    colors = colors,
+                    contentPadding = contentPadding,
+                    container = {
+                        OutlinedTextFieldDefaults.Container(
+                            enabled = enabled,
+                            isError = isError,
+                            interactionSource = interactionSource,
+                            colors = colors,
+                            shape = shape,
+                        )
+                    },
+                ),
+        )
+    }
+}
+
+private val SecureTextFieldKeyboardOptions =
+    KeyboardOptions(autoCorrectEnabled = false, keyboardType = KeyboardType.Password, imeAction = ImeAction.Done)
+
+private const val DefaultObfuscationCharacter: Char = '\u2022'

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import pl.cuyer.rusthub.android.designsystem.SecureTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -27,7 +28,6 @@ import pl.cuyer.rusthub.android.designsystem.AppButton
 import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.flow.Flow
@@ -134,11 +134,10 @@ private fun RegisterScreenCompact(
             modifier = Modifier.fillMaxWidth()
         )
 
-        OutlinedTextField(
+        SecureTextField(
             value = password,
             onValueChange = { onPasswordChange(it) },
             label = { Text("Password") },
-            visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -263,11 +262,10 @@ private fun RegisterScreenExpanded(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            OutlinedTextField(
+            SecureTextField(
                 value = password,
                 onValueChange = { onPasswordChange(it) },
                 label = { Text("Password") },
-                visualTransformation = PasswordVisualTransformation(),
                 modifier = Modifier.fillMaxWidth()
             )
 


### PR DESCRIPTION
## Summary
- implement `SecureTextField` using `BasicSecureTextField`
- use `SecureTextField` for password input on Register screen

## Testing
- `./gradlew test --stacktrace` *(fails: requires network access to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857f1180dbc832188630050defa33d7