### PR TITLE
Add simple splash screen

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.androidx.compose.material3.adaptive.navigation3)
     implementation(libs.androidx.compose.material3.windowsizeclass)
     implementation(libs.androidx.lifecycle.process)
+    implementation(libs.androidx.core.splashscreen)
     implementation(libs.compose.icons)
     implementation(libs.paging.compose)
     implementation(libs.kotlin.serialization)

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name="pl.cuyer.rusthub.android.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
@@ -6,12 +6,14 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.graphics.toColorInt
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import org.koin.compose.KoinContext
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.presentation.ui.Colors
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         enableEdgeToEdge(
             navigationBarStyle = SystemBarStyle.auto(
                 lightScrim,

--- a/androidApp/src/main/res/values/colors.xml
+++ b/androidApp/src/main/res/values/colors.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="splash_background">#F2FDEC</color>
+</resources>

--- a/androidApp/src/main/res/values/styles.xml
+++ b/androidApp/src/main/res/values/styles.xml
@@ -1,3 +1,9 @@
 <resources>
+    <style name="SplashTheme" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/rusthub_logo</item>
+        <item name="postSplashScreenTheme">@style/AppTheme</item>
+    </style>
+
     <style name="AppTheme" parent="android:Theme.Material.NoActionBar"/>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,7 @@ napier = { module = "io.github.aakira:napier", version.ref = "napier" }
 moko-resources-generator = { module = "dev.icerock.moko:resources-generator", version.ref = "moko-resources" }
 moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko-resources" }
 androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleRuntimeKtx"}
+androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "splash-screen" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- configure splashscreen dependency
- show splash screen using `rusthub_logo.svg`

## Testing
- `./gradlew :androidApp:assembleDebug --stacktrace --no-parallel` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585bcbf8c883219e2e0f8a261a93bc