### PR TITLE
Implement guest auth

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/onboarding/OnboardingScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/onboarding/OnboardingScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.FilterList
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
@@ -68,10 +69,16 @@ fun OnboardingScreen(
 
     val isTabletMode = windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium
 
-    if (isTabletMode) {
-        OnboardingScreenExpanded(onAction)
-    } else {
-        OnboardingScreenCompact(onAction)
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        if (isTabletMode) {
+            OnboardingScreenExpanded(onAction)
+        } else {
+            OnboardingScreenCompact(onAction)
+        }
+
+        if (state.value.isLoading) {
+            LoadingIndicator()
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -19,7 +19,10 @@ actual val platformModule: Module = module {
     single { HttpClientFactory(get(), get()).create() }
     single { ClipboardHandler(get()) }
     viewModel {
-        OnboardingViewModel()
+        OnboardingViewModel(
+            authAnonymouslyUseCase = get(),
+            snackbarController = get(),
+        )
     }
     viewModel {
         LoginViewModel(

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
@@ -19,10 +19,10 @@ class AuthDataSourceImpl(
 ) : AuthDataSource, Queries(db) {
 
     override suspend fun insertUser(
-        email: String,
+        email: String?,
         username: String,
         accessToken: String,
-        refreshToken: String
+        refreshToken: String?
     ) {
         withContext(Dispatchers.IO) {
             queries.insertUser(

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/User.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/User.kt
@@ -1,7 +1,7 @@
 package pl.cuyer.rusthub.domain.model
 
 data class User(
-    val email: String,
+    val email: String?,
     val username: String,
     val accessToken: String,
     val refreshToken: String?

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthDataSource.kt
@@ -5,10 +5,10 @@ import pl.cuyer.rusthub.domain.model.User
 
 interface AuthDataSource {
     suspend fun insertUser(
-        email: String,
+        email: String?,
         username: String,
         accessToken: String,
-        refreshToken: String
+        refreshToken: String?
     )
 
     suspend fun deleteUser()

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
@@ -1,0 +1,39 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import app.cash.paging.ExperimentalPagingApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+
+class AuthAnonymouslyUseCase(
+    private val client: AuthRepository,
+    private val dataSource: AuthDataSource,
+) {
+    @OptIn(ExperimentalPagingApi::class)
+    operator fun invoke(): Flow<Result<Unit>> = channelFlow {
+        client.authAnonymously().collectLatest { result ->
+            when (result) {
+                is Result.Success -> {
+                    with(result.data) {
+                        dataSource.insertUser(
+                            email = null,
+                            username = username,
+                            accessToken = accessToken,
+                            refreshToken = null
+                        )
+                        send(Result.Success(Unit))
+                    }
+                }
+
+                is Result.Error -> {
+                    send(Result.Error(result.exception))
+                }
+
+                is Result.Loading -> send(Result.Loading)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -36,6 +36,7 @@ import pl.cuyer.rusthub.domain.usecase.GetSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
+import pl.cuyer.rusthub.domain.usecase.AuthAnonymouslyUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
 import pl.cuyer.rusthub.util.validator.EmailValidator
@@ -76,6 +77,7 @@ val appModule = module {
     single { GetServerDetailsUseCase(get()) }
     single { RegisterUserUseCase(get(), get()) }
     single { LoginUserUseCase(get(), get()) }
+    single { AuthAnonymouslyUseCase(get(), get()) }
 }
 
 expect val platformModule: Module

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -463,10 +463,10 @@ DELETE FROM searchQueryEntity WHERE query = :query;
 
 CREATE TABLE userEntity (
   id TEXT NOT NULL PRIMARY KEY,
-  email         TEXT   NOT NULL,
+  email         TEXT,
   username      TEXT   NOT NULL,
   access_token  TEXT   NOT NULL,
-  refresh_token TEXT   NOT NULL
+  refresh_token TEXT
 );
 
 insertUser:

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -15,7 +15,12 @@ actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
     single { HttpClientFactory(get(), get()).create() }
     single { ClipboardHandler() }
-    factory { OnboardingViewModel() }
+    factory {
+        OnboardingViewModel(
+            authAnonymouslyUseCase = get(),
+            snackbarController = get(),
+        )
+    }
     factory {
         LoginViewModel(
             loginUserUseCase = get(),


### PR DESCRIPTION
## Summary
- allow nullable email and refresh token in DB
- update use case to store null values
- show LoadingIndicator while guest auth in progress

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586873daec8321bc12fd8cb03d045d