### PR TITLE
Ensure first request uses bearer token

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -41,7 +41,7 @@ actual class HttpClientFactory actual constructor(
             install(Auth) {
                 bearer {
                     loadTokens {
-                        authDataSource.getUser().firstOrNull()?.let {
+                        authDataSource.getUserOnce()?.let {
                             BearerTokens(it.accessToken, it.refreshToken ?: "")
                         }
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
@@ -48,4 +48,10 @@ class AuthDataSourceImpl(
             .map { it?.toUser() }
     }
 
+    override suspend fun getUserOnce(): User? {
+        return withContext(Dispatchers.IO) {
+            queries.getUser().executeAsOneOrNull()?.toUser()
+        }
+    }
+
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthDataSource.kt
@@ -13,4 +13,6 @@ interface AuthDataSource {
 
     suspend fun deleteUser()
     fun getUser(): Flow<User?>
+
+    suspend fun getUserOnce(): User?
 }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
@@ -42,7 +42,7 @@ actual class HttpClientFactory actual constructor(
             install(Auth) {
                 bearer {
                     loadTokens {
-                        authDataSource.getUser().firstOrNull()?.let {
+                        authDataSource.getUserOnce()?.let {
                             BearerTokens(it.accessToken, it.refreshToken ?: "")
                         }
                     }


### PR DESCRIPTION
## Summary
- add `getUserOnce` method to `AuthDataSource` for synchronous token retrieval
- use new method in both HttpClient factories to load tokens
- expose implementation in `AuthDataSourceImpl`

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a31fde2c83219ea28062a8d47227