### PR TITLE
Add next wipe field and notification subscription

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -90,6 +91,9 @@ fun ServerDetailsScreen(
                         val icon =
                             if (state.details?.isFavorite == true) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder
                         Icon(icon, contentDescription = null)
+                    }
+                    IconButton(onClick = { onAction(ServerDetailsAction.OnSubscribe) }) {
+                        Icon(Icons.Filled.Notifications, contentDescription = null)
                     }
                 },
                 scrollBehavior = scrollBehavior
@@ -209,6 +213,14 @@ fun ServerDetailsScreen(
                             ServerDetail(
                                 modifier = Modifier.padding(spacing.medium),
                                 label = "Last wipe",
+                                value = it
+                            )
+                        }
+
+                        it.nextWipe?.let {
+                            ServerDetail(
+                                modifier = Modifier.padding(spacing.medium),
+                                label = "Next wipe",
                                 value = it
                             )
                         }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -113,7 +113,8 @@ fun ServerEntity.toServerInfo(): ServerInfo {
         isPremium = is_premium == 1L,
         mapUrl = map_url,
         headerImage = header_image,
-        isFavorite = favourite == 1L
+        isFavorite = favourite == 1L,
+        nextWipe = rust_next_wipe?.let { Instant.parse(it) }
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
@@ -63,7 +63,8 @@ class ServerDataSourceImpl(
                         monuments = info.monuments?.toLong(),
                         mapUrl = info.mapUrl,
                         headerImage = info.headerImage,
-                        favourite = info.isFavorite == true
+                        favourite = info.isFavorite == true,
+                        nextWipe = info.nextWipe?.toString()
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
@@ -42,7 +42,8 @@ fun ServerInfoDto.toDomain(): ServerInfo {
         isPremium = isPremium,
         mapUrl = mapUrl,
         headerImage = headerImage,
-        isFavorite = isFavorite
+        isFavorite = isFavorite,
+        nextWipe = nextWipe
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/ServerInfoDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/ServerInfoDto.kt
@@ -62,5 +62,7 @@ data class ServerInfoDto(
     @SerialName("header_image")
     val headerImage: String? = null,
     @SerialName("is_favorite")
-    val isFavorite: Boolean? = null
+    val isFavorite: Boolean? = null,
+    @SerialName("rust_next_wipe")
+    val nextWipe: Instant? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerInfo.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerInfo.kt
@@ -37,5 +37,6 @@ data class ServerInfo(
     val isPremium: Boolean? = null,
     val mapUrl: String? = null,
     val headerImage: String? = null,
-    val isFavorite: Boolean? = null
+    val isFavorite: Boolean? = null,
+    val nextWipe: Instant? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -62,7 +62,7 @@ class ServerDetailsViewModel(
             is ServerDetailsAction.OnSaveToClipboard -> saveIpToClipboard(action.ipAddress)
             ServerDetailsAction.OnToggleFavourite -> toggleFavourite()
             ServerDetailsAction.OnDismissSubscriptionDialog -> showSubscriptionDialog(false)
-            ServerDetailsAction.OnSubscribe -> showSubscriptionDialog(false)
+            ServerDetailsAction.OnSubscribe -> handleSubscribeAction()
         }
     }
 
@@ -132,6 +132,22 @@ class ServerDetailsViewModel(
             it.copy(
                 showSubscriptionDialog = show
             )
+        }
+    }
+
+    private fun handleSubscribeAction() {
+        if (state.value.showSubscriptionDialog) {
+            coroutineScope.launch {
+                snackbarController.sendEvent(
+                    SnackbarEvent(
+                        message = "Subscribed to notifications",
+                        duration = Duration.SHORT
+                    )
+                )
+            }
+            showSubscriptionDialog(false)
+        } else {
+            showSubscriptionDialog(true)
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
@@ -42,6 +42,7 @@ data class ServerInfoUi(
     val monuments: Int? = null,
     val averageFps: Long? = null,
     val lastWipe: String? = null,
+    val nextWipe: String? = null,
     val pve: Boolean? = null,
     val website: String? = null,
     val isPremium: Boolean? = null,

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
@@ -39,6 +39,7 @@ fun ServerInfo.toUi(): ServerInfoUi {
         monuments = monuments,
         averageFps = averageFps,
         lastWipe = wipe?.let { formatLastWipe(it) },
+        nextWipe = nextWipe?.let { formatNextWipe(it) },
         pve = pve,
         website = website,
         isPremium = isPremium,
@@ -62,4 +63,20 @@ fun formatLastWipe(wipeInstant: Instant): String {
     }
 
     return "$formattedDate ($timeAgo)"
+}
+
+fun formatNextWipe(wipeInstant: Instant): String {
+    val now = Clock.System.now()
+    val duration = wipeInstant - now
+    val localDateTime = wipeInstant.toLocalDateTime(TimeZone.currentSystemDefault())
+    val formattedDate = formatLocalDateTime(localDateTime)
+
+    val inTime = when {
+        duration.inWholeDays >= 1 -> "in ${duration.inWholeDays} days"
+        duration.inWholeHours >= 1 -> "in ${duration.inWholeHours} hours"
+        duration.inWholeMinutes >= 0 -> "in ${duration.inWholeMinutes} minutes"
+        else -> "soon"
+    }
+
+    return "$formattedDate ($inTime)"
 }

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -45,6 +45,7 @@ CREATE TABLE serverEntity (
     is_premium     INTEGER,
     map_url        TEXT,
     header_image   TEXT,
+    rust_next_wipe TEXT,
     favourite      INTEGER    NOT NULL DEFAULT 0
 );
 
@@ -131,6 +132,7 @@ INSERT INTO serverEntity (
     map_url,
     header_image,
     monuments,
+    rust_next_wipe,
     favourite
 ) VALUES (
     :id,
@@ -167,6 +169,7 @@ INSERT INTO serverEntity (
     :mapUrl,
     :headerImage,
     :monuments,
+    :nextWipe,
     CASE WHEN :favourite THEN 1 ELSE 0 END
 ) ON CONFLICT(id) DO UPDATE SET
     name           = excluded.name,
@@ -202,6 +205,7 @@ INSERT INTO serverEntity (
     is_premium     = excluded.is_premium,
     map_url        = excluded.map_url,
     header_image   = excluded.header_image,
+    rust_next_wipe = excluded.rust_next_wipe,
     favourite      = excluded.favourite;
 
 clearServers:


### PR DESCRIPTION
## Summary
- add `nextWipe` information across DTO, domain, DB and UI models
- map new `rust_next_wipe` API field in network and persistence layers
- expose next wipe on Server Details screen and add subscribe icon in top bar
- allow subscribing via dialog using `ServerDetailsViewModel`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b21b563e883218450aa6fff56232d