### PR TITLE
Add Google sign-in to registration and improve settings

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/RegisterScreen.kt
@@ -171,9 +171,7 @@ private fun RegisterScreenCompact(
             modifier = Modifier.fillMaxWidth(),
             backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
             contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
-        ) {
-
-        }
+        ) { onAction(RegisterAction.OnGoogleLogin) }
     }
 }
 
@@ -268,9 +266,7 @@ private fun RegisterScreenExpanded(
                 modifier = Modifier.fillMaxWidth(),
                 backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
                 contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
-            ) {
-
-            }
+            ) { onAction(RegisterAction.OnGoogleLogin) }
         }
     }
 }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -46,6 +46,7 @@ import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
 import pl.cuyer.rusthub.domain.model.Language
 import pl.cuyer.rusthub.domain.model.Theme
+import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.domain.model.displayName
 import pl.cuyer.rusthub.presentation.features.settings.SettingsAction
 import pl.cuyer.rusthub.presentation.features.settings.SettingsState
@@ -106,6 +107,7 @@ fun SettingsScreen(
                 theme = state.value.theme,
                 language = state.value.language,
                 username = state.value.username,
+                provider = state.value.provider,
                 onAction = onAction
             )
         } else {
@@ -118,6 +120,7 @@ fun SettingsScreen(
                 theme = state.value.theme,
                 language = state.value.language,
                 username = state.value.username,
+                provider = state.value.provider,
                 onAction = onAction
             )
         }
@@ -130,6 +133,7 @@ private fun SettingsScreenCompact(
     username: String?,
     theme: Theme,
     language: Language,
+    provider: AuthProvider?,
     onAction: (SettingsAction) -> Unit
 ) {
     Column(
@@ -139,7 +143,7 @@ private fun SettingsScreenCompact(
         GreetingSection(username)
         PreferencesSection(theme, language, onAction)
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
-        AccountSection(onAction)
+        AccountSection(provider, onAction)
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
         OtherSection(onAction)
     }
@@ -151,6 +155,7 @@ private fun SettingsScreenExpanded(
     username: String?,
     theme: Theme,
     language: Language,
+    provider: AuthProvider?,
     onAction: (SettingsAction) -> Unit
 ) {
     Row(
@@ -166,7 +171,7 @@ private fun SettingsScreenExpanded(
             GreetingSection(username)
             PreferencesSection(theme, language, onAction)
             HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
-            AccountSection(onAction)
+            AccountSection(provider, onAction)
         }
         Column(
             modifier = Modifier
@@ -221,7 +226,7 @@ private fun PreferencesSection(
 }
 
 @Composable
-private fun AccountSection(onAction: (SettingsAction) -> Unit) {
+private fun AccountSection(provider: AuthProvider?, onAction: (SettingsAction) -> Unit) {
     Text(
         text = "Account",
         style = MaterialTheme.typography.titleLarge,
@@ -262,11 +267,39 @@ private fun AccountSection(onAction: (SettingsAction) -> Unit) {
         }
     }
 
-    AppTextButton(
-        modifier = Modifier.fillMaxWidth(),
-        onClick = { onAction(SettingsAction.OnDeleteAccount) }
-    ) {
-        Text("Delete account", color = MaterialTheme.colorScheme.error)
+    if (provider == AuthProvider.ANONYMOUS) {
+        AppTextButton(
+            onClick = { onAction(SettingsAction.OnUpgradeAccount) }
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Upgrade account")
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                    contentDescription = "Upgrade account button"
+                )
+            }
+        }
+    } else {
+        AppTextButton(
+            onClick = { onAction(SettingsAction.OnDeleteAccount) }
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("Delete account", color = MaterialTheme.colorScheme.error)
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                    contentDescription = "Delete account button",
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
     }
 }
 

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -58,6 +58,9 @@ actual val platformModule: Module = module {
     viewModel {
         RegisterViewModel(
             registerUserUseCase = get(),
+            loginWithGoogleUseCase = get(),
+            getGoogleClientIdUseCase = get(),
+            googleAuthClient = get(),
             snackbarController = get(),
             emailValidator = get(),
             passwordValidator = get(),

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/register/RegisterAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/register/RegisterAction.kt
@@ -3,6 +3,8 @@ package pl.cuyer.rusthub.presentation.features.auth.register
 sealed interface RegisterAction {
     data object OnRegister : RegisterAction
 
+    data object OnGoogleLogin : RegisterAction
+
     data class OnEmailChange(val email: String) : RegisterAction
     data class OnPasswordChange(val password: String) : RegisterAction
     data class OnUsernameChange(val username: String) : RegisterAction

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -14,4 +14,5 @@ sealed interface SettingsAction {
     data object OnSubscribe : SettingsAction
     data object OnPrivacyPolicy : SettingsAction
     data object OnDeleteAccount : SettingsAction
+    data object OnUpgradeAccount : SettingsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -27,6 +27,7 @@ import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
+import pl.cuyer.rusthub.presentation.navigation.Register
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
 
@@ -66,6 +67,7 @@ class SettingsViewModel(
             SettingsAction.OnSubscribe -> showSubscriptionDialog(false)
             SettingsAction.OnPrivacyPolicy -> openPrivacyPolicy()
             SettingsAction.OnDeleteAccount -> navigateDeleteAccount()
+            SettingsAction.OnUpgradeAccount -> navigateRegister()
         }
     }
 
@@ -82,6 +84,12 @@ class SettingsViewModel(
     private fun navigateChangePassword() {
         coroutineScope.launch {
             _uiEvent.send(UiEvent.Navigate(ChangePassword))
+        }
+    }
+
+    private fun navigateRegister() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(Register))
         }
     }
 

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -53,6 +53,9 @@ actual val platformModule: Module = module {
     factory {
         RegisterViewModel(
             registerUserUseCase = get(),
+            loginWithGoogleUseCase = get(),
+            getGoogleClientIdUseCase = get(),
+            googleAuthClient = get(),
             snackbarController = get(),
             emailValidator = get(),
             passwordValidator = get(),


### PR DESCRIPTION
## Summary
- enable Google sign-in on the register screen
- handle Google auth in `RegisterViewModel`
- update DI modules for new dependencies
- show *Delete account* or *Upgrade account* button depending on auth type
- style account actions consistently

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0331ca88321a97ee2eec46166f5