### PR TITLE
Update FCM token handling

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/notification/RustHubFirebaseMessagingService.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/notification/RustHubFirebaseMessagingService.kt
@@ -25,7 +25,7 @@ class RustHubFirebaseMessagingService : FirebaseMessagingService() {
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         CoroutineScope(Dispatchers.Default).launch {
-            tokenManager.currentToken()
+            tokenManager.registerToken(token)
         }
     }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.android.kt
@@ -9,6 +9,10 @@ actual class MessagingTokenManager actual constructor(
     private val repository: MessagingTokenRepository,
     private val scheduler: MessagingTokenScheduler
 ) {
+    actual suspend fun registerToken(token: String) {
+        repository.registerToken(token, Clock.System.now())
+        scheduler.schedule()
+    }
     /**
      * Returns the current FCM token and ensures the refresh worker is scheduled.
      *

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.kt
@@ -7,6 +7,7 @@ expect class MessagingTokenManager(
     repository: MessagingTokenRepository,
     scheduler: MessagingTokenScheduler
 ) {
+    suspend fun registerToken(token: String)
     suspend fun currentToken(): String?
     suspend fun deleteToken()
 }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/MessagingTokenManager.ios.kt
@@ -6,6 +6,7 @@ actual class MessagingTokenManager(
     private val repository: MessagingTokenRepository,
     private val scheduler: MessagingTokenScheduler
 ) {
+    actual suspend fun registerToken(token: String) {}
     actual suspend fun currentToken(): String? = null
     actual suspend fun deleteToken() {}
 }


### PR DESCRIPTION
## Summary
- add `registerToken(token: String)` to `MessagingTokenManager`
- register tokens from `RustHubFirebaseMessagingService`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686064c52b1c8321a56fed01e6e4da5d