### PR TITLE
Handle empty HTTP body errors

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/util/BaseApiResponse.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/util/BaseApiResponse.kt
@@ -3,6 +3,7 @@ package pl.cuyer.rusthub.data.network.util
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.ensureActive
@@ -11,17 +12,22 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.data.network.model.ErrorResponse
 import pl.cuyer.rusthub.domain.exception.AnonymousUpgradeException
 import pl.cuyer.rusthub.domain.exception.FavoriteLimitException
 import pl.cuyer.rusthub.domain.exception.FiltersOptionsException
+import pl.cuyer.rusthub.domain.exception.ForbiddenException
+import pl.cuyer.rusthub.domain.exception.HttpStatusException
 import pl.cuyer.rusthub.domain.exception.InvalidCredentialsException
 import pl.cuyer.rusthub.domain.exception.InvalidRefreshTokenException
 import pl.cuyer.rusthub.domain.exception.NetworkUnavailableException
+import pl.cuyer.rusthub.domain.exception.NotFoundException
 import pl.cuyer.rusthub.domain.exception.ServersQueryException
 import pl.cuyer.rusthub.domain.exception.TimeoutException
+import pl.cuyer.rusthub.domain.exception.UnauthorizedException
 import pl.cuyer.rusthub.domain.exception.UserAlreadyExistsException
 import kotlin.coroutines.coroutineContext
 
@@ -38,8 +44,18 @@ abstract class BaseApiResponse(
                 val data: T = response.body()
                 emit(success(data))
             } else {
-                val errorResponse = json.decodeFromString<ErrorResponse>(response.bodyAsText())
-                emit(Result.Error(parseException(errorResponse)))
+                val body = response.bodyAsText()
+                val exception = try {
+                    if (body.isNotBlank()) {
+                        val errorResponse = json.decodeFromString<ErrorResponse>(body)
+                        parseException(errorResponse)
+                    } else {
+                        parseStatusCodeException(response.status.value)
+                    }
+                } catch (e: SerializationException) {
+                    parseStatusCodeException(response.status.value)
+                }
+                emit(Result.Error(exception))
             }
         }.onStart {
             emit(loading())
@@ -82,6 +98,18 @@ abstract class BaseApiResponse(
                 errorResponse.message ?: "Favorite limit error"
             )
             else -> Exception(errorResponse.message)
+        }
+    }
+
+    fun parseStatusCodeException(statusCode: Int): HttpStatusException {
+        return when (statusCode) {
+            HttpStatusCode.Unauthorized.value ->
+                UnauthorizedException("Unauthorized")
+            HttpStatusCode.Forbidden.value ->
+                ForbiddenException("Forbidden")
+            HttpStatusCode.NotFound.value ->
+                NotFoundException("Not found")
+            else -> HttpStatusException("HTTP $statusCode error")
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/HttpStatusException.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/HttpStatusException.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.domain.exception
+
+open class HttpStatusException(message: String) : RuntimeException(message)
+
+class UnauthorizedException(message: String) : HttpStatusException(message)
+class ForbiddenException(message: String) : HttpStatusException(message)
+class NotFoundException(message: String) : HttpStatusException(message)


### PR DESCRIPTION
## Summary
- add `HttpStatusException` hierarchy for HTTP codes
- parse empty API responses and convert status codes to exceptions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b29a202148321b2b9a29bc4558762