### PR TITLE
Fix token refresh scheduling

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
@@ -9,6 +9,12 @@ actual class MessagingTokenManager actual constructor(
     private val repository: MessagingTokenRepository,
     private val scheduler: MessagingTokenScheduler
 ) {
+    /**
+     * Returns the current FCM token and ensures the refresh worker is scheduled.
+     *
+     * The scheduler checks for existing [TokenRefreshWorker] instances so
+     * invoking this method repeatedly will not reset the worker's period.
+     */
     actual suspend fun currentToken(): String? {
         val token = runCatching { FirebaseMessaging.getInstance().token.await() }.getOrNull()
         token?.let {

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenScheduler.android.kt
@@ -5,23 +5,34 @@ import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import pl.cuyer.rusthub.work.TokenRefreshWorker
 import java.util.concurrent.TimeUnit
 
 actual class MessagingTokenScheduler(private val context: Context) {
+    /**
+     * Schedule periodic token refresh if no [TokenRefreshWorker] is currently enqueued or running.
+     */
     actual fun schedule() {
-        val request = PeriodicWorkRequestBuilder<TokenRefreshWorker>(15, TimeUnit.MINUTES)
-            .setConstraints(
-                Constraints.Builder()
-                    .setRequiredNetworkType(NetworkType.CONNECTED)
-                    .build()
+        val manager = WorkManager.getInstance(context)
+        val existing = manager.getWorkInfosForUniqueWork(TokenRefreshWorker.WORK_NAME).get()
+        val active = existing.any { info ->
+            info.state == WorkInfo.State.ENQUEUED || info.state == WorkInfo.State.RUNNING
+        }
+        if (!active) {
+            val request = PeriodicWorkRequestBuilder<TokenRefreshWorker>(15, TimeUnit.MINUTES)
+                .setConstraints(
+                    Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build()
+                )
+                .build()
+            manager.enqueueUniquePeriodicWork(
+                TokenRefreshWorker.WORK_NAME,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
             )
-            .build()
-        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-            TokenRefreshWorker.WORK_NAME,
-            ExistingPeriodicWorkPolicy.KEEP,
-            request
-        )
+        }
     }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/TokenRefreshWorker.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/TokenRefreshWorker.kt
@@ -15,6 +15,8 @@ class TokenRefreshWorker(
     }
 
     override suspend fun doWork(): Result {
+        // This will fetch the token and schedule the refresh worker if needed.
+        // Scheduling is idempotent so the worker won't reset its period on each run.
         tokenManager.currentToken()
         return Result.success()
     }


### PR DESCRIPTION
## Summary
- prevent multiple `TokenRefreshWorker` enqueues
- document token retrieval behaviour
- clarify worker behaviour

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605ef1c6b083219991432d6c2e0165