### PR TITLE
Fix logout token caching

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LogoutUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LogoutUserUseCase.kt
@@ -1,14 +1,22 @@
 package pl.cuyer.rusthub.domain.usecase
 
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.util.MessagingTokenManager
 
 class LogoutUserUseCase(
     private val dataSource: AuthDataSource,
     private val tokenManager: MessagingTokenManager,
+    private val httpClient: HttpClient,
 ) {
     suspend operator fun invoke() {
         tokenManager.deleteToken()
         dataSource.deleteUser()
+        httpClient.plugin(Auth)
+            .providers
+            .filterIsInstance<BearerAuthProvider>()
+            .forEach { it.clearToken() }
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -107,7 +107,7 @@ val appModule = module {
     single { LoginUserUseCase(get(), get(), get()) }
     single { AuthAnonymouslyUseCase(get(), get(), get()) }
     single { GetUserUseCase(get()) }
-    single { LogoutUserUseCase(get(), get()) }
+    single { LogoutUserUseCase(get(), get(), get()) }
     single { GetSettingsUseCase(get()) }
     single { SaveSettingsUseCase(get()) }
     single { SettingsController(get()) }


### PR DESCRIPTION
## Summary
- clear in-memory bearer tokens when logging out to avoid re-login issues
- update DI to provide HttpClient to `LogoutUserUseCase`

## Testing
- `./gradlew :shared:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f26e532a8832186dbde13b66c1249