### PR TITLE
Improve FCM error logging

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
@@ -1,6 +1,7 @@
 package pl.cuyer.rusthub.util
 
 import com.google.firebase.messaging.FirebaseMessaging
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.tasks.await
 import kotlinx.datetime.Clock
 import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
@@ -16,17 +17,29 @@ actual class MessagingTokenManager actual constructor(
      * invoking this method repeatedly will not reset the worker's period.
      */
     actual suspend fun currentToken(): String? {
-        val token = runCatching { FirebaseMessaging.getInstance().token.await() }.getOrNull()
-        token?.let {
-            repository.registerToken(it, Clock.System.now())
+        return try {
+            val token = FirebaseMessaging.getInstance().token.await()
+            repository.registerToken(token, Clock.System.now())
             scheduler.schedule()
+            token
+        } catch (e: Exception) {
+            Napier.e("Failed to get FCM token", e)
+            null
         }
-        return token
     }
 
     actual suspend fun deleteToken() {
-        val token = runCatching { FirebaseMessaging.getInstance().token.await() }.getOrNull()
+        val token = try {
+            FirebaseMessaging.getInstance().token.await()
+        } catch (e: Exception) {
+            Napier.e("Failed to read FCM token before deletion", e)
+            null
+        }
         token?.let { repository.deleteToken(it) }
-        runCatching { FirebaseMessaging.getInstance().deleteToken().await() }
+        try {
+            FirebaseMessaging.getInstance().deleteToken().await()
+        } catch (e: Exception) {
+            Napier.e("Failed to delete FCM token", e)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- capture exceptions from Firebase token retrieval and deletion
- log failures using Napier

## Testing
- `./gradlew :shared:compileDebugKotlinAndroid --no-daemon --console=plain | head -n 20` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860642898648321a16c2a8fd1574adf