### PR TITLE
Add reactive state validators

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSecureTextField.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSecureTextField.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -33,11 +32,14 @@ import pl.cuyer.rusthub.android.util.composeUtil.keyboardAsState
 @Composable
 fun AppSecureTextField(
     modifier: Modifier = Modifier,
-    textFieldState: () -> TextFieldState,
+    value: String,
     labelText: String,
     placeholderText: String,
     onSubmit: () -> Unit,
-    imeAction: ImeAction
+    imeAction: ImeAction,
+    onValueChange: (String) -> Unit = {},
+    isError: Boolean = false,
+    errorText: String? = null
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     var passwordVisible by remember { mutableStateOf(false) }
@@ -53,10 +55,8 @@ fun AppSecureTextField(
 
     OutlinedTextField(
         modifier = modifier.focusRequester(focusRequester),
-        value = textFieldState().text.toString(),
-        onValueChange = { newValue ->
-            textFieldState().edit { replace(0, length, newValue) }
-        },
+        value = value,
+        onValueChange = onValueChange,
         readOnly = false,
         singleLine = true,
         keyboardOptions = KeyboardOptions(
@@ -74,7 +74,7 @@ fun AppSecureTextField(
             }
         ),
         trailingIcon = {
-            Crossfade(targetState = textFieldState().text.isNotEmpty()) { hasText ->
+            Crossfade(targetState = value.isNotEmpty()) { hasText ->
                 if (hasText) {
                     IconButton(onClick = { passwordVisible = !passwordVisible }) {
                         Crossfade(
@@ -90,7 +90,7 @@ fun AppSecureTextField(
                 }
             }
         },
-        isError = false,
+        isError = isError,
         visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
         label = {
             Text(
@@ -103,6 +103,9 @@ fun AppSecureTextField(
             )
         },
         interactionSource = interactionSource,
-        colors = OutlinedTextFieldDefaults.colors()
+        colors = OutlinedTextFieldDefaults.colors(),
+        supportingText = if (isError && errorText != null) {
+            { Text(errorText) }
+        } else null
     )
 }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppTextField.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppTextField.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -32,7 +31,7 @@ import pl.cuyer.rusthub.android.util.composeUtil.keyboardAsState
 @Composable
 fun AppTextField(
     modifier: Modifier = Modifier,
-    textFieldState: () -> TextFieldState,
+    value: String,
     labelText: String,
     placeholderText: String,
     keyboardType: KeyboardType,
@@ -40,7 +39,10 @@ fun AppTextField(
     suffix: @Composable (() -> Unit)? = null,
     imeAction: ImeAction,
     requestFocus: Boolean = false,
-    onSubmit: () -> Unit = { }
+    onSubmit: () -> Unit = { },
+    onValueChange: (String) -> Unit = {},
+    isError: Boolean = false,
+    errorText: String? = null
 ) {
 
     val interactionSource = remember {
@@ -58,10 +60,8 @@ fun AppTextField(
     OutlinedTextField(
         modifier = if (requestFocus) modifier
             .focusRequester(focusRequester) else modifier,
-        value = textFieldState().text.toString(),
-        onValueChange = { newValue ->
-            textFieldState().edit { replace(0, length, newValue) }
-        },
+        value = value,
+        onValueChange = onValueChange,
         singleLine = true,
         keyboardOptions = KeyboardOptions(
             capitalization = KeyboardCapitalization.None,
@@ -95,7 +95,11 @@ fun AppTextField(
         interactionSource = interactionSource,
         visualTransformation = VisualTransformation.None,
         colors = OutlinedTextFieldDefaults.colors(),
-        suffix = suffix
+        suffix = suffix,
+        isError = isError,
+        supportingText = if (isError && errorText != null) {
+            { Text(errorText) }
+        } else null
     )
 }
 
@@ -113,7 +117,8 @@ private fun AppTextFieldPreview() {
                 keyboardType = KeyboardType.Email,
                 imeAction = ImeAction.Next,
                 requestFocus = false,
-                textFieldState = { TextFieldState() }
+                value = "",
+                onValueChange = {}
             )
         }
     }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -56,9 +54,6 @@ fun RegisterScreen(
         if (event is UiEvent.Navigate) onNavigate(event.destination)
     }
 
-    val passwordState = rememberTextFieldState()
-    val emailState = rememberTextFieldState()
-    val usernameState = rememberTextFieldState()
 
     val context = LocalContext.current
     val windowSizeClass = calculateWindowSizeClass(context as Activity)
@@ -69,43 +64,28 @@ fun RegisterScreen(
         RegisterScreenExpanded(
             onRegister = {
                 focusManager.clearFocus()
-                onAction(
-                    RegisterAction.OnRegister(
-                        email = emailState.text.toString(),
-                        password = passwordState.text.toString(),
-                        username = usernameState.text.toString()
-                    )
-                )
+                onAction(RegisterAction.OnRegister)
             },
-            usernameState = usernameState,
-            passwordState = passwordState,
-            emailState = emailState,
+            state = state.value,
+            onAction = onAction
         )
     } else {
         RegisterScreenCompact(
             onRegister = {
                 focusManager.clearFocus()
-                onAction(
-                    RegisterAction.OnRegister(
-                        email = emailState.text.toString(),
-                        password = passwordState.text.toString(),
-                        username = usernameState.text.toString()
-                    )
-                )
+                onAction(RegisterAction.OnRegister)
             },
-            usernameState = usernameState,
-            passwordState = passwordState,
-            emailState = emailState,
+            state = state.value,
+            onAction = onAction
         )
     }
 }
 
 @Composable
 private fun RegisterScreenCompact(
-    usernameState: TextFieldState,
-    passwordState: TextFieldState,
-    emailState: TextFieldState,
-    onRegister: () -> Unit
+    state: RegisterState,
+    onRegister: () -> Unit,
+    onAction: (RegisterAction) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -124,29 +104,38 @@ private fun RegisterScreenCompact(
 
         AppTextField(
             modifier = Modifier.fillMaxWidth(),
-            textFieldState = { usernameState },
+            value = state.username,
             labelText = "Username",
             placeholderText = "Enter your username",
             keyboardType = KeyboardType.Text,
             imeAction = ImeAction.Next,
+            onValueChange = { onAction(RegisterAction.OnUsernameChange(it)) },
+            isError = state.usernameError != null,
+            errorText = state.usernameError
         )
 
         AppTextField(
             modifier = Modifier.fillMaxWidth(),
-            textFieldState = { emailState },
+            value = state.email,
             labelText = "E-mail",
             placeholderText = "Enter your e-mail",
             keyboardType = KeyboardType.Email,
             imeAction = ImeAction.Next,
+            onValueChange = { onAction(RegisterAction.OnEmailChange(it)) },
+            isError = state.emailError != null,
+            errorText = state.emailError
         )
 
         AppSecureTextField(
-            textFieldState = { passwordState },
+            value = state.password,
             labelText = "Password",
             placeholderText = "Enter password",
             onSubmit = onRegister,
             modifier = Modifier.fillMaxWidth(),
-            imeAction = if (usernameState.text.isNotBlank() && emailState.text.isNotBlank()) ImeAction.Send else ImeAction.Done
+            imeAction = if (state.username.isNotBlank() && state.email.isNotBlank()) ImeAction.Send else ImeAction.Done,
+            onValueChange = { onAction(RegisterAction.OnPasswordChange(it)) },
+            isError = state.passwordError != null,
+            errorText = state.passwordError
         )
 
         AppButton(
@@ -206,10 +195,9 @@ private fun RegisterScreenCompact(
 
 @Composable
 private fun RegisterScreenExpanded(
-    usernameState: TextFieldState,
-    passwordState: TextFieldState,
-    emailState: TextFieldState,
-    onRegister: () -> Unit
+    state: RegisterState,
+    onRegister: () -> Unit,
+    onAction: (RegisterAction) -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -247,29 +235,38 @@ private fun RegisterScreenExpanded(
 
             AppTextField(
                 modifier = Modifier.fillMaxWidth(),
-                textFieldState = { usernameState },
+                value = state.username,
                 labelText = "Username",
                 placeholderText = "Enter your username",
                 keyboardType = KeyboardType.Text,
                 imeAction = ImeAction.Next,
+                onValueChange = { onAction(RegisterAction.OnUsernameChange(it)) },
+                isError = state.usernameError != null,
+                errorText = state.usernameError
             )
 
             AppTextField(
                 modifier = Modifier.fillMaxWidth(),
-                textFieldState = { emailState },
+                value = state.email,
                 labelText = "E-mail",
                 placeholderText = "Enter your e-mail",
                 keyboardType = KeyboardType.Email,
                 imeAction = ImeAction.Next,
+                onValueChange = { onAction(RegisterAction.OnEmailChange(it)) },
+                isError = state.emailError != null,
+                errorText = state.emailError
             )
 
             AppSecureTextField(
                 modifier = Modifier.fillMaxWidth(),
-                textFieldState = { passwordState },
+                value = state.password,
                 labelText = "Password",
                 placeholderText = "Enter password",
                 onSubmit = { },
-                imeAction = if (usernameState.text.isNotBlank() && emailState.text.isNotBlank()) ImeAction.Send else ImeAction.Done
+                imeAction = if (state.username.isNotBlank() && state.email.isNotBlank()) ImeAction.Send else ImeAction.Done,
+                onValueChange = { onAction(RegisterAction.OnPasswordChange(it)) },
+                isError = state.passwordError != null,
+                errorText = state.passwordError
             )
 
             AppButton(

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -22,8 +22,11 @@ actual val platformModule: Module = module {
     }
     viewModel {
         RegisterViewModel(
-            get(),
-            get()
+            registerUserUseCase = get(),
+            snackbarController = get(),
+            emailValidator = get(),
+            passwordValidator = get(),
+            usernameValidator = get()
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -37,6 +37,9 @@ import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
+import pl.cuyer.rusthub.util.validator.EmailValidator
+import pl.cuyer.rusthub.util.validator.PasswordValidator
+import pl.cuyer.rusthub.util.validator.UsernameValidator
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 
 val appModule = module {
@@ -58,6 +61,9 @@ val appModule = module {
     singleOf(::FiltersOptionsDataSourceImpl) bind FiltersOptionsDataSource::class
     singleOf(::AuthRepositoryImpl) bind AuthRepository::class
     singleOf(::AuthDataSourceImpl) bind AuthDataSource::class
+    single { EmailValidator }
+    single { PasswordValidator }
+    single { UsernameValidator }
     single { GetPagedServersUseCase(get(), get(), get(), get()) }
     single { GetFiltersUseCase(get()) }
     single { SaveFiltersUseCase(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/RegisterAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/RegisterAction.kt
@@ -1,6 +1,9 @@
 package pl.cuyer.rusthub.presentation.features.auth
 
 sealed interface RegisterAction {
-    data class OnRegister(val email: String, val password: String, val username: String) :
-        RegisterAction
+    data object OnRegister : RegisterAction
+
+    data class OnEmailChange(val email: String) : RegisterAction
+    data class OnPasswordChange(val password: String) : RegisterAction
+    data class OnUsernameChange(val username: String) : RegisterAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/RegisterState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/RegisterState.kt
@@ -1,5 +1,11 @@
 package pl.cuyer.rusthub.presentation.features.auth
 
 data class RegisterState(
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
+    val email: String = "",
+    val username: String = "",
+    val password: String = "",
+    val emailError: String? = null,
+    val usernameError: String? = null,
+    val passwordError: String? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/RegisterViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/RegisterViewModel.kt
@@ -8,10 +8,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.common.BaseViewModel
@@ -20,33 +24,65 @@ import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.validator.EmailValidator
+import pl.cuyer.rusthub.util.validator.PasswordValidator
+import pl.cuyer.rusthub.util.validator.UsernameValidator
 
 class RegisterViewModel(
     private val registerUserUseCase: RegisterUserUseCase,
-    private val snackbarController: SnackbarController
+    private val snackbarController: SnackbarController,
+    private val emailValidator: EmailValidator,
+    private val passwordValidator: PasswordValidator,
+    private val usernameValidator: UsernameValidator
 ) : BaseViewModel() {
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
     val uiEvent = _uiEvent.receiveAsFlow()
 
     private val _state = MutableStateFlow(RegisterState())
-    val state = _state.stateIn(
-        scope = coroutineScope,
-        started = SharingStarted.WhileSubscribed(5_000L),
-        initialValue = RegisterState()
-    )
+    val state = _state
+        .onStart {
+            observeEmail()
+            observePassword()
+            observeUsername()
+        }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = RegisterState()
+        )
 
     var registerJob: Job? = null
 
     fun onAction(action: RegisterAction) {
         when (action) {
-            is RegisterAction.OnRegister -> register(action.email, action.password, action.username)
+            RegisterAction.OnRegister -> register()
+            is RegisterAction.OnEmailChange -> _state.update { it.copy(email = action.email) }
+            is RegisterAction.OnPasswordChange -> _state.update { it.copy(password = action.password) }
+            is RegisterAction.OnUsernameChange -> _state.update { it.copy(username = action.username) }
         }
     }
 
-    private fun register(email: String, password: String, username: String) {
+    private fun register() {
         registerJob?.cancel()
 
         registerJob = coroutineScope.launch {
+            val email = _state.value.email
+            val password = _state.value.password
+            val username = _state.value.username
+            val emailResult = emailValidator.validate(email)
+            val passwordResult = passwordValidator.validate(password)
+            val usernameResult = usernameValidator.validate(username)
+
+            _state.update {
+                it.copy(
+                    emailError = emailResult.errorMessage,
+                    passwordError = passwordResult.errorMessage,
+                    usernameError = usernameResult.errorMessage
+                )
+            }
+
+            if (!emailResult.isValid || !passwordResult.isValid || !usernameResult.isValid) return@launch
+
             registerUserUseCase(email, password, username)
                 .onStart {
                     updateLoading(true)
@@ -88,5 +124,38 @@ class RegisterViewModel(
                 isLoading = isLoading
             )
         }
+    }
+
+    private fun observeEmail() {
+        _state
+            .map { it.email }
+            .distinctUntilChanged()
+            .onEach { value ->
+                val validation = emailValidator.validate(value)
+                _state.update { it.copy(emailError = validation.errorMessage) }
+            }
+            .launchIn(coroutineScope)
+    }
+
+    private fun observePassword() {
+        _state
+            .map { it.password }
+            .distinctUntilChanged()
+            .onEach { value ->
+                val validation = passwordValidator.validate(value)
+                _state.update { it.copy(passwordError = validation.errorMessage) }
+            }
+            .launchIn(coroutineScope)
+    }
+
+    private fun observeUsername() {
+        _state
+            .map { it.username }
+            .distinctUntilChanged()
+            .onEach { value ->
+                val validation = usernameValidator.validate(value)
+                _state.update { it.copy(usernameError = validation.errorMessage) }
+            }
+            .launchIn(coroutineScope)
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/EmailValidator.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/EmailValidator.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.util.validator
+
+/** Simple e-mail validator using regex. */
+object EmailValidator : Validator<String> {
+    private val emailRegex = Regex("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")
+
+    override fun validate(value: String): ValidationResult {
+        return if (emailRegex.matches(value)) {
+            ValidationResult(true, null)
+        } else {
+            ValidationResult(false, "Invalid e-mail format")
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/PasswordValidator.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/PasswordValidator.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.util.validator
+
+/** Password validator requiring at least 8 characters including a digit. */
+object PasswordValidator : Validator<String> {
+    private val digitRegex = Regex(".*\\d.*")
+
+    override fun validate(value: String): ValidationResult {
+        return if (value.length >= 8 && digitRegex.containsMatchIn(value)) {
+            ValidationResult(true, null)
+        } else {
+            ValidationResult(false, "Password must be 8+ chars and contain a digit")
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/UsernameValidator.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/UsernameValidator.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.util.validator
+
+/** Username validator requiring at least 3 characters. */
+object UsernameValidator : Validator<String> {
+    override fun validate(value: String): ValidationResult {
+        return if (value.length >= 3) {
+            ValidationResult(true, null)
+        } else {
+            ValidationResult(false, "Username too short")
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/Validator.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/validator/Validator.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.util.validator
+
+/** Result of validation. */
+data class ValidationResult(
+    val isValid: Boolean,
+    val errorMessage: String? = null
+)
+
+/** Basic validator interface. */
+fun interface Validator<T> {
+    fun validate(value: T): ValidationResult
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -14,5 +14,13 @@ actual val platformModule: Module = module {
     single { HttpClientFactory(get()).create() }
     single { ClipboardHandler() }
     factory { OnboardingViewModel() }
-    factory { RegisterViewModel() }
+    factory {
+        RegisterViewModel(
+            registerUserUseCase = get(),
+            snackbarController = get(),
+            emailValidator = get(),
+            passwordValidator = get(),
+            usernameValidator = get()
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- remove flow fields from `RegisterState`
- observe changes to email, password, and username in `RegisterViewModel`
- update validation errors reactively when the state changes

## Testing
- `./gradlew :shared:compileDebugKotlinAndroid --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685835bd10e883218bc8ec0360ef420c