### PR TITLE
Add rate app store navigation

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -42,6 +42,7 @@ import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
+import org.koin.compose.koinInject
 import pl.cuyer.rusthub.domain.model.Language
 import pl.cuyer.rusthub.domain.model.Theme
 import pl.cuyer.rusthub.domain.model.displayName
@@ -49,6 +50,7 @@ import pl.cuyer.rusthub.presentation.features.settings.SettingsAction
 import pl.cuyer.rusthub.presentation.features.settings.SettingsState
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.util.StoreNavigator
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
@@ -270,6 +272,7 @@ private fun AccountSection(onAction: (SettingsAction) -> Unit) {
 
 @Composable
 private fun OtherSection() {
+    val storeNavigator = koinInject<StoreNavigator>()
     Text(
         text = "Other",
         style = MaterialTheme.typography.titleLarge,
@@ -294,7 +297,7 @@ private fun OtherSection() {
     }
 
     AppTextButton(
-        onClick = { }
+        onClick = { storeNavigator.openStore() }
     ) {
         Row(
             modifier = Modifier

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -18,6 +18,7 @@ import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 import pl.cuyer.rusthub.util.TopicSubscriber
+import pl.cuyer.rusthub.util.StoreNavigator
 import dev.icerock.moko.permissions.PermissionsController
 
 actual val platformModule: Module = module {
@@ -27,6 +28,7 @@ actual val platformModule: Module = module {
     single { SyncScheduler(get()) }
     single { SubscriptionSyncScheduler(get()) }
     single { TopicSubscriber() }
+    single { StoreNavigator(androidContext()) }
     single { PermissionsController(androidContext()) }
     viewModel {
         StartupViewModel(get(), get())

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/StoreNavigator.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/StoreNavigator.android.kt
@@ -1,0 +1,23 @@
+package pl.cuyer.rusthub.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+actual class StoreNavigator(private val context: Context) {
+    actual fun openStore() {
+        val uri = Uri.parse("market://details?id=${context.packageName}")
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        try {
+            context.startActivity(intent)
+        } catch (_: Exception) {
+            val webIntent = Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse("https://play.google.com/store/apps/details?id=${context.packageName}")
+            ).apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+            context.startActivity(webIntent)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/StoreNavigator.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/StoreNavigator.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+expect class StoreNavigator {
+    fun openStore()
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -14,6 +14,7 @@ import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 import pl.cuyer.rusthub.util.TopicSubscriber
+import pl.cuyer.rusthub.util.StoreNavigator
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
@@ -22,6 +23,7 @@ actual val platformModule: Module = module {
     single { SyncScheduler() }
     single { SubscriptionSyncScheduler() }
     single { TopicSubscriber() }
+    single { StoreNavigator() }
     factory { StartupViewModel(get()) }
     factory {
         OnboardingViewModel(

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/StoreNavigator.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/StoreNavigator.ios.kt
@@ -1,0 +1,15 @@
+package pl.cuyer.rusthub.util
+
+import platform.Foundation.NSBundle
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+
+actual class StoreNavigator {
+    actual fun openStore() {
+        val bundleId = NSBundle.mainBundle.bundleIdentifier ?: return
+        val url = NSURL.URLWithString("itms-apps://itunes.apple.com/app/" + bundleId)
+        if (url != null) {
+            UIApplication.sharedApplication.openURL(url)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add StoreNavigator expect class with Android/iOS implementations
- register StoreNavigator via Koin modules
- inject navigator in SettingsScreen and open store when tapping *Rate application*

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f031025188321ba3711b696467ab4