### PR TITLE
Add typed exception messages

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/model/ErrorResponse.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/model/ErrorResponse.kt
@@ -3,4 +3,7 @@ package pl.cuyer.rusthub.data.network.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ErrorResponse(val message: String)
+data class ErrorResponse(
+    val message: String,
+    val exception: String,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/AuthException.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/AuthException.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.domain.exception
+
+open class AuthException(message: String) : RuntimeException(message)
+
+class UserAlreadyExistsException(message: String) : AuthException(message)
+class InvalidCredentialsException(message: String) : AuthException(message)
+class InvalidRefreshTokenException(message: String) : AuthException(message)
+class AnonymousUpgradeException(message: String) : AuthException(message)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/FiltersException.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/FiltersException.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.domain.exception
+
+open class FiltersException(message: String) : RuntimeException(message)
+
+class FiltersOptionsException(message: String) : FiltersException(message)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/ServersException.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/ServersException.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.domain.exception
+
+open class ServersException(message: String) : RuntimeException(message)
+
+class ServersQueryException(message: String) : ServersException(message)
+class FavoriteLimitException(message: String) : ServersException(message)


### PR DESCRIPTION
## Summary
- pass server error message into domain exceptions
- instantiate typed exceptions with server message in `BaseApiResponse`

## Testing
- `./gradlew shared:compileKotlinMetadata --no-daemon`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dac9af7883219265479c4d7ab936