### PR TITLE
Add Firebase topic subscription

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -16,6 +16,7 @@ import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
+import pl.cuyer.rusthub.util.TopicSubscriber
 import dev.icerock.moko.permissions.PermissionsController
 
 actual val platformModule: Module = module {
@@ -24,6 +25,7 @@ actual val platformModule: Module = module {
     single { ClipboardHandler(get()) }
     single { SyncScheduler(get()) }
     single { SubscriptionSyncScheduler(get()) }
+    single { TopicSubscriber() }
     single { PermissionsController(androidContext()) }
     viewModel {
         StartupViewModel(get(), get())

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
@@ -11,6 +11,7 @@ import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.work.CustomWorkerFactory
+import pl.cuyer.rusthub.util.TopicSubscriber
 
 class RustHubApplication : Application(), Configuration.Provider {
 
@@ -19,6 +20,7 @@ class RustHubApplication : Application(), Configuration.Provider {
     val subscriptionRepository by inject<SubscriptionRepository>()
     val subscriptionSyncDataSource by inject<SubscriptionSyncDataSource>()
     val serverDataSource by inject<ServerDataSource>()
+    val topicSubscriber by inject<TopicSubscriber>()
 
     override fun onCreate() {
         super.onCreate()
@@ -37,7 +39,8 @@ class RustHubApplication : Application(), Configuration.Provider {
                     favouriteSyncDataSource = syncDataSource,
                     subscriptionRepository = subscriptionRepository,
                     subscriptionSyncDataSource = subscriptionSyncDataSource,
-                    serverDataSource = serverDataSource
+                    serverDataSource = serverDataSource,
+                    topicSubscriber = topicSubscriber
                 )
             )
             .build()

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.android.kt
@@ -1,0 +1,13 @@
+package pl.cuyer.rusthub.util
+
+import com.google.firebase.messaging.FirebaseMessaging
+
+actual class TopicSubscriber {
+    actual fun subscribe(topic: String) {
+        FirebaseMessaging.getInstance().subscribeToTopic(topic)
+    }
+
+    actual fun unsubscribe(topic: String) {
+        FirebaseMessaging.getInstance().unsubscribeFromTopic(topic)
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/CustomWorkerFactory.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/CustomWorkerFactory.kt
@@ -9,13 +9,15 @@ import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
+import pl.cuyer.rusthub.util.TopicSubscriber
 
 class CustomWorkerFactory(
     private val favouriteRepository: FavouriteRepository,
     private val favouriteSyncDataSource: FavouriteSyncDataSource,
     private val subscriptionRepository: SubscriptionRepository,
     private val subscriptionSyncDataSource: SubscriptionSyncDataSource,
-    private val serverDataSource: ServerDataSource
+    private val serverDataSource: ServerDataSource,
+    private val topicSubscriber: TopicSubscriber
 ) : WorkerFactory() {
 
     override fun createWorker(
@@ -39,7 +41,8 @@ class CustomWorkerFactory(
                     workerParameters,
                     subscriptionRepository,
                     subscriptionSyncDataSource,
-                    serverDataSource
+                    serverDataSource,
+                    topicSubscriber
                 )
             }
 

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/SubscriptionSyncWorker.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/SubscriptionSyncWorker.kt
@@ -12,6 +12,7 @@ import pl.cuyer.rusthub.domain.exception.SubscriptionLimitException
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
+import pl.cuyer.rusthub.util.TopicSubscriber
 import pl.cuyer.rusthub.common.Result as DomainResult
 
 class SubscriptionSyncWorker(
@@ -19,7 +20,8 @@ class SubscriptionSyncWorker(
     params: WorkerParameters,
     private val repository: SubscriptionRepository,
     private val syncDataSource: SubscriptionSyncDataSource,
-    private val serverDataSource: ServerDataSource
+    private val serverDataSource: ServerDataSource,
+    private val topicSubscriber: TopicSubscriber
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result = coroutineScope {
@@ -37,6 +39,8 @@ class SubscriptionSyncWorker(
                         is DomainResult.Success -> {
                             serverDataSource.updateSubscription(operation.serverId, operation.isAdd)
                             syncDataSource.deleteOperation(operation.serverId)
+                            if (operation.isAdd) topicSubscriber.subscribe(operation.serverId.toString())
+                            else topicSubscriber.unsubscribe(operation.serverId.toString())
                             success = true
                         }
                         is DomainResult.Error -> {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ToggleSubscriptionUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ToggleSubscriptionUseCase.kt
@@ -12,12 +12,14 @@ import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSourc
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
+import pl.cuyer.rusthub.util.TopicSubscriber
 
 class ToggleSubscriptionUseCase(
     private val serverDataSource: ServerDataSource,
     private val repository: SubscriptionRepository,
     private val syncDataSource: SubscriptionSyncDataSource,
-    private val scheduler: SubscriptionSyncScheduler
+    private val scheduler: SubscriptionSyncScheduler,
+    private val topicSubscriber: TopicSubscriber
 ) {
     operator fun invoke(serverId: Long, add: Boolean): Flow<Result<Unit>> = channelFlow {
         val flow = if (add) repository.addSubscription(serverId) else repository.removeSubscription(serverId)
@@ -27,6 +29,8 @@ class ToggleSubscriptionUseCase(
                 is Result.Success -> {
                     serverDataSource.updateSubscription(serverId, add)
                     syncDataSource.deleteOperation(serverId)
+                    if (add) topicSubscriber.subscribe(serverId.toString())
+                    else topicSubscriber.unsubscribe(serverId.toString())
                     send(Result.Success(Unit))
                 }
                 is Result.Error -> {
@@ -41,6 +45,8 @@ class ToggleSubscriptionUseCase(
                                 )
                             )
                             scheduler.schedule(serverId)
+                            if (add) topicSubscriber.subscribe(serverId.toString())
+                            else topicSubscriber.unsubscribe(serverId.toString())
                             send(Result.Success(Unit))
                         }
                         else -> send(Result.Error(result.exception))

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -55,6 +55,7 @@ import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.util.validator.EmailValidator
 import pl.cuyer.rusthub.util.validator.PasswordValidator
 import pl.cuyer.rusthub.util.validator.UsernameValidator
+import pl.cuyer.rusthub.util.TopicSubscriber
 
 val appModule = module {
     single<SnackbarController> { SnackbarController }
@@ -97,7 +98,7 @@ val appModule = module {
     single { GetUserUseCase(get()) }
     single { LogoutUserUseCase(get()) }
     single { ToggleFavouriteUseCase(get(), get(), get(), get()) }
-    single { ToggleSubscriptionUseCase(get(), get(), get(), get()) }
+    single { ToggleSubscriptionUseCase(get(), get(), get(), get(), get()) }
 }
 
 expect val platformModule: Module

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.util
+
+expect class TopicSubscriber {
+    fun subscribe(topic: String)
+    fun unsubscribe(topic: String)
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -12,6 +12,7 @@ import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
+import pl.cuyer.rusthub.util.TopicSubscriber
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
@@ -19,6 +20,7 @@ actual val platformModule: Module = module {
     single { ClipboardHandler() }
     single { SyncScheduler() }
     single { SubscriptionSyncScheduler() }
+    single { TopicSubscriber() }
     factory { StartupViewModel(get()) }
     factory {
         OnboardingViewModel(

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.ios.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.util
+
+actual class TopicSubscriber {
+    actual fun subscribe(topic: String) { /* no-op */ }
+    actual fun unsubscribe(topic: String) { /* no-op */ }
+}


### PR DESCRIPTION
## Summary
- implement TopicSubscriber expect/actual class for Firebase topic subscription
- wire TopicSubscriber into Koin modules
- subscribe/unsubscribe from topics in ToggleSubscriptionUseCase and SubscriptionSyncWorker
- pass TopicSubscriber to worker factory and application

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c673de238832180b790b8cbdbb337