### PR TITLE
Move notification channel init to application

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
@@ -11,6 +11,7 @@ import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.network.SubscriptionRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.NotificationPresenter
 import pl.cuyer.rusthub.work.CustomWorkerFactory
 
 class RustHubApplication : Application(), Configuration.Provider {
@@ -28,6 +29,7 @@ class RustHubApplication : Application(), Configuration.Provider {
             androidContext(this@RustHubApplication)
             modules(appModule, platformModule)
         }
+        NotificationPresenter.registerChannels(this)
         WorkManager.initialize(this, workManagerConfiguration)
     }
 

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.android.kt
@@ -21,7 +21,6 @@ actual class NotificationPresenter(private val context: Context) {
     }
 
     private fun buildNotification(type: NotificationType, name: String, timestamp: String) {
-        createNotificationChannel(type, NotificationManager.IMPORTANCE_DEFAULT)
         rusthubNotificationManager().notify(
             (type.name + name + timestamp).hashCode(),
             notificationBuilder(type, name, timestamp).build()
@@ -41,7 +40,7 @@ actual class NotificationPresenter(private val context: Context) {
             .setAutoCancel(true)
     }
 
-    private fun createNotificationChannel(type: NotificationType, importance: Int) {
+    fun createNotificationChannel(type: NotificationType, importance: Int) {
         with(rusthubNotificationManager()) {
             val channelId = channelId(type)
             val channelName = channelName(type)
@@ -121,5 +120,12 @@ actual class NotificationPresenter(private val context: Context) {
     companion object {
         const val MAIN_ACTIVITY = "pl.cuyer.rusthub.android.MainActivity"
         const val PACKAGE_NAME = "pl.cuyer.rusthub.android"
+
+        fun registerChannels(context: Context) {
+            val presenter = NotificationPresenter(context)
+            NotificationType.values().forEach { type ->
+                presenter.createNotificationChannel(type, NotificationManager.IMPORTANCE_DEFAULT)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- set up notification channels once when the `Application` starts
- use new helper to register all channels

## Testing
- `./gradlew tasks --all`
- `./gradlew assembleDebug -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686064118c90832182bd9f7d251c358d