### PR TITLE
Add notification settings action

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -195,7 +195,7 @@ private fun PreferencesSection(
         onSelectionChanged = { onAction(SettingsAction.OnLanguageChange(Language.entries[it])) }
     )
     AppTextButton(
-        onClick = {}
+        onClick = { onAction(SettingsAction.OnNotificationsClick) }
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -73,7 +73,8 @@ actual val platformModule: Module = module {
             getSettingsUseCase = get(),
             saveSettingsUseCase = get(),
             logoutUserUseCase = get(),
-            getUserUseCase = get()
+            getUserUseCase = get(),
+            permissionsController = get()
         )
     }
     viewModel { (serverId: Long, serverName: String?) ->

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -6,5 +6,6 @@ import pl.cuyer.rusthub.domain.model.Theme
 sealed interface SettingsAction {
     data class OnThemeChange(val theme: Theme) : SettingsAction
     data class OnLanguageChange(val language: Language) : SettingsAction
+    data object OnNotificationsClick : SettingsAction
     data object OnLogout : SettingsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -24,12 +24,14 @@ import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import dev.icerock.moko.permissions.PermissionsController
 
 class SettingsViewModel(
     private val getSettingsUseCase: GetSettingsUseCase,
     private val saveSettingsUseCase: SaveSettingsUseCase,
     private val logoutUserUseCase: LogoutUserUseCase,
-    private val getUserUseCase: GetUserUseCase
+    private val getUserUseCase: GetUserUseCase,
+    private val permissionsController: PermissionsController
 ) : BaseViewModel() {
 
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
@@ -59,6 +61,7 @@ class SettingsViewModel(
         when (action) {
             is SettingsAction.OnThemeChange -> updateTheme(action.theme)
             is SettingsAction.OnLanguageChange -> updateLanguage(action.language)
+            SettingsAction.OnNotificationsClick -> permissionsController.openAppSettings()
             SettingsAction.OnLogout -> logout()
         }
     }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -14,6 +14,7 @@ import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 import pl.cuyer.rusthub.util.TopicSubscriber
+import dev.icerock.moko.permissions.PermissionsController
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
@@ -22,6 +23,7 @@ actual val platformModule: Module = module {
     single { SyncScheduler() }
     single { SubscriptionSyncScheduler() }
     single { TopicSubscriber() }
+    single { PermissionsController() }
     factory { StartupViewModel(get()) }
     factory {
         OnboardingViewModel(
@@ -51,7 +53,8 @@ actual val platformModule: Module = module {
             getSettingsUseCase = get(),
             saveSettingsUseCase = get(),
             logoutUserUseCase = get(),
-            getUserUseCase = get()
+            getUserUseCase = get(),
+            permissionsController = get()
         )
     }
 }


### PR DESCRIPTION
## Summary
- handle notification settings click in SettingsViewModel
- inject PermissionsController for SettingsViewModel on Android and iOS
- wire up Notifications button in SettingsScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f020d20708321a86a13e61c4e516f