### PR TITLE
Add next map wipe field

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -225,6 +225,14 @@ fun ServerDetailsScreen(
                             )
                         }
 
+                        it.nextMapWipe?.let {
+                            ServerDetail(
+                                modifier = Modifier.padding(spacing.medium),
+                                label = "Next map wipe",
+                                value = it
+                            )
+                        }
+
                         it.pve?.let {
                             ServerDetail(
                                 modifier = Modifier.padding(spacing.medium),

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -114,7 +114,8 @@ fun ServerEntity.toServerInfo(): ServerInfo {
         mapUrl = map_url,
         headerImage = header_image,
         isFavorite = favourite == 1L,
-        nextWipe = rust_next_wipe?.let { Instant.parse(it) }
+        nextWipe = rust_next_wipe?.let { Instant.parse(it) },
+        nextMapWipe = rust_next_map_wipe?.let { Instant.parse(it) }
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
@@ -64,7 +64,8 @@ class ServerDataSourceImpl(
                         mapUrl = info.mapUrl,
                         headerImage = info.headerImage,
                         favourite = info.isFavorite == true,
-                        nextWipe = info.nextWipe?.toString()
+                        nextWipe = info.nextWipe?.toString(),
+                        nextMapWipe = info.nextMapWipe?.toString()
                     )
                 }
             }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
@@ -43,7 +43,8 @@ fun ServerInfoDto.toDomain(): ServerInfo {
         mapUrl = mapUrl,
         headerImage = headerImage,
         isFavorite = isFavorite,
-        nextWipe = nextWipe
+        nextWipe = nextWipe,
+        nextMapWipe = nextMapWipe
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/ServerInfoDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/ServerInfoDto.kt
@@ -64,5 +64,7 @@ data class ServerInfoDto(
     @SerialName("is_favorite")
     val isFavorite: Boolean? = null,
     @SerialName("next_wipe")
-    val nextWipe: Instant? = null
+    val nextWipe: Instant? = null,
+    @SerialName("next_map_wipe")
+    val nextMapWipe: Instant? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerInfo.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerInfo.kt
@@ -38,5 +38,6 @@ data class ServerInfo(
     val mapUrl: String? = null,
     val headerImage: String? = null,
     val isFavorite: Boolean? = null,
-    val nextWipe: Instant? = null
+    val nextWipe: Instant? = null,
+    val nextMapWipe: Instant? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
@@ -43,6 +43,7 @@ data class ServerInfoUi(
     val averageFps: Long? = null,
     val lastWipe: String? = null,
     val nextWipe: String? = null,
+    val nextMapWipe: String? = null,
     val pve: Boolean? = null,
     val website: String? = null,
     val isPremium: Boolean? = null,

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
@@ -40,6 +40,7 @@ fun ServerInfo.toUi(): ServerInfoUi {
         averageFps = averageFps,
         lastWipe = wipe?.let { formatLastWipe(it) },
         nextWipe = nextWipe?.let { formatNextWipe(it) },
+        nextMapWipe = nextMapWipe?.let { formatNextWipe(it) },
         pve = pve,
         website = website,
         isPremium = isPremium,

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -46,6 +46,7 @@ CREATE TABLE serverEntity (
     map_url        TEXT,
     header_image   TEXT,
     rust_next_wipe TEXT,
+    rust_next_map_wipe TEXT,
     favourite      INTEGER    NOT NULL DEFAULT 0
 );
 
@@ -133,6 +134,7 @@ INSERT INTO serverEntity (
     header_image,
     monuments,
     rust_next_wipe,
+    rust_next_map_wipe,
     favourite
 ) VALUES (
     :id,
@@ -170,6 +172,7 @@ INSERT INTO serverEntity (
     :headerImage,
     :monuments,
     :nextWipe,
+    :nextMapWipe,
     CASE WHEN :favourite THEN 1 ELSE 0 END
 ) ON CONFLICT(id) DO UPDATE SET
     name           = excluded.name,
@@ -206,6 +209,7 @@ INSERT INTO serverEntity (
     map_url        = excluded.map_url,
     header_image   = excluded.header_image,
     rust_next_wipe = excluded.rust_next_wipe,
+    rust_next_map_wipe = excluded.rust_next_map_wipe,
     favourite      = excluded.favourite;
 
 clearServers:


### PR DESCRIPTION
## Summary
- parse new `next_map_wipe` from server API
- save next map wipe in the local database
- expose next map wipe on domain and UI models
- show "Next map wipe" in server details screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b94a65f8c8321983fbd224116bad5