### PR TITLE
Add typed notification channels

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/notification/RustHubFirebaseMessagingService.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/notification/RustHubFirebaseMessagingService.kt
@@ -3,11 +3,14 @@ package pl.cuyer.rusthub.notification
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import pl.cuyer.rusthub.util.NotificationPresenter
+import pl.cuyer.rusthub.domain.model.NotificationType
 
 class RustHubFirebaseMessagingService : FirebaseMessagingService() {
     override fun onMessageReceived(message: RemoteMessage) {
-        val title = message.notification?.title ?: return
-        val body = message.notification?.body ?: return
-        NotificationPresenter(this).show(title, body)
+        val type = message.data["type"]?.let { value ->
+            runCatching { NotificationType.valueOf(value) }.getOrNull()
+        } ?: return
+        val id = message.data["id"] ?: return
+        NotificationPresenter(this).show(id, type)
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/NotificationType.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/NotificationType.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.domain.model
+
+enum class NotificationType {
+    MapWipe,
+    Wipe,
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.kt
@@ -1,5 +1,7 @@
 package pl.cuyer.rusthub.util
 
+import pl.cuyer.rusthub.domain.model.NotificationType
+
 expect class NotificationPresenter {
-    fun show(title: String, body: String)
+    fun show(id: String, type: NotificationType)
 }

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -3,4 +3,10 @@
     <string name="app_name">RustHub</string>
     <string name="notification_channel_name">Notifications</string>
     <string name="notification_channel_description">General notifications in the application.</string>
+    <string name="map_wipe_notification_channel_name">Map wipe notifications</string>
+    <string name="map_wipe_notification_channel_description">Notifications about map wipes.</string>
+    <string name="wipe_notification_channel_name">Wipe notifications</string>
+    <string name="wipe_notification_channel_description">Notifications about server wipes.</string>
+    <string name="map_wipe_notification_body">Map wipe on server %1$s</string>
+    <string name="wipe_notification_body">Server %1$s has been wiped</string>
 </resources>

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.ios.kt
@@ -1,5 +1,7 @@
 package pl.cuyer.rusthub.util
 
+import pl.cuyer.rusthub.domain.model.NotificationType
+
 actual class NotificationPresenter {
-    actual fun show(title: String, body: String) { /* no-op */ }
+    actual fun show(id: String, type: NotificationType) { /* no-op */ }
 }


### PR DESCRIPTION
## Summary
- handle typed notifications in `NotificationPresenter`
- map notification channels for MapWipe and Wipe events
- parse notification type in `RustHubFirebaseMessagingService`
- provide `NotificationType` enum

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4c22ed0c8321977f51e06cbee3f6