### PR TITLE
Add subscription support

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.NotificationsNone
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
@@ -93,7 +94,12 @@ fun ServerDetailsScreen(
                         Icon(icon, contentDescription = null)
                     }
                     IconButton(onClick = { onAction(ServerDetailsAction.OnSubscribe) }) {
-                        Icon(Icons.Filled.Notifications, contentDescription = null)
+                        val icon = if (state.details?.isSubscribed == true) {
+                            Icons.Filled.Notifications
+                        } else {
+                            Icons.Outlined.NotificationsNone
+                        }
+                        Icon(icon, contentDescription = null)
                     }
                 },
                 scrollBehavior = scrollBehavior

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -15,12 +15,14 @@ import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
+import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory(androidContext()).create() }
     single { HttpClientFactory(get(), get()).create() }
     single { ClipboardHandler(get()) }
     single { SyncScheduler(get()) }
+    single { SubscriptionSyncScheduler(get()) }
     viewModel {
         StartupViewModel(get(), get())
     }
@@ -65,6 +67,7 @@ actual val platformModule: Module = module {
         ServerDetailsViewModel(
             getServerDetailsUseCase = get(),
             toggleFavouriteUseCase = get(),
+            toggleSubscriptionUseCase = get(),
             serverName = serverName,
             serverId = serverId,
             clipboardHandler = get(),

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
@@ -8,12 +8,16 @@ import org.koin.android.ext.koin.androidContext
 import pl.cuyer.rusthub.domain.repository.favourite.FavouriteSyncDataSource
 import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.work.FavouriteWorkerFactory
 
 class RustHubApplication : Application(), Configuration.Provider {
 
     val repository by inject<FavouriteRepository>()
     val syncDataSource by inject<FavouriteSyncDataSource>()
+    val subscriptionRepository by inject<SubscriptionRepository>()
+    val subscriptionSyncDataSource by inject<SubscriptionSyncDataSource>()
     val serverDataSource by inject<ServerDataSource>()
 
     override fun onCreate() {
@@ -29,8 +33,10 @@ class RustHubApplication : Application(), Configuration.Provider {
         get() = Configuration.Builder()
             .setWorkerFactory(
                 FavouriteWorkerFactory(
-                    repository = repository,
-                    syncDataSource = syncDataSource,
+                    favouriteRepository = repository,
+                    favouriteSyncDataSource = syncDataSource,
+                    subscriptionRepository = subscriptionRepository,
+                    subscriptionSyncDataSource = subscriptionSyncDataSource,
                     serverDataSource = serverDataSource
                 )
             )

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/SubscriptionSyncScheduler.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/SubscriptionSyncScheduler.android.kt
@@ -1,0 +1,30 @@
+package pl.cuyer.rusthub.util
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import pl.cuyer.rusthub.work.SubscriptionSyncWorker
+
+actual class SubscriptionSyncScheduler(
+    private val context: Context
+) {
+    actual fun schedule(serverId: Long) {
+        val request = OneTimeWorkRequestBuilder<SubscriptionSyncWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+            )
+            .build()
+        WorkManager
+            .getInstance(context)
+            .enqueueUniqueWork(
+                "subscription_$serverId",
+                ExistingWorkPolicy.REPLACE,
+                request
+            )
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/FavouriteWorkerFactory.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/FavouriteWorkerFactory.kt
@@ -7,10 +7,14 @@ import androidx.work.WorkerParameters
 import pl.cuyer.rusthub.domain.repository.favourite.FavouriteSyncDataSource
 import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 
 class FavouriteWorkerFactory(
-    private val repository: FavouriteRepository,
-    private val syncDataSource: FavouriteSyncDataSource,
+    private val favouriteRepository: FavouriteRepository,
+    private val favouriteSyncDataSource: FavouriteSyncDataSource,
+    private val subscriptionRepository: SubscriptionRepository,
+    private val subscriptionSyncDataSource: SubscriptionSyncDataSource,
     private val serverDataSource: ServerDataSource
 ) : WorkerFactory() {
 
@@ -24,8 +28,17 @@ class FavouriteWorkerFactory(
                 FavouriteSyncWorker(
                     appContext,
                     workerParameters,
-                    repository,
-                    syncDataSource,
+                    favouriteRepository,
+                    favouriteSyncDataSource,
+                    serverDataSource
+                )
+            }
+            SubscriptionSyncWorker::class.qualifiedName -> {
+                SubscriptionSyncWorker(
+                    appContext,
+                    workerParameters,
+                    subscriptionRepository,
+                    subscriptionSyncDataSource,
                     serverDataSource
                 )
             }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/SubscriptionSyncWorker.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/SubscriptionSyncWorker.kt
@@ -1,0 +1,61 @@
+package pl.cuyer.rusthub.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.collectLatest
+import pl.cuyer.rusthub.domain.exception.SubscriptionLimitException
+import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
+import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
+import pl.cuyer.rusthub.common.Result as DomainResult
+
+class SubscriptionSyncWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val repository: SubscriptionRepository,
+    private val syncDataSource: SubscriptionSyncDataSource,
+    private val serverDataSource: ServerDataSource
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result = coroutineScope {
+        val operations = syncDataSource.getPendingOperations()
+        if (operations.isEmpty()) return@coroutineScope Result.success()
+
+        val tasks = operations.map { operation ->
+            async {
+                var success = false
+                repository.run {
+                    if (operation.isAdd) addSubscription(operation.serverId)
+                    else removeSubscription(operation.serverId)
+                }.collectLatest { result ->
+                    when (result) {
+                        is DomainResult.Success -> {
+                            serverDataSource.updateSubscription(operation.serverId, operation.isAdd)
+                            syncDataSource.deleteOperation(operation.serverId)
+                            success = true
+                        }
+                        is DomainResult.Error -> {
+                            when (result.exception) {
+                                is SubscriptionLimitException -> {
+                                    syncDataSource.deleteOperation(operation.serverId)
+                                    success = true
+                                }
+                                else -> success = false
+                            }
+                        }
+                        else -> Unit
+                    }
+                }
+                success
+            }
+        }
+
+        val results = tasks.awaitAll()
+        return@coroutineScope if (results.any { !it }) Result.retry() else Result.success()
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -114,6 +114,7 @@ fun ServerEntity.toServerInfo(): ServerInfo {
         mapUrl = map_url,
         headerImage = header_image,
         isFavorite = favourite == 1L,
+        isSubscribed = subscribed == 1L,
         nextWipe = rust_next_wipe?.let { Instant.parse(it) },
         nextMapWipe = rust_next_map_wipe?.let { Instant.parse(it) }
     )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/server/ServerDataSourceImpl.kt
@@ -64,6 +64,7 @@ class ServerDataSourceImpl(
                         mapUrl = info.mapUrl,
                         headerImage = info.headerImage,
                         favourite = info.isFavorite == true,
+                        subscribed = info.isSubscribed == true,
                         nextWipe = info.nextWipe?.toString(),
                         nextMapWipe = info.nextMapWipe?.toString()
                     )
@@ -109,6 +110,14 @@ class ServerDataSourceImpl(
         withContext(Dispatchers.IO) {
             runCatching {
                 queries.updateFavourite(id = serverId, favourite = favourite)
+            }
+        }
+    }
+
+    override suspend fun updateSubscription(serverId: Long, subscribed: Boolean) {
+        withContext(Dispatchers.IO) {
+            runCatching {
+                queries.updateSubscription(id = serverId, subscribed = subscribed)
             }
         }
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/subscription/SubscriptionSyncDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/subscription/SubscriptionSyncDataSourceImpl.kt
@@ -1,0 +1,44 @@
+package pl.cuyer.rusthub.data.local.subscription
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import pl.cuyer.rusthub.data.local.Queries
+import pl.cuyer.rusthub.database.RustHubDatabase
+import pl.cuyer.rusthub.domain.model.SubscriptionSyncOperation
+import pl.cuyer.rusthub.domain.model.SyncState
+import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
+
+class SubscriptionSyncDataSourceImpl(
+    db: RustHubDatabase
+) : SubscriptionSyncDataSource, Queries(db) {
+    override suspend fun upsertOperation(operation: SubscriptionSyncOperation) {
+        withContext(Dispatchers.IO) {
+            queries.upsertSubscriptionSync(
+                server_id = operation.serverId,
+                action = if (operation.isAdd) 1L else 0L,
+                sync_state = operation.syncState.name
+            )
+        }
+    }
+
+    override suspend fun deleteOperation(serverId: Long) {
+        withContext(Dispatchers.IO) {
+            queries.deleteSubscriptionSync(server_id = serverId)
+        }
+    }
+
+    override suspend fun getPendingOperations(): List<SubscriptionSyncOperation> {
+        return withContext(Dispatchers.IO) {
+            queries.getPendingSubscriptionSync()
+                .executeAsList()
+                .map {
+                    SubscriptionSyncOperation(
+                        serverId = it.server_id,
+                        isAdd = it.action == 1L,
+                        syncState = SyncState.valueOf(it.sync_state)
+                    )
+                }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/mapper/ServerInfoNetworkMapper.kt
@@ -43,6 +43,7 @@ fun ServerInfoDto.toDomain(): ServerInfo {
         mapUrl = mapUrl,
         headerImage = headerImage,
         isFavorite = isFavorite,
+        isSubscribed = isSubscribed,
         nextWipe = nextWipe,
         nextMapWipe = nextMapWipe
     )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/ServerInfoDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/server/model/ServerInfoDto.kt
@@ -63,6 +63,8 @@ data class ServerInfoDto(
     val headerImage: String? = null,
     @SerialName("is_favorite")
     val isFavorite: Boolean? = null,
+    @SerialName("is_subscribed")
+    val isSubscribed: Boolean? = null,
     @SerialName("next_wipe")
     val nextWipe: Instant? = null,
     @SerialName("next_map_wipe")

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/subscription/SubscriptionClientImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/subscription/SubscriptionClientImpl.kt
@@ -1,0 +1,41 @@
+package pl.cuyer.rusthub.data.network.subscription
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
+import io.ktor.client.request.post
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.data.network.util.BaseApiResponse
+import pl.cuyer.rusthub.data.network.util.NetworkConstants
+import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
+
+class SubscriptionClientImpl(
+    private val httpClient: HttpClient,
+    json: Json
+) : SubscriptionRepository, BaseApiResponse(json) {
+    override fun addSubscription(id: Long): Flow<Result<Unit>> {
+        return safeApiCall<Unit> {
+            httpClient.post(NetworkConstants.BASE_URL + "subscriptions/$id")
+        }.map { result ->
+            when (result) {
+                is Result.Success -> Result.Success(Unit)
+                is Result.Error -> result
+                Result.Loading -> Result.Loading
+            }
+        }
+    }
+
+    override fun removeSubscription(id: Long): Flow<Result<Unit>> {
+        return safeApiCall<Unit> {
+            httpClient.delete(NetworkConstants.BASE_URL + "subscriptions/$id")
+        }.map { result ->
+            when (result) {
+                is Result.Success -> Result.Success(Unit)
+                is Result.Error -> result
+                Result.Loading -> Result.Loading
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/util/BaseApiResponse.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/util/BaseApiResponse.kt
@@ -18,6 +18,7 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.data.network.model.ErrorResponse
 import pl.cuyer.rusthub.domain.exception.AnonymousUpgradeException
 import pl.cuyer.rusthub.domain.exception.FavoriteLimitException
+import pl.cuyer.rusthub.domain.exception.SubscriptionLimitException
 import pl.cuyer.rusthub.domain.exception.FiltersOptionsException
 import pl.cuyer.rusthub.domain.exception.ForbiddenException
 import pl.cuyer.rusthub.domain.exception.HttpStatusException
@@ -96,6 +97,9 @@ abstract class BaseApiResponse(
 
             FavoriteLimitException::class.simpleName -> FavoriteLimitException(
                 errorResponse.message ?: "Favorite limit error"
+            )
+            SubscriptionLimitException::class.simpleName -> SubscriptionLimitException(
+                errorResponse.message ?: "Subscription limit error"
             )
             else -> Exception(errorResponse.message)
         }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/ServersException.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/exception/ServersException.kt
@@ -4,3 +4,4 @@ open class ServersException(message: String) : RuntimeException(message)
 
 class ServersQueryException(message: String) : ServersException(message)
 class FavoriteLimitException(message: String) : ServersException(message)
+class SubscriptionLimitException(message: String) : ServersException(message)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerInfo.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerInfo.kt
@@ -38,6 +38,7 @@ data class ServerInfo(
     val mapUrl: String? = null,
     val headerImage: String? = null,
     val isFavorite: Boolean? = null,
+    val isSubscribed: Boolean? = null,
     val nextWipe: Instant? = null,
     val nextMapWipe: Instant? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/SubscriptionSyncOperation.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/SubscriptionSyncOperation.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.domain.model
+
+data class SubscriptionSyncOperation(
+    val serverId: Long,
+    val isAdd: Boolean,
+    val syncState: SyncState
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/server/ServerDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/server/ServerDataSource.kt
@@ -12,4 +12,5 @@ interface ServerDataSource {
     fun getServerById(serverId: Long): Flow<ServerInfo?>
     suspend fun deleteServers()
     suspend fun updateFavourite(serverId: Long, favourite: Boolean)
+    suspend fun updateSubscription(serverId: Long, subscribed: Boolean)
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/subscription/SubscriptionSyncDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/subscription/SubscriptionSyncDataSource.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.domain.repository.subscription
+
+import pl.cuyer.rusthub.domain.model.SubscriptionSyncOperation
+
+interface SubscriptionSyncDataSource {
+    suspend fun upsertOperation(operation: SubscriptionSyncOperation)
+    suspend fun deleteOperation(serverId: Long)
+    suspend fun getPendingOperations(): List<SubscriptionSyncOperation>
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/subscription/network/SubscriptionRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/subscription/network/SubscriptionRepository.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.domain.repository.subscription.network
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.common.Result
+
+interface SubscriptionRepository {
+    fun addSubscription(id: Long): Flow<Result<Unit>>
+    fun removeSubscription(id: Long): Flow<Result<Unit>>
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ToggleSubscriptionUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ToggleSubscriptionUseCase.kt
@@ -1,0 +1,53 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.exception.NetworkUnavailableException
+import pl.cuyer.rusthub.domain.exception.TimeoutException
+import pl.cuyer.rusthub.domain.model.SubscriptionSyncOperation
+import pl.cuyer.rusthub.domain.model.SyncState
+import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
+import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
+import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
+
+class ToggleSubscriptionUseCase(
+    private val serverDataSource: ServerDataSource,
+    private val repository: SubscriptionRepository,
+    private val syncDataSource: SubscriptionSyncDataSource,
+    private val scheduler: SubscriptionSyncScheduler
+) {
+    operator fun invoke(serverId: Long, add: Boolean): Flow<Result<Unit>> = channelFlow {
+        val flow = if (add) repository.addSubscription(serverId) else repository.removeSubscription(serverId)
+
+        flow.collectLatest { result ->
+            when (result) {
+                is Result.Success -> {
+                    serverDataSource.updateSubscription(serverId, add)
+                    syncDataSource.deleteOperation(serverId)
+                    send(Result.Success(Unit))
+                }
+                is Result.Error -> {
+                    when (result.exception) {
+                        is NetworkUnavailableException, is TimeoutException -> {
+                            serverDataSource.updateSubscription(serverId, add)
+                            syncDataSource.upsertOperation(
+                                SubscriptionSyncOperation(
+                                    serverId,
+                                    add,
+                                    SyncState.PENDING
+                                )
+                            )
+                            scheduler.schedule(serverId)
+                            send(Result.Success(Unit))
+                        }
+                        else -> send(Result.Error(result.exception))
+                    }
+                }
+                Result.Loading -> Unit
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -16,9 +16,11 @@ import pl.cuyer.rusthub.data.local.remotekey.RemoteKeyDataSourceImpl
 import pl.cuyer.rusthub.data.local.search.SearchQueryDataSourceImpl
 import pl.cuyer.rusthub.data.local.server.ServerDataSourceImpl
 import pl.cuyer.rusthub.data.local.favourite.FavouriteSyncDataSourceImpl
+import pl.cuyer.rusthub.data.local.subscription.SubscriptionSyncDataSourceImpl
 import pl.cuyer.rusthub.data.network.auth.AuthRepositoryImpl
 import pl.cuyer.rusthub.data.network.filtersOptions.FiltersOptionsClientImpl
 import pl.cuyer.rusthub.data.network.favourite.FavouriteClientImpl
+import pl.cuyer.rusthub.data.network.subscription.SubscriptionClientImpl
 import pl.cuyer.rusthub.data.network.server.ServerClientImpl
 import pl.cuyer.rusthub.domain.repository.RemoteKeyDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
@@ -31,6 +33,8 @@ import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.server.ServerRepository
 import pl.cuyer.rusthub.domain.repository.favourite.FavouriteSyncDataSource
 import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
+import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
+import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.domain.usecase.AuthAnonymouslyUseCase
 import pl.cuyer.rusthub.domain.usecase.ClearFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteSearchQueriesUseCase
@@ -43,6 +47,7 @@ import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleFavouriteUseCase
+import pl.cuyer.rusthub.domain.usecase.ToggleSubscriptionUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
@@ -62,8 +67,10 @@ val appModule = module {
     }
     singleOf(::ServerClientImpl) bind ServerRepository::class
     singleOf(::FavouriteClientImpl) bind FavouriteRepository::class
+    singleOf(::SubscriptionClientImpl) bind SubscriptionRepository::class
     singleOf(::ServerDataSourceImpl) bind ServerDataSource::class
     singleOf(::FavouriteSyncDataSourceImpl) bind FavouriteSyncDataSource::class
+    singleOf(::SubscriptionSyncDataSourceImpl) bind SubscriptionSyncDataSource::class
     singleOf(::FiltersDataSourceImpl) bind FiltersDataSource::class
     singleOf(::SearchQueryDataSourceImpl) bind SearchQueryDataSource::class
     singleOf(::RemoteKeyDataSourceImpl) bind RemoteKeyDataSource::class
@@ -90,6 +97,7 @@ val appModule = module {
     single { GetUserUseCase(get()) }
     single { LogoutUserUseCase(get()) }
     single { ToggleFavouriteUseCase(get(), get(), get(), get()) }
+    single { ToggleSubscriptionUseCase(get(), get(), get(), get()) }
 }
 
 expect val platformModule: Module

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerInfoUi.kt
@@ -49,5 +49,6 @@ data class ServerInfoUi(
     val isPremium: Boolean? = null,
     val mapUrl: String? = null,
     val headerImage: String? = null,
-    val isFavorite: Boolean? = null
+    val isFavorite: Boolean? = null,
+    val isSubscribed: Boolean? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/model/ServerUiMapper.kt
@@ -46,7 +46,8 @@ fun ServerInfo.toUi(): ServerInfoUi {
         isPremium = isPremium,
         mapUrl = mapUrl,
         headerImage = headerImage,
-        isFavorite = isFavorite
+        isFavorite = isFavorite,
+        isSubscribed = isSubscribed
     )
 
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/SubscriptionSyncScheduler.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/SubscriptionSyncScheduler.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+expect class SubscriptionSyncScheduler {
+    fun schedule(serverId: Long)
+}

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -47,7 +47,8 @@ CREATE TABLE serverEntity (
     header_image   TEXT,
     rust_next_wipe TEXT,
     rust_next_map_wipe TEXT,
-    favourite      INTEGER    NOT NULL DEFAULT 0
+    favourite      INTEGER    NOT NULL DEFAULT 0,
+    subscribed     INTEGER    NOT NULL DEFAULT 0
 );
 
 -- =============================================================================
@@ -135,7 +136,8 @@ INSERT INTO serverEntity (
     monuments,
     rust_next_wipe,
     rust_next_map_wipe,
-    favourite
+    favourite,
+    subscribed
 ) VALUES (
     :id,
     :name,
@@ -173,7 +175,8 @@ INSERT INTO serverEntity (
     :monuments,
     :nextWipe,
     :nextMapWipe,
-    CASE WHEN :favourite THEN 1 ELSE 0 END
+    CASE WHEN :favourite THEN 1 ELSE 0 END,
+    CASE WHEN :subscribed THEN 1 ELSE 0 END
 ) ON CONFLICT(id) DO UPDATE SET
     name           = excluded.name,
     wipe           = excluded.wipe,
@@ -210,7 +213,8 @@ INSERT INTO serverEntity (
     header_image   = excluded.header_image,
     rust_next_wipe = excluded.rust_next_wipe,
     rust_next_map_wipe = excluded.rust_next_map_wipe,
-    favourite      = excluded.favourite;
+    favourite      = excluded.favourite,
+    subscribed     = excluded.subscribed;
 
 clearServers:
 DELETE FROM serverEntity;
@@ -220,6 +224,9 @@ SELECT * FROM serverEntity WHERE id == :id;
 
 updateFavourite:
 UPDATE serverEntity SET favourite = CASE WHEN :favourite THEN 1 ELSE 0 END WHERE id = :id;
+
+updateSubscription:
+UPDATE serverEntity SET subscribed = CASE WHEN :subscribed THEN 1 ELSE 0 END WHERE id = :id;
 
 
 CREATE TABLE filtersEntity (
@@ -481,6 +488,12 @@ CREATE TABLE favouriteSyncEntity (
     sync_state TEXT NOT NULL
 );
 
+CREATE TABLE subscriptionSyncEntity (
+    server_id INTEGER NOT NULL PRIMARY KEY,
+    action INTEGER NOT NULL,
+    sync_state TEXT NOT NULL
+);
+
 upsertFavouriteSync:
 INSERT INTO favouriteSyncEntity (server_id, action, sync_state)
 VALUES (:server_id, :action, :sync_state)
@@ -493,6 +506,19 @@ SELECT * FROM favouriteSyncEntity WHERE sync_state = 'PENDING';
 
 deleteFavouriteSync:
 DELETE FROM favouriteSyncEntity WHERE server_id = :server_id;
+
+upsertSubscriptionSync:
+INSERT INTO subscriptionSyncEntity (server_id, action, sync_state)
+VALUES (:server_id, :action, :sync_state)
+ON CONFLICT(server_id) DO UPDATE SET
+    action = excluded.action,
+    sync_state = excluded.sync_state;
+
+getPendingSubscriptionSync:
+SELECT * FROM subscriptionSyncEntity WHERE sync_state = 'PENDING';
+
+deleteSubscriptionSync:
+DELETE FROM subscriptionSyncEntity WHERE server_id = :server_id;
 
 CREATE TABLE userEntity (
   id TEXT NOT NULL PRIMARY KEY,

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -11,12 +11,14 @@ import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
+import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
     single { HttpClientFactory(get(), get()).create() }
     single { ClipboardHandler() }
     single { SyncScheduler() }
+    single { SubscriptionSyncScheduler() }
     factory { StartupViewModel(get()) }
     factory {
         OnboardingViewModel(

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/SubscriptionSyncScheduler.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/SubscriptionSyncScheduler.ios.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+actual class SubscriptionSyncScheduler {
+    actual fun schedule(serverId: Long) { /* no-op */ }
+}


### PR DESCRIPTION
## Summary
- add subscribe/unsubscribe API client and local sync
- handle subscription limit errors
- persist server subscription status
- update workers and schedulers for subscription
- wire new use case into view models and UI

## Testing
- `./gradlew test` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf80840148321b799dece7f3493e4