### PR TITLE
Add settings screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -43,18 +43,20 @@ import pl.cuyer.rusthub.android.feature.auth.RegisterScreen
 import pl.cuyer.rusthub.android.feature.onboarding.OnboardingScreen
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
+import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
-import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
+import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
 import pl.cuyer.rusthub.presentation.navigation.Login
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.Register
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.Settings
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 
@@ -87,7 +89,6 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
 
     val backStack = rememberNavBackStack(startDestination)
     val listDetailStrategy = rememberListDetailSceneStrategy<Any>()
-    val logoutUseCase = koinInject<LogoutUserUseCase>()
 
     LaunchedEffect(startDestination) {
         if (backStack.firstOrNull() != startDestination) {
@@ -182,6 +183,16 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                                 onNavigate = { dest -> backStack.add(dest) }
                             )
                         }
+                        entry<Settings> {
+                            val viewModel = koinViewModel<SettingsViewModel>()
+                            val state = viewModel.state.collectAsStateWithLifecycle()
+                            SettingsScreen(
+                                stateProvider = { state },
+                                uiEvent = viewModel.uiEvent,
+                                onAction = viewModel::onAction,
+                                onNavigate = { dest -> backStack.add(dest) }
+                            )
+                        }
                     },
                     sceneStrategy = listDetailStrategy
                 )
@@ -190,7 +201,7 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
     }
 
     val current = backStack.lastOrNull()
-    val showNav = current is ServerList || current is ServerDetails
+    val showNav = current is ServerList || current is ServerDetails || current is Settings
 
     if (showNav) {
         NavigationSuiteScaffold(
@@ -210,21 +221,14 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                     label = { Text("Servers") }
                 )
                 NavigationSuiteItem(
-                    selected = false,
+                    selected = current is Settings,
                     onClick = {
-                        scope.launch {
-                            logoutUseCase()
-                            backStack.clear()
-                            backStack.add(Onboarding)
+                        if (backStack.lastOrNull() !is Settings) {
+                            backStack.add(Settings)
                         }
                     },
-                    icon = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.Logout,
-                            contentDescription = "Log out"
-                        )
-                    },
-                    label = { Text("Log out") }
+                    icon = { Icon(Icons.Default.Settings, contentDescription = "Settings") },
+                    label = { Text("Settings") }
                 )
             },
             content = {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -1,0 +1,91 @@
+package pl.cuyer.rusthub.android.feature.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Logout
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppExposedDropdownMenu
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.features.settings.SettingsAction
+import pl.cuyer.rusthub.presentation.features.settings.SettingsState
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+@Composable
+fun SettingsScreen(
+    onNavigate: (NavKey) -> Unit,
+    uiEvent: Flow<UiEvent>,
+    stateProvider: () -> State<SettingsState>,
+    onAction: (SettingsAction) -> Unit
+) {
+    val state = stateProvider()
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(spacing.medium)
+    ) {
+        Text(
+            text = "General",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = spacing.small)
+        )
+        AppExposedDropdownMenu(
+            label = "Theme",
+            options = pl.cuyer.rusthub.domain.model.Theme.entries.map { it.displayName },
+            selectedValue = pl.cuyer.rusthub.domain.model.Theme.entries.indexOf(state.value.theme),
+            onSelectionChanged = { onAction(SettingsAction.OnThemeChange(pl.cuyer.rusthub.domain.model.Theme.entries[it])) }
+        )
+        AppExposedDropdownMenu(
+            label = "Language",
+            options = pl.cuyer.rusthub.domain.model.Language.entries.map { it.displayName },
+            selectedValue = pl.cuyer.rusthub.domain.model.Language.entries.indexOf(state.value.language),
+            onSelectionChanged = { onAction(SettingsAction.OnLanguageChange(pl.cuyer.rusthub.domain.model.Language.entries[it])) }
+        )
+        HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
+        Text(
+            text = "Account",
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(bottom = spacing.small)
+        )
+        AppButton(
+            modifier = Modifier.fillMaxWidth(),
+            onClick = { onAction(SettingsAction.OnLogout) },
+            icon = Icons.Default.Logout
+        ) { Text("Log out") }
+    }
+}
+
+@Preview
+@Composable
+private fun SettingsPreview() {
+    RustHubTheme {
+        SettingsScreen(
+            onNavigate = {},
+            uiEvent = MutableStateFlow(UiEvent.Navigate(Onboarding)),
+            stateProvider = { androidx.compose.runtime.mutableStateOf(SettingsState()) },
+            onAction = {}
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -12,6 +12,7 @@ import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
+import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
@@ -65,6 +66,13 @@ actual val platformModule: Module = module {
             saveSearchQueryUseCase = get(),
             getSearchQueriesUseCase = get(),
             deleteSearchQueriesUseCase = get()
+        )
+    }
+    viewModel {
+        SettingsViewModel(
+            getSettingsUseCase = get(),
+            saveSettingsUseCase = get(),
+            logoutUserUseCase = get()
         )
     }
     viewModel { (serverId: Long, serverName: String?) ->

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -11,6 +11,7 @@ import database.RemoteKeyEntity
 import database.SearchQueryEntity
 import database.ServerEntity
 import database.UserEntity
+import database.SettingsEntity
 import kotlinx.datetime.Instant
 import pl.cuyer.rusthub.data.local.model.DifficultyEntity
 import pl.cuyer.rusthub.data.local.model.FlagEntity
@@ -20,6 +21,8 @@ import pl.cuyer.rusthub.data.local.model.RegionEntity
 import pl.cuyer.rusthub.data.local.model.ServerStatusEntity
 import pl.cuyer.rusthub.data.local.model.WipeScheduleEntity
 import pl.cuyer.rusthub.data.local.model.WipeTypeEntity
+import pl.cuyer.rusthub.data.local.model.LanguageEntity
+import pl.cuyer.rusthub.data.local.model.ThemeEntity
 import pl.cuyer.rusthub.domain.model.Difficulty
 import pl.cuyer.rusthub.domain.model.FiltersOptions
 import pl.cuyer.rusthub.domain.model.Flag
@@ -34,6 +37,9 @@ import pl.cuyer.rusthub.domain.model.ServerStatus
 import pl.cuyer.rusthub.domain.model.User
 import pl.cuyer.rusthub.domain.model.WipeSchedule
 import pl.cuyer.rusthub.domain.model.WipeType
+import pl.cuyer.rusthub.domain.model.Language
+import pl.cuyer.rusthub.domain.model.Settings
+import pl.cuyer.rusthub.domain.model.Theme
 
 fun DifficultyEntity?.toDomain(): Difficulty? = this?.let { Difficulty.valueOf(it.name) }
 fun Difficulty?.toEntity(): DifficultyEntity? = this?.let { DifficultyEntity.valueOf(it.name) }
@@ -170,3 +176,16 @@ fun SearchQueryEntity.toDomain(): SearchQuery = SearchQuery(id, query, Instant.p
 
 fun UserEntity.toUser(): User = User(email, username, access_token, refresh_token)
 
+
+
+
+fun ThemeEntity?.toDomain(): Theme? = this?.let { Theme.valueOf(it.name) }
+fun Theme?.toEntity(): ThemeEntity? = this?.let { ThemeEntity.valueOf(it.name) }
+
+fun LanguageEntity?.toDomain(): Language? = this?.let { Language.valueOf(it.name) }
+fun Language?.toEntity(): LanguageEntity? = this?.let { LanguageEntity.valueOf(it.name) }
+
+fun SettingsEntity.toSettings(): Settings = Settings(
+    theme = theme.toDomain() ?: Theme.SYSTEM,
+    language = language.toDomain() ?: Language.ENGLISH
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/model/LanguageEntity.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/model/LanguageEntity.kt
@@ -1,0 +1,3 @@
+package pl.cuyer.rusthub.data.local.model
+
+enum class LanguageEntity { ENGLISH, POLISH }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/model/ThemeEntity.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/model/ThemeEntity.kt
@@ -1,0 +1,3 @@
+package pl.cuyer.rusthub.data.local.model
+
+enum class ThemeEntity { LIGHT, DARK, SYSTEM }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/settings/SettingsDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/settings/SettingsDataSourceImpl.kt
@@ -1,0 +1,38 @@
+package pl.cuyer.rusthub.data.local.settings
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import pl.cuyer.rusthub.common.Constants.DEFAULT_KEY
+import pl.cuyer.rusthub.data.local.Queries
+import pl.cuyer.rusthub.data.local.mapper.toSettings
+import pl.cuyer.rusthub.data.local.mapper.toEntity
+import pl.cuyer.rusthub.database.RustHubDatabase
+import pl.cuyer.rusthub.domain.model.Settings
+import pl.cuyer.rusthub.domain.repository.settings.SettingsDataSource
+
+class SettingsDataSourceImpl(
+    db: RustHubDatabase
+) : SettingsDataSource, Queries(db) {
+
+    override fun getSettings(): Flow<Settings?> {
+        return queries.getSettings(DEFAULT_KEY)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toSettings() }
+    }
+
+    override suspend fun upsertSettings(settings: Settings) {
+        withContext(Dispatchers.IO) {
+            queries.upsertSettings(
+                id = DEFAULT_KEY,
+                theme = settings.theme.toEntity(),
+                language = settings.language.toEntity()
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Language.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Language.kt
@@ -1,0 +1,17 @@
+package pl.cuyer.rusthub.domain.model
+
+enum class Language {
+    ENGLISH,
+    POLISH;
+
+    companion object {
+        fun fromDisplayName(name: String): Language? =
+            entries.firstOrNull { it.displayName == name }
+    }
+}
+
+val Language.displayName: String
+    get() = when (this) {
+        Language.ENGLISH -> "English"
+        Language.POLISH -> "Polish"
+    }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Settings.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Settings.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.domain.model
+
+data class Settings(
+    val theme: Theme,
+    val language: Language
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Theme.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Theme.kt
@@ -1,0 +1,19 @@
+package pl.cuyer.rusthub.domain.model
+
+enum class Theme {
+    LIGHT,
+    DARK,
+    SYSTEM;
+
+    companion object {
+        fun fromDisplayName(name: String): Theme? =
+            entries.firstOrNull { it.displayName == name }
+    }
+}
+
+val Theme.displayName: String
+    get() = when (this) {
+        Theme.LIGHT -> "Light"
+        Theme.DARK -> "Dark"
+        Theme.SYSTEM -> "System"
+    }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/settings/SettingsDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/settings/SettingsDataSource.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.domain.repository.settings
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.domain.model.Settings
+
+interface SettingsDataSource {
+    fun getSettings(): Flow<Settings?>
+    suspend fun upsertSettings(settings: Settings)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetSettingsUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetSettingsUseCase.kt
@@ -1,0 +1,13 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.domain.model.Settings
+import pl.cuyer.rusthub.domain.repository.settings.SettingsDataSource
+
+class GetSettingsUseCase(
+    private val dataSource: SettingsDataSource
+) {
+    operator fun invoke(): Flow<Settings?> {
+        return dataSource.getSettings()
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/SaveSettingsUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/SaveSettingsUseCase.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import pl.cuyer.rusthub.domain.model.Settings
+import pl.cuyer.rusthub.domain.repository.settings.SettingsDataSource
+
+class SaveSettingsUseCase(
+    private val dataSource: SettingsDataSource
+) {
+    suspend operator fun invoke(settings: Settings) {
+        dataSource.upsertSettings(settings)
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -17,6 +17,7 @@ import pl.cuyer.rusthub.data.local.search.SearchQueryDataSourceImpl
 import pl.cuyer.rusthub.data.local.server.ServerDataSourceImpl
 import pl.cuyer.rusthub.data.local.favourite.FavouriteSyncDataSourceImpl
 import pl.cuyer.rusthub.data.local.subscription.SubscriptionSyncDataSourceImpl
+import pl.cuyer.rusthub.data.local.settings.SettingsDataSourceImpl
 import pl.cuyer.rusthub.data.network.auth.AuthRepositoryImpl
 import pl.cuyer.rusthub.data.network.filtersOptions.FiltersOptionsClientImpl
 import pl.cuyer.rusthub.data.network.favourite.FavouriteClientImpl
@@ -35,6 +36,7 @@ import pl.cuyer.rusthub.domain.repository.favourite.FavouriteSyncDataSource
 import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
+import pl.cuyer.rusthub.domain.repository.settings.SettingsDataSource
 import pl.cuyer.rusthub.domain.usecase.AuthAnonymouslyUseCase
 import pl.cuyer.rusthub.domain.usecase.ClearFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteSearchQueriesUseCase
@@ -46,6 +48,8 @@ import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
+import pl.cuyer.rusthub.domain.usecase.GetSettingsUseCase
+import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleFavouriteUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleSubscriptionUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
@@ -75,6 +79,7 @@ val appModule = module {
     singleOf(::FiltersDataSourceImpl) bind FiltersDataSource::class
     singleOf(::SearchQueryDataSourceImpl) bind SearchQueryDataSource::class
     singleOf(::RemoteKeyDataSourceImpl) bind RemoteKeyDataSource::class
+    singleOf(::SettingsDataSourceImpl) bind SettingsDataSource::class
     single { GetPagedServersUseCase(get(), get(), get(), get()) }
     singleOf(::FiltersOptionsClientImpl) bind FiltersOptionsRepository::class
     singleOf(::FiltersOptionsDataSourceImpl) bind FiltersOptionsDataSource::class
@@ -97,6 +102,8 @@ val appModule = module {
     single { AuthAnonymouslyUseCase(get(), get()) }
     single { GetUserUseCase(get()) }
     single { LogoutUserUseCase(get()) }
+    single { GetSettingsUseCase(get()) }
+    single { SaveSettingsUseCase(get()) }
     single { ToggleFavouriteUseCase(get(), get(), get(), get()) }
     single { ToggleSubscriptionUseCase(get(), get(), get(), get(), get()) }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.rusthub.presentation.features.settings
+
+import pl.cuyer.rusthub.domain.model.Language
+import pl.cuyer.rusthub.domain.model.Theme
+
+sealed interface SettingsAction {
+    data class OnThemeChange(val theme: Theme) : SettingsAction
+    data class OnLanguageChange(val language: Language) : SettingsAction
+    data object OnLogout : SettingsAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.presentation.features.settings
+
+import pl.cuyer.rusthub.domain.model.Language
+import pl.cuyer.rusthub.domain.model.Theme
+
+data class SettingsState(
+    val theme: Theme = Theme.SYSTEM,
+    val language: Language = Language.ENGLISH
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -1,0 +1,76 @@
+package pl.cuyer.rusthub.presentation.features.settings
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.domain.model.Settings
+import pl.cuyer.rusthub.domain.usecase.GetSettingsUseCase
+import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
+import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
+import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+class SettingsViewModel(
+    private val getSettingsUseCase: GetSettingsUseCase,
+    private val saveSettingsUseCase: SaveSettingsUseCase,
+    private val logoutUserUseCase: LogoutUserUseCase
+) : BaseViewModel() {
+
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(SettingsState())
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = SettingsState()
+    )
+
+    init {
+        coroutineScope.launch {
+            getSettingsUseCase().collect { settings ->
+                settings?.let { updateFromSettings(it) }
+            }
+        }
+    }
+
+    fun onAction(action: SettingsAction) {
+        when (action) {
+            is SettingsAction.OnThemeChange -> updateTheme(action.theme)
+            is SettingsAction.OnLanguageChange -> updateLanguage(action.language)
+            SettingsAction.OnLogout -> logout()
+        }
+    }
+
+    private fun updateTheme(theme: pl.cuyer.rusthub.domain.model.Theme) {
+        _state.update { it.copy(theme = theme) }
+        save()
+    }
+
+    private fun updateLanguage(language: pl.cuyer.rusthub.domain.model.Language) {
+        _state.update { it.copy(language = language) }
+        save()
+    }
+
+    private fun save() {
+        val settings = Settings(_state.value.theme, _state.value.language)
+        coroutineScope.launch { saveSettingsUseCase(settings) }
+    }
+
+    private fun updateFromSettings(settings: Settings) {
+        _state.update { it.copy(theme = settings.theme, language = settings.language) }
+    }
+
+    private fun logout() {
+        coroutineScope.launch {
+            logoutUserUseCase()
+            _uiEvent.send(UiEvent.Navigate(Onboarding))
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -16,6 +16,9 @@ data object Register : NavKey
 data object ServerList : NavKey
 
 @Serializable
+data object Settings : NavKey
+
+@Serializable
 data class ServerDetails(
     val id: Long,
     val name: String

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -6,6 +6,8 @@ import pl.cuyer.rusthub.data.local.model.WipeScheduleEntity;
 import pl.cuyer.rusthub.data.local.model.OrderEntity;
 import pl.cuyer.rusthub.data.local.model.ServerStatusEntity;
 import pl.cuyer.rusthub.data.local.model.WipeTypeEntity;
+import pl.cuyer.rusthub.data.local.model.ThemeEntity;
+import pl.cuyer.rusthub.data.local.model.LanguageEntity;
 
 -- =============================================================================
 -- Table Definition
@@ -545,3 +547,19 @@ DELETE FROM userEntity;
 
 getUser:
 SELECT * FROM userEntity LIMIT 1;
+
+CREATE TABLE settingsEntity (
+    id TEXT NOT NULL PRIMARY KEY,
+    theme TEXT AS ThemeEntity NOT NULL,
+    language TEXT AS LanguageEntity NOT NULL
+);
+
+upsertSettings:
+INSERT INTO settingsEntity (id, theme, language)
+VALUES (:id, :theme, :language)
+ON CONFLICT(id) DO UPDATE SET
+    theme = excluded.theme,
+    language = excluded.language;
+
+getSettings:
+SELECT * FROM settingsEntity WHERE id = ?;

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -9,6 +9,7 @@ import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
+import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
@@ -43,6 +44,13 @@ actual val platformModule: Module = module {
             emailValidator = get(),
             passwordValidator = get(),
             usernameValidator = get()
+        )
+    }
+    factory {
+        SettingsViewModel(
+            getSettingsUseCase = get(),
+            saveSettingsUseCase = get(),
+            logoutUserUseCase = get()
         )
     }
 }


### PR DESCRIPTION
## Summary
- add Settings enum model and entity
- persist user settings in DB
- hook settings data source and use cases to DI
- implement SettingsViewModel with state/actions
- build SettingsScreen UI in Compose
- register Settings screen in navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d101317c4832192ccc1328406d720