### PR TITLE
Add section dividers on details screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
@@ -256,6 +257,7 @@ fun ServerDetailsScreen(
                         }
 
                         item {
+                            HorizontalDivider()
                             Text(
                                 modifier = Modifier.padding(spacing.medium),
                                 style = MaterialTheme.typography.titleLarge,
@@ -311,6 +313,7 @@ fun ServerDetailsScreen(
                             }
                         }
                         item {
+                            HorizontalDivider()
                             Text(
                                 modifier = Modifier.padding(spacing.medium),
                                 style = MaterialTheme.typography.titleLarge,
@@ -322,6 +325,7 @@ fun ServerDetailsScreen(
                             )
                         }
                         item {
+                            HorizontalDivider()
                             Text(
                                 modifier = Modifier.padding(spacing.medium),
                                 style = MaterialTheme.typography.titleLarge,


### PR DESCRIPTION
## Summary
- add `HorizontalDivider` import
- insert dividers before Settings, Description and Map information headings

## Testing
- `./gradlew test` *(fails: Gradle build cancelled due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_685af96712c8832195e3b622ba4bc39a