### PR TITLE
Add change password stub

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -44,6 +44,7 @@ import pl.cuyer.rusthub.android.feature.onboarding.OnboardingScreen
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
 import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
+import pl.cuyer.rusthub.android.feature.settings.ChangePasswordScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
 import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
@@ -57,6 +58,7 @@ import pl.cuyer.rusthub.presentation.navigation.Register
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings
+import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 
@@ -192,6 +194,9 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                                 onAction = viewModel::onAction,
                                 onNavigate = { dest -> backStack.add(dest) }
                             )
+                        }
+                        entry<ChangePassword> {
+                            ChangePasswordScreen(onNavigateUp = { backStack.removeLastOrNull() })
                         }
                     },
                     sceneStrategy = listDetailStrategy

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/ChangePasswordScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/ChangePasswordScreen.kt
@@ -1,0 +1,40 @@
+package pl.cuyer.rusthub.android.feature.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ChangePasswordScreen(onNavigateUp: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Change password") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Feature coming soon")
+        }
+    }
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -221,7 +221,7 @@ private fun AccountSection(onAction: (SettingsAction) -> Unit) {
     )
 
     AppTextButton(
-        onClick = { }
+        onClick = { onAction(SettingsAction.OnChangePasswordClick) }
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -6,5 +6,6 @@ import pl.cuyer.rusthub.domain.model.Theme
 sealed interface SettingsAction {
     data class OnThemeChange(val theme: Theme) : SettingsAction
     data class OnLanguageChange(val language: Language) : SettingsAction
+    data object OnChangePasswordClick : SettingsAction
     data object OnLogout : SettingsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -23,6 +23,7 @@ import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
 class SettingsViewModel(
@@ -59,6 +60,7 @@ class SettingsViewModel(
         when (action) {
             is SettingsAction.OnThemeChange -> updateTheme(action.theme)
             is SettingsAction.OnLanguageChange -> updateLanguage(action.language)
+            SettingsAction.OnChangePasswordClick -> navigateChangePassword()
             SettingsAction.OnLogout -> logout()
         }
     }
@@ -71,6 +73,12 @@ class SettingsViewModel(
     private fun updateLanguage(language: Language) {
         _state.update { it.copy(language = language) }
         save()
+    }
+
+    private fun navigateChangePassword() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(ChangePassword))
+        }
     }
 
     private fun observeSettings() {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -19,6 +19,9 @@ data object ServerList : NavKey
 data object Settings : NavKey
 
 @Serializable
+data object ChangePassword : NavKey
+
+@Serializable
 data class ServerDetails(
     val id: Long,
     val name: String


### PR DESCRIPTION
## Summary
- enable navigation from Settings to a new Change Password screen
- stub out ChangePasswordScreen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f03558db48321964954a3aa6878db