### PR TITLE
Implement Privacy Policy WebView

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -44,6 +44,7 @@ import pl.cuyer.rusthub.android.feature.onboarding.OnboardingScreen
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
 import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
+import pl.cuyer.rusthub.android.feature.settings.PrivacyPolicyScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
@@ -57,6 +58,8 @@ import pl.cuyer.rusthub.presentation.navigation.Register
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings
+import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
+import pl.cuyer.rusthub.common.Constants
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 
@@ -191,6 +194,12 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                                 uiEvent = viewModel.uiEvent,
                                 onAction = viewModel::onAction,
                                 onNavigate = { dest -> backStack.add(dest) }
+                            )
+                        }
+                        entry<PrivacyPolicy> {
+                            PrivacyPolicyScreen(
+                                url = Constants.PRIVACY_POLICY_URL,
+                                onNavigateUp = { backStack.removeLastOrNull() }
                             )
                         }
                     },

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/PrivacyPolicyScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/PrivacyPolicyScreen.kt
@@ -1,0 +1,48 @@
+package pl.cuyer.rusthub.android.feature.settings
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PrivacyPolicyScreen(url: String, onNavigateUp: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Privacy policy") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Navigate up")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        AndroidView(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            factory = { context ->
+                WebView(context).apply {
+                    webViewClient = WebViewClient()
+                    loadUrl(url)
+                }
+            },
+            update = { it.loadUrl(url) }
+        )
+    }
+}
+

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -133,7 +133,7 @@ private fun SettingsScreenCompact(
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
         AccountSection(onAction)
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
-        OtherSection()
+        OtherSection(onAction)
     }
 }
 
@@ -166,7 +166,7 @@ private fun SettingsScreenExpanded(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(spacing.medium)
         ) {
-            OtherSection()
+            OtherSection(onAction)
         }
     }
 }
@@ -269,7 +269,7 @@ private fun AccountSection(onAction: (SettingsAction) -> Unit) {
 }
 
 @Composable
-private fun OtherSection() {
+private fun OtherSection(onAction: (SettingsAction) -> Unit) {
     Text(
         text = "Other",
         style = MaterialTheme.typography.titleLarge,
@@ -277,7 +277,7 @@ private fun OtherSection() {
     )
 
     AppTextButton(
-        onClick = { }
+        onClick = { onAction(SettingsAction.OnPrivacyPolicy) }
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/common/Constants.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/common/Constants.kt
@@ -3,4 +3,5 @@ package pl.cuyer.rusthub.common
 object Constants {
     const val DEFAULT_KEY = "default"
     const val SERVERS_VALIDITY_TIMEOUT = 1 //hours
+    const val PRIVACY_POLICY_URL = "https://github.com/Cuyer/RustHub_KMM/blob/main/PRIVACY_POLICY.md"
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -7,4 +7,5 @@ sealed interface SettingsAction {
     data class OnThemeChange(val theme: Theme) : SettingsAction
     data class OnLanguageChange(val language: Language) : SettingsAction
     data object OnLogout : SettingsAction
+    data object OnPrivacyPolicy : SettingsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -23,6 +23,7 @@ import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
 class SettingsViewModel(
@@ -60,6 +61,7 @@ class SettingsViewModel(
             is SettingsAction.OnThemeChange -> updateTheme(action.theme)
             is SettingsAction.OnLanguageChange -> updateLanguage(action.language)
             SettingsAction.OnLogout -> logout()
+            SettingsAction.OnPrivacyPolicy -> openPrivacyPolicy()
         }
     }
 
@@ -105,6 +107,12 @@ class SettingsViewModel(
         coroutineScope.launch {
             logoutUserUseCase()
             _uiEvent.send(UiEvent.Navigate(Onboarding))
+        }
+    }
+
+    private fun openPrivacyPolicy() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(PrivacyPolicy))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -23,3 +23,6 @@ data class ServerDetails(
     val id: Long,
     val name: String
 ) : NavKey
+
+@Serializable
+data object PrivacyPolicy : NavKey


### PR DESCRIPTION
## Summary
- add a constant with the privacy policy URL
- add `PrivacyPolicy` destination
- support `OnPrivacyPolicy` action and navigation
- show a PrivacyPolicyScreen that loads the URL in a WebView
- wire the button in SettingsScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f02c078d48321b17f66443d7b1c71