### PR TITLE
Add subscription dialog to settings

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import pl.cuyer.rusthub.android.designsystem.AppButton
 import pl.cuyer.rusthub.android.designsystem.AppExposedDropdownMenu
 import pl.cuyer.rusthub.android.designsystem.AppTextButton
+import pl.cuyer.rusthub.android.designsystem.SubscriptionDialog
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
@@ -89,6 +90,11 @@ fun SettingsScreen(
             )
         }
     ) { innerPadding ->
+        SubscriptionDialog(
+            showDialog = state.value.showSubscriptionDialog,
+            onConfirm = { onAction(SettingsAction.OnSubscribe) },
+            onDismiss = { onAction(SettingsAction.OnDismissSubscriptionDialog) }
+        )
         if (isTabletMode) {
             SettingsScreenExpanded(
                 modifier = Modifier
@@ -238,7 +244,7 @@ private fun AccountSection(onAction: (SettingsAction) -> Unit) {
     }
 
     AppTextButton(
-        onClick = { }
+        onClick = { onAction(SettingsAction.OnSubscriptionClick) }
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -7,4 +7,7 @@ sealed interface SettingsAction {
     data class OnThemeChange(val theme: Theme) : SettingsAction
     data class OnLanguageChange(val language: Language) : SettingsAction
     data object OnLogout : SettingsAction
+    data object OnSubscriptionClick : SettingsAction
+    data object OnDismissSubscriptionDialog : SettingsAction
+    data object OnSubscribe : SettingsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
@@ -6,5 +6,6 @@ import pl.cuyer.rusthub.domain.model.Theme
 data class SettingsState(
     val theme: Theme = Theme.SYSTEM,
     val language: Language = Language.ENGLISH,
-    val username: String? = null
+    val username: String? = null,
+    val showSubscriptionDialog: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -60,6 +60,9 @@ class SettingsViewModel(
             is SettingsAction.OnThemeChange -> updateTheme(action.theme)
             is SettingsAction.OnLanguageChange -> updateLanguage(action.language)
             SettingsAction.OnLogout -> logout()
+            SettingsAction.OnSubscriptionClick -> showSubscriptionDialog(true)
+            SettingsAction.OnDismissSubscriptionDialog -> showSubscriptionDialog(false)
+            SettingsAction.OnSubscribe -> showSubscriptionDialog(false)
         }
     }
 
@@ -105,6 +108,14 @@ class SettingsViewModel(
         coroutineScope.launch {
             logoutUserUseCase()
             _uiEvent.send(UiEvent.Navigate(Onboarding))
+        }
+    }
+
+    private fun showSubscriptionDialog(show: Boolean) {
+        _state.update {
+            it.copy(
+                showSubscriptionDialog = show
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle subscription actions in `SettingsViewModel`
- expose subscription dialog state
- show dialog in `SettingsScreen`
- wire up Subscription button click

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :shared:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f032220fc8321ad9615cf0cf8f64a