### PR TITLE
Add username greeting on settings screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -122,6 +122,7 @@ private fun SettingsScreenCompact(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(spacing.medium)
     ) {
+        GreetingSection(state.username)
         PreferencesSection(state, onAction)
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
         AccountSection(onAction)
@@ -146,6 +147,7 @@ private fun SettingsScreenExpanded(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(spacing.medium)
         ) {
+            GreetingSection(state.username)
             PreferencesSection(state, onAction)
             HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
             AccountSection(onAction)
@@ -302,6 +304,17 @@ private fun OtherSection() {
         text = "App version: 1.0",
         textAlign = TextAlign.Center
     )
+}
+
+@Composable
+private fun GreetingSection(username: String?) {
+    if (username != null) {
+        Text(
+            text = "Hello $username!",
+            style = MaterialTheme.typography.headlineSmall,
+            modifier = Modifier.padding(bottom = spacing.medium)
+        )
+    }
 }
 
 @Preview

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -72,7 +72,8 @@ actual val platformModule: Module = module {
         SettingsViewModel(
             getSettingsUseCase = get(),
             saveSettingsUseCase = get(),
-            logoutUserUseCase = get()
+            logoutUserUseCase = get(),
+            getUserUseCase = get()
         )
     }
     viewModel { (serverId: Long, serverName: String?) ->

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
@@ -5,5 +5,6 @@ import pl.cuyer.rusthub.domain.model.Theme
 
 data class SettingsState(
     val theme: Theme = Theme.SYSTEM,
-    val language: Language = Language.ENGLISH
+    val language: Language = Language.ENGLISH,
+    val username: String? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -15,13 +15,15 @@ import pl.cuyer.rusthub.domain.model.Theme
 import pl.cuyer.rusthub.domain.usecase.GetSettingsUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
+import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
 class SettingsViewModel(
     private val getSettingsUseCase: GetSettingsUseCase,
     private val saveSettingsUseCase: SaveSettingsUseCase,
-    private val logoutUserUseCase: LogoutUserUseCase
+    private val logoutUserUseCase: LogoutUserUseCase,
+    private val getUserUseCase: GetUserUseCase
 ) : BaseViewModel() {
 
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
@@ -38,6 +40,11 @@ class SettingsViewModel(
         coroutineScope.launch {
             getSettingsUseCase().collect { settings ->
                 settings?.let { updateFromSettings(it) }
+            }
+        }
+        coroutineScope.launch {
+            getUserUseCase().collect { user ->
+                _state.update { it.copy(username = user?.username) }
             }
         }
     }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -50,7 +50,8 @@ actual val platformModule: Module = module {
         SettingsViewModel(
             getSettingsUseCase = get(),
             saveSettingsUseCase = get(),
-            logoutUserUseCase = get()
+            logoutUserUseCase = get(),
+            getUserUseCase = get()
         )
     }
 }


### PR DESCRIPTION
## Summary
- greet the logged in user on the settings screen
- expose `username` from `SettingsState` via `SettingsViewModel`
- provide `GetUserUseCase` to `SettingsViewModel` through Koin

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dcba7603c832194f9d774d4e32d87