### PR TITLE
Implement notification permission flow with new DSL

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -2,8 +2,6 @@ package pl.cuyer.rusthub.android.feature.server
 
 import android.Manifest
 import android.os.Build
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -34,8 +32,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -50,7 +50,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
-import androidx.core.content.ContextCompat
 import coil3.compose.AsyncImage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,6 +57,7 @@ import pl.cuyer.rusthub.android.designsystem.ServerDetail
 import pl.cuyer.rusthub.android.designsystem.ServerWebsite
 import pl.cuyer.rusthub.android.designsystem.SubscriptionDialog
 import pl.cuyer.rusthub.android.designsystem.NotificationInfoDialog
+import pl.cuyer.rusthub.android.util.HandlePermission
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
 import pl.cuyer.rusthub.domain.model.Flag
@@ -80,10 +80,35 @@ fun ServerDetailsScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val lazyListState = rememberLazyListState()
     val state = stateProvider().value
-    val context = LocalContext.current
-    val requestPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission()
-    ) { onAction(ServerDetailsAction.OnSubscribe) }
+    var requestPermission by remember { mutableStateOf(false) }
+
+    if (requestPermission) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            HandlePermission(
+                permission = Manifest.permission.POST_NOTIFICATIONS,
+                onResult = { granted ->
+                    requestPermission = false
+                    if (granted) onAction(ServerDetailsAction.OnSubscribe)
+                }
+            ) {
+                onGranted {
+                    requestPermission = false
+                    onAction(ServerDetailsAction.OnSubscribe)
+                }
+                onShowRationale { handler ->
+                    NotificationInfoDialog(
+                        showDialog = true,
+                        onConfirm = { handler.launchPermissionRequest() },
+                        onDismiss = { requestPermission = false }
+                    )
+                }
+                onRequestPermission { }
+            }
+        } else {
+            requestPermission = false
+            onAction(ServerDetailsAction.OnSubscribe)
+        }
+    }
 
     Scaffold(
         modifier = Modifier
@@ -104,7 +129,13 @@ fun ServerDetailsScreen(
                             if (state.details?.isFavorite == true) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder
                         Icon(icon, contentDescription = null)
                     }
-                    IconButton(onClick = { onAction(ServerDetailsAction.OnSubscribe) }) {
+                    IconButton(onClick = {
+                        if (state.details?.isSubscribed == true) {
+                            onAction(ServerDetailsAction.OnSubscribe)
+                        } else {
+                            requestPermission = true
+                        }
+                    }) {
                         val icon = if (state.details?.isSubscribed == true) {
                             Icons.Filled.Notifications
                         } else {
@@ -122,22 +153,6 @@ fun ServerDetailsScreen(
                 showDialog = state.showSubscriptionDialog,
                 onConfirm = { onAction(ServerDetailsAction.OnSubscribe) },
                 onDismiss = { onAction(ServerDetailsAction.OnDismissSubscriptionDialog) }
-            )
-            NotificationInfoDialog(
-                showDialog = state.showNotificationInfoDialog,
-                onConfirm = {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                        ContextCompat.checkSelfPermission(
-                            context,
-                            Manifest.permission.POST_NOTIFICATIONS
-                        ) != android.content.pm.PackageManager.PERMISSION_GRANTED
-                    ) {
-                        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                    } else {
-                        onAction(ServerDetailsAction.OnSubscribe)
-                    }
-                },
-                onDismiss = { onAction(ServerDetailsAction.OnDismissNotificationDialog) }
             )
             LazyColumn(
                 state = lazyListState,

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/util/PermissionsDsl.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/util/PermissionsDsl.kt
@@ -1,0 +1,88 @@
+package pl.cuyer.rusthub.android.util
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+@DslMarker
+annotation class PermissionsDSL
+
+@PermissionsDSL
+class PermissionHandlerScope(
+    val isGranted: Boolean,
+    val shouldShowRationale: Boolean,
+    private val launchRequest: () -> Unit
+) {
+    private var handled = false
+
+    fun launchPermissionRequest() {
+        launchRequest()
+    }
+
+    @Composable
+    fun onGranted(body: @Composable () -> Unit) {
+        if (!handled && isGranted) {
+            handled = true
+            body()
+        }
+    }
+
+    @Composable
+    fun onShowRationale(body: @Composable (PermissionHandlerScope) -> Unit) {
+        if (!handled && shouldShowRationale && !isGranted) {
+            handled = true
+            body(this)
+        }
+    }
+
+    @Composable
+    fun onRequestPermission(body: @Composable () -> Unit) {
+        if (!handled && !isGranted && !shouldShowRationale) {
+            handled = true
+            body()
+            launchRequest()
+        }
+    }
+
+    @Composable
+    fun onDenied(body: @Composable () -> Unit) {
+        if (!handled && !isGranted) {
+            handled = true
+            body()
+        }
+    }
+}
+
+@Composable
+fun HandlePermission(
+    permission: String,
+    onResult: (Boolean) -> Unit,
+    content: @Composable PermissionHandlerScope.() -> Unit
+) {
+    val context = LocalContext.current
+    val activity = context as? Activity
+    val launcher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+        onResult
+    )
+
+    val granted = ContextCompat.checkSelfPermission(
+        context,
+        permission
+    ) == PackageManager.PERMISSION_GRANTED
+
+    val rationale = activity?.let {
+        ActivityCompat.shouldShowRequestPermissionRationale(it, permission)
+    } ?: false
+
+    PermissionHandlerScope(
+        isGranted = granted,
+        shouldShowRationale = rationale,
+        launchRequest = { launcher.launch(permission) }
+    ).content()
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsAction.kt
@@ -5,5 +5,4 @@ sealed interface ServerDetailsAction {
     data object OnToggleFavourite : ServerDetailsAction
     data object OnSubscribe : ServerDetailsAction
     data object OnDismissSubscriptionDialog : ServerDetailsAction
-    data object OnDismissNotificationDialog : ServerDetailsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsState.kt
@@ -7,6 +7,5 @@ data class ServerDetailsState(
     val isLoading: Boolean = true,
     val serverId: Long? = null,
     val serverName: String? = null,
-    val showSubscriptionDialog: Boolean = false,
-    val showNotificationInfoDialog: Boolean = false
+    val showSubscriptionDialog: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -66,7 +66,6 @@ class ServerDetailsViewModel(
             is ServerDetailsAction.OnSaveToClipboard -> saveIpToClipboard(action.ipAddress)
             ServerDetailsAction.OnToggleFavourite -> toggleFavourite()
             ServerDetailsAction.OnDismissSubscriptionDialog -> showSubscriptionDialog(false)
-            ServerDetailsAction.OnDismissNotificationDialog -> showNotificationInfoDialog(false)
             ServerDetailsAction.OnSubscribe -> handleSubscribeAction()
         }
     }
@@ -174,34 +173,20 @@ class ServerDetailsViewModel(
         }
     }
 
-    private fun showNotificationInfoDialog(show: Boolean) {
-        _state.update {
-            it.copy(
-                showNotificationInfoDialog = show
-            )
-        }
-    }
-
     private fun handleSubscribeAction() {
         val subscribed = state.value.details?.isSubscribed == true
-        when {
-            state.value.showSubscriptionDialog -> {
-                coroutineScope.launch {
-                    snackbarController.sendEvent(
-                        SnackbarEvent(
-                            message = "Subscribed to notifications",
-                            duration = Duration.SHORT
-                        )
+        if (state.value.showSubscriptionDialog) {
+            coroutineScope.launch {
+                snackbarController.sendEvent(
+                    SnackbarEvent(
+                        message = "Subscribed to notifications",
+                        duration = Duration.SHORT
                     )
-                }
-                showSubscriptionDialog(false)
+                )
             }
-            state.value.showNotificationInfoDialog -> {
-                toggleSubscription()
-                showNotificationInfoDialog(false)
-            }
-            !subscribed -> showNotificationInfoDialog(true)
-            else -> toggleSubscription()
+            showSubscriptionDialog(false)
+        } else {
+            toggleSubscription()
         }
     }
 


### PR DESCRIPTION
## Summary
- add `PermissionsDsl` to manage runtime permission requests in Compose
- refactor `ServerDetailsScreen` to use the new DSL for notification permission
- remove obsolete notification dialog handling from view model
- clean up state and actions

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c39509fc88321970840abf61719f2