### PR TITLE
Check logged user on startup

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
@@ -7,29 +7,49 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.graphics.toColorInt
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.compose.runtime.mutableStateOf
+import androidx.navigation3.runtime.NavKey
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.getKoin
 import org.koin.compose.KoinContext
 import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
+import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.ui.Colors
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        installSplashScreen()
+        var keepSplash = true
+        val startDestination = mutableStateOf<NavKey>(Onboarding)
+        val splashScreen = installSplashScreen()
+        splashScreen.setKeepOnScreenCondition { keepSplash }
+
         enableEdgeToEdge(
             navigationBarStyle = SystemBarStyle.auto(
                 lightScrim,
                 darkScrim
             )
         )
+
         super.onCreate(savedInstanceState)
+
+        lifecycleScope.launch {
+            val user = getKoin().get<GetUserUseCase>().invoke().firstOrNull()
+            startDestination.value = if (user != null) ServerList else Onboarding
+            keepSplash = false
+        }
+
         setContent {
             KoinContext(
                 content = {
                     RustHubTheme {
-                        NavigationRoot()
+                        NavigationRoot(startDestination = startDestination.value)
                     }
                 }
             )
-
         }
     }
 }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entry
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
@@ -55,7 +56,7 @@ import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
     ExperimentalMaterial3AdaptiveApi::class
 )
 @Composable
-fun NavigationRoot() {
+fun NavigationRoot(startDestination: NavKey = Onboarding) {
     val snackbarHostState = remember { SnackbarHostState() }
     val snackbarController = SnackbarController
     val scope = rememberCoroutineScope()
@@ -85,7 +86,7 @@ fun NavigationRoot() {
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { innerPadding ->
-            val backStack = rememberNavBackStack(Onboarding)
+            val backStack = rememberNavBackStack(startDestination)
             val listDetailStrategy = rememberListDetailSceneStrategy<Any>()
             NavDisplay(
                 entryDecorators = listOf(

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetUserUseCase.kt
@@ -1,0 +1,11 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.domain.model.User
+import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+
+class GetUserUseCase(
+    private val dataSource: AuthDataSource,
+) {
+    operator fun invoke(): Flow<User?> = dataSource.getUser()
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -34,6 +34,7 @@ import pl.cuyer.rusthub.domain.usecase.GetFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.GetPagedServersUseCase
 import pl.cuyer.rusthub.domain.usecase.GetSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
+import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
@@ -76,6 +77,7 @@ val appModule = module {
     single { GetServerDetailsUseCase(get()) }
     single { RegisterUserUseCase(get(), get()) }
     single { LoginUserUseCase(get(), get()) }
+    single { GetUserUseCase(get()) }
 }
 
 expect val platformModule: Module


### PR DESCRIPTION
## Summary
- navigate to server list if a user already exists
- expose `GetUserUseCase` for startup checks
- wire user check into splash screen and simplify onboarding

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685868029e348321ac4f4d81cb4127a4