### PR TITLE
Add FCM token management

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ koin = "4.0.2"
 ktor = "3.2.0"
 sql-delight-version = "2.1.0"
 coroutines-core = "1.10.2"
+coroutines-play-services = "1.10.2"
 datetime = "0.6.2"
 napier = "2.7.1"
 splash-screen = "1.2.0-beta02"
@@ -81,6 +82,7 @@ firebase-performance = { module = "com.google.firebase:firebase-perf" }
 #KOTLIN
 kotlin-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 kotlin-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines-core" }
+kotlin-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "coroutines-play-services" }
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 #ADAPTIVE LAYOUT

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
             implementation(libs.ktor.client.okhttp)
             implementation(project.dependencies.platform(libs.firebase.bom))
             implementation(libs.firebase.messaging)
+            implementation(libs.kotlin.coroutines.play.services)
         }
         commonMain.dependencies {
             implementation(project.dependencies.platform(libs.koin.bom))

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/notification/RustHubFirebaseMessagingService.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/notification/RustHubFirebaseMessagingService.kt
@@ -2,10 +2,17 @@ package pl.cuyer.rusthub.notification
 
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.domain.model.NotificationType
 import pl.cuyer.rusthub.util.NotificationPresenter
+import pl.cuyer.rusthub.util.MessagingTokenManager
+import org.koin.android.ext.android.inject
 
 class RustHubFirebaseMessagingService : FirebaseMessagingService() {
+    private val tokenManager by inject<MessagingTokenManager>()
+
     override fun onMessageReceived(message: RemoteMessage) {
         val type = message.data["type"]?.let { value ->
             runCatching { NotificationType.valueOf(value) }.getOrNull()
@@ -17,5 +24,8 @@ class RustHubFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
+        CoroutineScope(Dispatchers.Default).launch {
+            tokenManager.currentToken()
+        }
     }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -17,8 +17,8 @@ import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
-import pl.cuyer.rusthub.util.TopicSubscriber
 import pl.cuyer.rusthub.util.StoreNavigator
+import pl.cuyer.rusthub.util.MessagingTokenScheduler
 import dev.icerock.moko.permissions.PermissionsController
 
 actual val platformModule: Module = module {
@@ -27,7 +27,7 @@ actual val platformModule: Module = module {
     single { ClipboardHandler(get()) }
     single { SyncScheduler(get()) }
     single { SubscriptionSyncScheduler(get()) }
-    single { TopicSubscriber() }
+    single { MessagingTokenScheduler(get()) }
     single { StoreNavigator(androidContext()) }
     single { PermissionsController(androidContext()) }
     viewModel {

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
@@ -10,8 +10,8 @@ import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
+import pl.cuyer.rusthub.util.MessagingTokenManager
 import pl.cuyer.rusthub.work.CustomWorkerFactory
-import pl.cuyer.rusthub.util.TopicSubscriber
 
 class RustHubApplication : Application(), Configuration.Provider {
 
@@ -20,7 +20,7 @@ class RustHubApplication : Application(), Configuration.Provider {
     val subscriptionRepository by inject<SubscriptionRepository>()
     val subscriptionSyncDataSource by inject<SubscriptionSyncDataSource>()
     val serverDataSource by inject<ServerDataSource>()
-    val topicSubscriber by inject<TopicSubscriber>()
+    val tokenManager by inject<MessagingTokenManager>()
 
     override fun onCreate() {
         super.onCreate()
@@ -40,9 +40,8 @@ class RustHubApplication : Application(), Configuration.Provider {
                     subscriptionRepository = subscriptionRepository,
                     subscriptionSyncDataSource = subscriptionSyncDataSource,
                     serverDataSource = serverDataSource,
-                    topicSubscriber = topicSubscriber
+                    tokenManager = tokenManager
                 )
             )
             .build()
-
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
@@ -1,0 +1,26 @@
+package pl.cuyer.rusthub.util
+
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.tasks.await
+import kotlinx.datetime.Clock
+import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
+
+actual class MessagingTokenManager(
+    private val repository: MessagingTokenRepository,
+    private val scheduler: MessagingTokenScheduler
+) {
+    actual suspend fun currentToken(): String? {
+        val token = runCatching { FirebaseMessaging.getInstance().token.await() }.getOrNull()
+        token?.let {
+            repository.registerToken(it, Clock.System.now())
+            scheduler.schedule()
+        }
+        return token
+    }
+
+    actual suspend fun deleteToken() {
+        val token = runCatching { FirebaseMessaging.getInstance().token.await() }.getOrNull()
+        token?.let { repository.deleteToken(it) }
+        runCatching { FirebaseMessaging.getInstance().deleteToken().await() }
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.android.kt
@@ -1,0 +1,27 @@
+package pl.cuyer.rusthub.util
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import pl.cuyer.rusthub.work.TokenRefreshWorker
+import java.util.concurrent.TimeUnit
+
+actual class MessagingTokenScheduler(private val context: Context) {
+    actual fun schedule() {
+        val request = PeriodicWorkRequestBuilder<TokenRefreshWorker>(30, TimeUnit.DAYS)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+            )
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            "token_refresh",
+            ExistingPeriodicWorkPolicy.KEEP,
+            request
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/TopicSubscriber.android.kt
@@ -1,13 +1,7 @@
 package pl.cuyer.rusthub.util
 
-import com.google.firebase.messaging.FirebaseMessaging
-
 actual class TopicSubscriber {
-    actual fun subscribe(topic: String) {
-        FirebaseMessaging.getInstance().subscribeToTopic(topic)
-    }
+    actual fun subscribe(topic: String) { /* no-op */ }
 
-    actual fun unsubscribe(topic: String) {
-        FirebaseMessaging.getInstance().unsubscribeFromTopic(topic)
-    }
+    actual fun unsubscribe(topic: String) { /* no-op */ }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/CustomWorkerFactory.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/CustomWorkerFactory.kt
@@ -9,7 +9,7 @@ import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
-import pl.cuyer.rusthub.util.TopicSubscriber
+import pl.cuyer.rusthub.util.MessagingTokenManager
 
 class CustomWorkerFactory(
     private val favouriteRepository: FavouriteRepository,
@@ -17,7 +17,7 @@ class CustomWorkerFactory(
     private val subscriptionRepository: SubscriptionRepository,
     private val subscriptionSyncDataSource: SubscriptionSyncDataSource,
     private val serverDataSource: ServerDataSource,
-    private val topicSubscriber: TopicSubscriber
+    private val tokenManager: MessagingTokenManager
 ) : WorkerFactory() {
 
     override fun createWorker(
@@ -41,11 +41,12 @@ class CustomWorkerFactory(
                     workerParameters,
                     subscriptionRepository,
                     subscriptionSyncDataSource,
-                    serverDataSource,
-                    topicSubscriber
+                    serverDataSource
                 )
             }
-
+            TokenRefreshWorker::class.qualifiedName -> {
+                TokenRefreshWorker(appContext, workerParameters, tokenManager)
+            }
             else -> null
         }
     }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/SubscriptionSyncWorker.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/SubscriptionSyncWorker.kt
@@ -12,7 +12,6 @@ import pl.cuyer.rusthub.domain.exception.SubscriptionLimitException
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
-import pl.cuyer.rusthub.util.TopicSubscriber
 import pl.cuyer.rusthub.common.Result as DomainResult
 
 class SubscriptionSyncWorker(
@@ -20,8 +19,7 @@ class SubscriptionSyncWorker(
     params: WorkerParameters,
     private val repository: SubscriptionRepository,
     private val syncDataSource: SubscriptionSyncDataSource,
-    private val serverDataSource: ServerDataSource,
-    private val topicSubscriber: TopicSubscriber
+    private val serverDataSource: ServerDataSource
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result = coroutineScope {
@@ -39,8 +37,6 @@ class SubscriptionSyncWorker(
                         is DomainResult.Success -> {
                             serverDataSource.updateSubscription(operation.serverId, operation.isAdd)
                             syncDataSource.deleteOperation(operation.serverId)
-                            if (operation.isAdd) topicSubscriber.subscribe(operation.serverId.toString())
-                            else topicSubscriber.unsubscribe(operation.serverId.toString())
                             success = true
                         }
                         is DomainResult.Error -> {

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/TokenRefreshWorker.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/TokenRefreshWorker.kt
@@ -1,0 +1,17 @@
+package pl.cuyer.rusthub.work
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import pl.cuyer.rusthub.util.MessagingTokenManager
+
+class TokenRefreshWorker(
+    appContext: Context,
+    params: WorkerParameters,
+    private val tokenManager: MessagingTokenManager
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        tokenManager.currentToken()
+        return Result.success()
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/notification/MessagingTokenClientImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/notification/MessagingTokenClientImpl.kt
@@ -1,0 +1,28 @@
+package pl.cuyer.rusthub.data.network.notification
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import kotlinx.datetime.Instant
+import pl.cuyer.rusthub.data.network.notification.model.FcmTokenRequest
+import pl.cuyer.rusthub.data.network.util.NetworkConstants
+import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
+
+class MessagingTokenClientImpl(
+    private val httpClient: HttpClient
+) : MessagingTokenRepository {
+    override suspend fun registerToken(token: String, timestamp: Instant) {
+        runCatching {
+            httpClient.post(NetworkConstants.BASE_URL + "fcm/token") {
+                setBody(FcmTokenRequest(token, timestamp))
+            }
+        }
+    }
+
+    override suspend fun deleteToken(token: String) {
+        runCatching {
+            httpClient.delete(NetworkConstants.BASE_URL + "fcm/token/$token")
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/notification/model/FcmTokenRequest.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/notification/model/FcmTokenRequest.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.rusthub.data.network.notification.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmTokenRequest(
+    val token: String,
+    val timestamp: Instant
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/notification/MessagingTokenRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/notification/MessagingTokenRepository.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.domain.repository.notification
+
+import kotlinx.datetime.Instant
+
+interface MessagingTokenRepository {
+    suspend fun registerToken(token: String, timestamp: Instant)
+    suspend fun deleteToken(token: String)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
@@ -7,10 +7,12 @@ import kotlinx.coroutines.flow.collectLatest
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.MessagingTokenManager
 
 class AuthAnonymouslyUseCase(
     private val client: AuthRepository,
     private val dataSource: AuthDataSource,
+    private val tokenManager: MessagingTokenManager,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(): Flow<Result<Unit>> = channelFlow {
@@ -24,6 +26,7 @@ class AuthAnonymouslyUseCase(
                             accessToken = accessToken,
                             refreshToken = null
                         )
+                        tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }
                 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
@@ -7,10 +7,12 @@ import kotlinx.coroutines.flow.collectLatest
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.MessagingTokenManager
 
 class LoginUserUseCase(
     private val client: AuthRepository,
     private val dataSource: AuthDataSource,
+    private val tokenManager: MessagingTokenManager,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(
@@ -27,6 +29,7 @@ class LoginUserUseCase(
                             username = username,
                             email = email
                         )
+                        tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }
                 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LogoutUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LogoutUserUseCase.kt
@@ -1,11 +1,14 @@
 package pl.cuyer.rusthub.domain.usecase
 
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+import pl.cuyer.rusthub.util.MessagingTokenManager
 
 class LogoutUserUseCase(
-    private val dataSource: AuthDataSource
+    private val dataSource: AuthDataSource,
+    private val tokenManager: MessagingTokenManager,
 ) {
     suspend operator fun invoke() {
+        tokenManager.deleteToken()
         dataSource.deleteUser()
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RegisterUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RegisterUserUseCase.kt
@@ -7,10 +7,12 @@ import kotlinx.coroutines.flow.collectLatest
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.MessagingTokenManager
 
 class RegisterUserUseCase(
     private val client: AuthRepository,
-    private val dataSource: AuthDataSource
+    private val dataSource: AuthDataSource,
+    private val tokenManager: MessagingTokenManager
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(
@@ -32,6 +34,7 @@ class RegisterUserUseCase(
                             username = username,
                             email = email
                         )
+                        tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }
                 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -60,7 +60,10 @@ import pl.cuyer.rusthub.presentation.settings.SettingsController
 import pl.cuyer.rusthub.util.validator.EmailValidator
 import pl.cuyer.rusthub.util.validator.PasswordValidator
 import pl.cuyer.rusthub.util.validator.UsernameValidator
-import pl.cuyer.rusthub.util.TopicSubscriber
+import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.MessagingTokenScheduler
+import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
+import pl.cuyer.rusthub.data.network.notification.MessagingTokenClientImpl
 
 val appModule = module {
     single<SnackbarController> { SnackbarController }
@@ -81,6 +84,8 @@ val appModule = module {
     singleOf(::SearchQueryDataSourceImpl) bind SearchQueryDataSource::class
     singleOf(::RemoteKeyDataSourceImpl) bind RemoteKeyDataSource::class
     singleOf(::SettingsDataSourceImpl) bind SettingsDataSource::class
+    singleOf(::MessagingTokenClientImpl) bind MessagingTokenRepository::class
+    single { MessagingTokenManager(get(), get()) }
     single { GetPagedServersUseCase(get(), get(), get(), get()) }
     singleOf(::FiltersOptionsClientImpl) bind FiltersOptionsRepository::class
     singleOf(::FiltersOptionsDataSourceImpl) bind FiltersOptionsDataSource::class
@@ -98,16 +103,16 @@ val appModule = module {
     single { GetSearchQueriesUseCase(get()) }
     single { DeleteSearchQueriesUseCase(get()) }
     single { GetServerDetailsUseCase(get()) }
-    single { RegisterUserUseCase(get(), get()) }
-    single { LoginUserUseCase(get(), get()) }
-    single { AuthAnonymouslyUseCase(get(), get()) }
+    single { RegisterUserUseCase(get(), get(), get()) }
+    single { LoginUserUseCase(get(), get(), get()) }
+    single { AuthAnonymouslyUseCase(get(), get(), get()) }
     single { GetUserUseCase(get()) }
-    single { LogoutUserUseCase(get()) }
+    single { LogoutUserUseCase(get(), get()) }
     single { GetSettingsUseCase(get()) }
     single { SaveSettingsUseCase(get()) }
     single { SettingsController(get()) }
     single { ToggleFavouriteUseCase(get(), get(), get(), get()) }
-    single { ToggleSubscriptionUseCase(get(), get(), get(), get(), get()) }
+    single { ToggleSubscriptionUseCase(get(), get(), get(), get()) }
 }
 
 expect val platformModule: Module

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.util
+
+import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
+
+/** Provides the current FCM token and allows deleting it. */
+expect class MessagingTokenManager(
+    repository: MessagingTokenRepository,
+    scheduler: MessagingTokenScheduler
+) {
+    suspend fun currentToken(): String?
+    suspend fun deleteToken()
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.util
+
+/** Schedules periodic token refresh. */
+expect class MessagingTokenScheduler {
+    fun schedule()
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -13,8 +13,8 @@ import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
-import pl.cuyer.rusthub.util.TopicSubscriber
 import pl.cuyer.rusthub.util.StoreNavigator
+import pl.cuyer.rusthub.util.MessagingTokenScheduler
 import dev.icerock.moko.permissions.PermissionsController
 
 actual val platformModule: Module = module {
@@ -23,7 +23,7 @@ actual val platformModule: Module = module {
     single { ClipboardHandler() }
     single { SyncScheduler() }
     single { SubscriptionSyncScheduler() }
-    single { TopicSubscriber() }
+    single { MessagingTokenScheduler() }
     single { StoreNavigator() }
     single { PermissionsController() }
     factory { StartupViewModel(get()) }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.ios.kt
@@ -1,0 +1,11 @@
+package pl.cuyer.rusthub.util
+
+import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
+
+actual class MessagingTokenManager(
+    private val repository: MessagingTokenRepository,
+    private val scheduler: MessagingTokenScheduler
+) {
+    actual suspend fun currentToken(): String? = null
+    actual suspend fun deleteToken() {}
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.ios.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+actual class MessagingTokenScheduler {
+    actual fun schedule() { /* no-op */ }
+}


### PR DESCRIPTION
## Summary
- add coroutine play services dependency
- provide MessagingTokenManager for crossplatform token management
- refresh token on login/registration/anonymous auth and delete on logout
- update RustHubFirebaseMessagingService to send updated token
- remove local Firebase topic subscription logic

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f11c2e9f0832189c5aaeefecaff38