### PR TITLE
Update login screen with state handling

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -39,6 +39,7 @@ import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.presentation.features.auth.RegisterViewModel
+import pl.cuyer.rusthub.presentation.features.auth.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
@@ -112,9 +113,14 @@ fun NavigationRoot() {
                         )
                     }
                     entry<Login> {
+                        val viewModel = koinViewModel<LoginViewModel>()
+                        val state = viewModel.state.collectAsStateWithLifecycle()
+
                         LoginScreen(
                             onNavigate = { destination -> backStack.add(destination) },
-                            uiEvent = flowOf(),
+                            stateProvider = { state },
+                            uiEvent = viewModel.uiEvent,
+                            onAction = viewModel::onAction,
                             onBack = { backStack.removeLastOrNull() }
                         )
                     }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/LoginScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/LoginScreen.kt
@@ -1,53 +1,320 @@
 package pl.cuyer.rusthub.android.feature.auth
 
+import android.app.Activity
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppSecureTextField
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
+import pl.cuyer.rusthub.android.designsystem.AppTextField
+import pl.cuyer.rusthub.android.designsystem.SignProviderButton
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
-import pl.cuyer.rusthub.android.designsystem.AppButton
-import pl.cuyer.rusthub.android.designsystem.AppTextButton
+import pl.cuyer.rusthub.common.getImageByFileName
+import pl.cuyer.rusthub.presentation.features.auth.LoginAction
+import pl.cuyer.rusthub.presentation.features.auth.LoginState
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
 @Composable
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class, ExperimentalMaterial3ExpressiveApi::class)
 fun LoginScreen(
     onNavigate: (NavKey) -> Unit,
     uiEvent: Flow<UiEvent>,
+    stateProvider: () -> State<LoginState>,
+    onAction: (LoginAction) -> Unit,
     onBack: () -> Unit
 ) {
+    val state = stateProvider()
+
     ObserveAsEvents(uiEvent) { event ->
         if (event is UiEvent.Navigate) onNavigate(event.destination)
     }
-    Column(
+
+    val context = LocalContext.current
+    val windowSizeClass = calculateWindowSizeClass(context as Activity)
+    val isTabletMode = windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium
+    val focusManager = LocalFocusManager.current
+
+    Box(
         modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        contentAlignment = Alignment.Center
     ) {
-        Text(text = "Login", style = MaterialTheme.typography.headlineMedium)
-        Spacer(modifier = Modifier.height(spacing.large))
-        AppButton(onClick = { onNavigate(ServerList) }) {
-            Text("Login")
+        if (isTabletMode) {
+            LoginScreenExpanded(
+                state = state.value,
+                onLogin = {
+                    focusManager.clearFocus()
+                    onAction(LoginAction.OnLogin)
+                },
+                onAction = onAction,
+                onBack = onBack
+            )
+        } else {
+            LoginScreenCompact(
+                state = state.value,
+                onLogin = {
+                    focusManager.clearFocus()
+                    onAction(LoginAction.OnLogin)
+                },
+                onAction = onAction,
+                onBack = onBack
+            )
         }
-        Spacer(modifier = Modifier.height(spacing.medium))
+
+        if (state.value.isLoading) {
+            LoadingIndicator()
+        }
+    }
+}
+
+@Composable
+private fun LoginScreenCompact(
+    state: LoginState,
+    onLogin: () -> Unit,
+    onAction: (LoginAction) -> Unit,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(spacing.medium),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacing.medium, Alignment.CenterVertically)
+    ) {
+        Image(
+            painter = painterResource(id = getImageByFileName("rusthub_logo").drawableResId),
+            contentDescription = "Application logo"
+        )
+
+        Text(text = "Log in to RustHub", style = MaterialTheme.typography.headlineMedium)
+
+        AppTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = state.username,
+            labelText = "Username or E-mail",
+            placeholderText = "Enter your username or e-mail",
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Next,
+            onValueChange = { onAction(LoginAction.OnUsernameChange(it)) },
+            isError = state.usernameError != null,
+            errorText = state.usernameError
+        )
+
+        AppSecureTextField(
+            value = state.password,
+            labelText = "Password",
+            placeholderText = "Enter your password",
+            onSubmit = onLogin,
+            modifier = Modifier.fillMaxWidth(),
+            imeAction = if (state.username.isNotBlank()) ImeAction.Send else ImeAction.Done,
+            onValueChange = { onAction(LoginAction.OnPasswordChange(it)) },
+            isError = state.passwordError != null,
+            errorText = state.passwordError
+        )
+
+        AppButton(
+            onClick = onLogin,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Log In")
+        }
+
+        SignProviderButton(
+            image = getImageByFileName("ic_google").drawableResId,
+            contentDescription = "Google logo",
+            text = "Sign in with Google",
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+            contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+        ) {}
+
+        SignProviderButton(
+            image = getImageByFileName("ic_apple").drawableResId,
+            contentDescription = "Apple logo",
+            text = "Sign in with Apple",
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+            contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+            tint = if (isSystemInDarkTheme()) Color.Black else Color.White
+        ) {}
+
+        SignProviderButton(
+            image = getImageByFileName("ic_facebook").drawableResId,
+            contentDescription = "Facebook logo",
+            text = "Sign in with Facebook",
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = Color(0xFF1877F2),
+            contentColor = Color.White
+        ) {}
+
+        SignProviderButton(
+            image = getImageByFileName("ic_x").drawableResId,
+            contentDescription = "X logo",
+            text = "Sign in with X",
+            modifier = Modifier.fillMaxWidth(),
+            backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+            contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+            tint = if (isSystemInDarkTheme()) Color.Black else Color.White
+        ) {}
+
         AppTextButton(
             onClick = onBack
         ) {
-            Text(
-                text = "Back",
+            Text(text = "Back")
+        }
+    }
+}
+
+@Composable
+private fun LoginScreenExpanded(
+    state: LoginState,
+    onLogin: () -> Unit,
+    onAction: (LoginAction) -> Unit,
+    onBack: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(spacing.medium),
+        horizontalArrangement = Arrangement.spacedBy(spacing.large),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxHeight(),
+            verticalArrangement = Arrangement.spacedBy(spacing.medium, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                painter = painterResource(id = getImageByFileName("rusthub_logo").drawableResId),
+                contentDescription = "RustHub Logo"
             )
+
+            Text(
+                text = "Log in to RustHub",
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.medium, Alignment.CenterVertically)
+        ) {
+            AppTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = state.username,
+                labelText = "Username or E-mail",
+                placeholderText = "Enter your username or e-mail",
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Next,
+                onValueChange = { onAction(LoginAction.OnUsernameChange(it)) },
+                isError = state.usernameError != null,
+                errorText = state.usernameError
+            )
+
+            AppSecureTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = state.password,
+                labelText = "Password",
+                placeholderText = "Enter password",
+                onSubmit = onLogin,
+                imeAction = if (state.username.isNotBlank()) ImeAction.Send else ImeAction.Done,
+                onValueChange = { onAction(LoginAction.OnPasswordChange(it)) },
+                isError = state.passwordError != null,
+                errorText = state.passwordError
+            )
+
+            AppButton(
+                onClick = onLogin,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Log In")
+            }
+
+            SignProviderButton(
+                image = getImageByFileName("ic_google").drawableResId,
+                contentDescription = "Google logo",
+                text = "Sign in with Google",
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+                contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+            ) {}
+
+            SignProviderButton(
+                image = getImageByFileName("ic_apple").drawableResId,
+                contentDescription = "Apple logo",
+                text = "Sign in with Apple",
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+                contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+                tint = if (isSystemInDarkTheme()) Color.Black else Color.White
+            ) {}
+
+            SignProviderButton(
+                image = getImageByFileName("ic_facebook").drawableResId,
+                contentDescription = "Facebook logo",
+                text = "Sign in with Facebook",
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = Color(0xFF1877F2),
+                contentColor = Color.White
+            ) {}
+
+            SignProviderButton(
+                image = getImageByFileName("ic_x").drawableResId,
+                contentDescription = "X logo",
+                text = "Sign in with X",
+                modifier = Modifier.fillMaxWidth(),
+                backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+                contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+                tint = if (isSystemInDarkTheme()) Color.Black else Color.White
+            ) {}
+
+            AppTextButton(
+                onClick = onBack
+            ) {
+                Text(text = "Back")
+            }
         }
     }
 }
@@ -59,6 +326,8 @@ private fun LoginPrev() {
         LoginScreen(
             onNavigate = {},
             uiEvent = MutableStateFlow(UiEvent.Navigate(ServerList)),
+            stateProvider = { androidx.compose.runtime.mutableStateOf(LoginState()) },
+            onAction = {},
             onBack = {}
         )
     }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -8,6 +8,7 @@ import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.presentation.features.auth.RegisterViewModel
+import pl.cuyer.rusthub.presentation.features.auth.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
@@ -19,6 +20,14 @@ actual val platformModule: Module = module {
     single { ClipboardHandler(get()) }
     viewModel {
         OnboardingViewModel()
+    }
+    viewModel {
+        LoginViewModel(
+            loginUserUseCase = get(),
+            snackbarController = get(),
+            passwordValidator = get(),
+            usernameValidator = get()
+        )
     }
     viewModel {
         RegisterViewModel(

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
@@ -1,0 +1,42 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import app.cash.paging.ExperimentalPagingApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+
+class LoginUserUseCase(
+    private val client: AuthRepository,
+    private val dataSource: AuthDataSource,
+) {
+    @OptIn(ExperimentalPagingApi::class)
+    operator fun invoke(
+        username: String,
+        password: String,
+    ): Flow<Result<Unit>> = channelFlow {
+        client.login(username = username, password = password).collectLatest { result ->
+            when (result) {
+                is Result.Success -> {
+                    with(result.data) {
+                        dataSource.insertUser(
+                            accessToken = accessToken,
+                            refreshToken = refreshToken,
+                            username = username,
+                            email = email
+                        )
+                        send(Result.Success(Unit))
+                    }
+                }
+
+                is Result.Error -> {
+                    send(Result.Error(result.exception))
+                }
+
+                is Result.Loading -> send(Result.Loading)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -35,6 +35,7 @@ import pl.cuyer.rusthub.domain.usecase.GetPagedServersUseCase
 import pl.cuyer.rusthub.domain.usecase.GetSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
+import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
 import pl.cuyer.rusthub.util.validator.EmailValidator
@@ -74,6 +75,7 @@ val appModule = module {
     single { DeleteSearchQueriesUseCase(get()) }
     single { GetServerDetailsUseCase(get()) }
     single { RegisterUserUseCase(get(), get()) }
+    single { LoginUserUseCase(get(), get()) }
 }
 
 expect val platformModule: Module

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/LoginAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/LoginAction.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.presentation.features.auth
+
+/** Actions from the login screen */
+sealed interface LoginAction {
+    data object OnLogin : LoginAction
+    data class OnUsernameChange(val username: String) : LoginAction
+    data class OnPasswordChange(val password: String) : LoginAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/LoginState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/LoginState.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.rusthub.presentation.features.auth
+
+/** State for the login screen */
+data class LoginState(
+    val isLoading: Boolean = false,
+    val username: String = "",
+    val password: String = "",
+    val usernameError: String? = null,
+    val passwordError: String? = null
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/LoginViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/LoginViewModel.kt
@@ -1,0 +1,117 @@
+package pl.cuyer.rusthub.presentation.features.auth
+
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.validator.PasswordValidator
+import pl.cuyer.rusthub.util.validator.UsernameValidator
+
+class LoginViewModel(
+    private val loginUserUseCase: LoginUserUseCase,
+    private val snackbarController: SnackbarController,
+    private val passwordValidator: PasswordValidator,
+    private val usernameValidator: UsernameValidator,
+) : BaseViewModel() {
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(LoginState())
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = LoginState()
+    )
+
+    var loginJob: Job? = null
+
+    fun onAction(action: LoginAction) {
+        when (action) {
+            LoginAction.OnLogin -> login()
+            is LoginAction.OnPasswordChange -> _state.update {
+                it.copy(
+                    password = action.password,
+                    passwordError = null
+                )
+            }
+            is LoginAction.OnUsernameChange -> _state.update {
+                it.copy(
+                    username = action.username,
+                    usernameError = null
+                )
+            }
+        }
+    }
+
+    private fun login() {
+        loginJob?.cancel()
+
+        loginJob = coroutineScope.launch {
+            val username = _state.value.username
+            val password = _state.value.password
+            val usernameResult = usernameValidator.validate(username)
+            val passwordResult = passwordValidator.validate(password)
+
+            _state.update {
+                it.copy(
+                    usernameError = usernameResult.errorMessage,
+                    passwordError = passwordResult.errorMessage
+                )
+            }
+
+            if (!usernameResult.isValid || !passwordResult.isValid) {
+                snackbarController.sendEvent(
+                    SnackbarEvent(
+                        message = "Please correct the errors above and try again.",
+                        action = null
+                    )
+                )
+                return@launch
+            }
+
+            loginUserUseCase(username, password)
+                .onStart { updateLoading(true) }
+                .catch { e -> showErrorSnackbar(e.message ?: "Unknown error") }
+                .onCompletion { updateLoading(false) }
+                .collectLatest { result ->
+                    when (result) {
+                        is Result.Success -> {
+                            Napier.i("Logged in")
+                        }
+
+                        is Result.Error -> {
+                            showErrorSnackbar(result.exception.message ?: "Unknown error")
+                        }
+
+                        else -> Unit
+                    }
+                }
+        }
+    }
+
+    private suspend fun showErrorSnackbar(message: String) {
+        snackbarController.sendEvent(
+            SnackbarEvent(message = message, action = null)
+        )
+    }
+
+    private fun updateLoading(isLoading: Boolean) {
+        _state.update { it.copy(isLoading = isLoading) }
+    }
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -6,6 +6,7 @@ import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.presentation.features.auth.RegisterViewModel
+import pl.cuyer.rusthub.presentation.features.auth.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 
@@ -14,6 +15,14 @@ actual val platformModule: Module = module {
     single { HttpClientFactory(get()).create() }
     single { ClipboardHandler() }
     factory { OnboardingViewModel() }
+    factory {
+        LoginViewModel(
+            loginUserUseCase = get(),
+            snackbarController = get(),
+            passwordValidator = get(),
+            usernameValidator = get()
+        )
+    }
     factory {
         RegisterViewModel(
             registerUserUseCase = get(),


### PR DESCRIPTION
## Summary
- implement LoginUserUseCase and LoginViewModel
- wire login ViewModel into android and iOS Koin modules
- hook login screen with state/actions and add error handling
- update NavigationRoot to use new viewmodel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584fd996a4832182e58c8b5e9321c4