### PR TITLE
Handle Google account deletion

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/DeleteAccountScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/DeleteAccountScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
@@ -20,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.navigation3.runtime.NavKey
+import pl.cuyer.rusthub.domain.model.AuthProvider
 import kotlinx.coroutines.flow.Flow
 import pl.cuyer.rusthub.android.designsystem.AppButton
 import pl.cuyer.rusthub.android.designsystem.AppSecureTextField
@@ -63,28 +65,34 @@ fun DeleteAccountScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(spacing.medium)
         ) {
-            AppTextField(
-                modifier = Modifier.fillMaxWidth(),
-                value = state.value.username,
-                labelText = "Username",
-                placeholderText = "Enter your username",
-                keyboardType = KeyboardType.Text,
-                imeAction = ImeAction.Next,
-                onValueChange = { onAction(DeleteAccountAction.OnUsernameChange(it)) },
-                isError = state.value.usernameError != null,
-                errorText = state.value.usernameError
+            Text(
+                "Deleting your account is irreversible. All your data will be removed.",
+                style = MaterialTheme.typography.bodyMedium
             )
-            AppSecureTextField(
-                modifier = Modifier.fillMaxWidth(),
-                value = state.value.password,
-                labelText = "Password",
-                placeholderText = "Enter your password",
-                onSubmit = { onAction(DeleteAccountAction.OnDelete) },
-                imeAction = ImeAction.Send,
-                onValueChange = { onAction(DeleteAccountAction.OnPasswordChange(it)) },
-                isError = state.value.passwordError != null,
-                errorText = state.value.passwordError
-            )
+            if (state.value.provider != AuthProvider.GOOGLE) {
+                AppTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = state.value.username,
+                    labelText = "Username",
+                    placeholderText = "Enter your username",
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Next,
+                    onValueChange = { onAction(DeleteAccountAction.OnUsernameChange(it)) },
+                    isError = state.value.usernameError != null,
+                    errorText = state.value.usernameError
+                )
+                AppSecureTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = state.value.password,
+                    labelText = "Password",
+                    placeholderText = "Enter your password",
+                    onSubmit = { onAction(DeleteAccountAction.OnDelete) },
+                    imeAction = ImeAction.Send,
+                    onValueChange = { onAction(DeleteAccountAction.OnPasswordChange(it)) },
+                    isError = state.value.passwordError != null,
+                    errorText = state.value.passwordError
+                )
+            }
             AppButton(
                 modifier = Modifier.fillMaxWidth(),
                 isLoading = state.value.isLoading,

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -96,7 +96,8 @@ actual val platformModule: Module = module {
             deleteAccountUseCase = get(),
             snackbarController = get(),
             passwordValidator = get(),
-            usernameValidator = get()
+            usernameValidator = get(),
+            getUserUseCase = get()
         )
     }
     viewModel { (serverId: Long, serverName: String?) ->

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/delete/DeleteAccountState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/delete/DeleteAccountState.kt
@@ -1,9 +1,12 @@
 package pl.cuyer.rusthub.presentation.features.auth.delete
 
+import pl.cuyer.rusthub.domain.model.AuthProvider
+
 data class DeleteAccountState(
     val username: String = "",
     val password: String = "",
     val usernameError: String? = null,
     val passwordError: String? = null,
+    val provider: AuthProvider? = null,
     val isLoading: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/delete/DeleteAccountViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/delete/DeleteAccountViewModel.kt
@@ -7,7 +7,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -16,6 +18,8 @@ import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.common.BaseViewModel
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.usecase.DeleteAccountUseCase
+import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
+import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
@@ -27,17 +31,20 @@ class DeleteAccountViewModel(
     private val deleteAccountUseCase: DeleteAccountUseCase,
     private val snackbarController: SnackbarController,
     private val passwordValidator: PasswordValidator,
-    private val usernameValidator: UsernameValidator
+    private val usernameValidator: UsernameValidator,
+    private val getUserUseCase: GetUserUseCase,
 ) : BaseViewModel() {
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
     val uiEvent = _uiEvent.receiveAsFlow()
 
     private val _state = MutableStateFlow(DeleteAccountState())
-    val state = _state.stateIn(
-        scope = coroutineScope,
-        started = SharingStarted.WhileSubscribed(5_000L),
-        initialValue = DeleteAccountState()
-    )
+    val state = _state
+        .onStart { observeUser() }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = DeleteAccountState()
+        )
 
     var deleteJob: Job? = null
 
@@ -57,9 +64,30 @@ class DeleteAccountViewModel(
         _state.update { it.copy(username = username, usernameError = null) }
     }
 
+    private fun observeUser() {
+        getUserUseCase()
+            .onEach { user -> _state.update { it.copy(provider = user?.provider) } }
+            .launchIn(coroutineScope)
+    }
+
     private fun delete() {
         deleteJob?.cancel()
         deleteJob = coroutineScope.launch {
+            if (_state.value.provider == AuthProvider.GOOGLE) {
+                deleteAccountUseCase("", "")
+                    .onStart { updateLoading(true) }
+                    .onCompletion { updateLoading(false) }
+                    .catch { e -> showErrorSnackbar(e.message ?: "Unknown error") }
+                    .collectLatest { result ->
+                        when (result) {
+                            is Result.Success -> _uiEvent.send(UiEvent.Navigate(Onboarding))
+                            is Result.Error -> showErrorSnackbar(result.exception.message ?: "Unable to delete account")
+                            else -> Unit
+                        }
+                    }
+                return@launch
+            }
+
             val username = _state.value.username
             val password = _state.value.password
             val usernameResult = usernameValidator.validate(username)

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -77,7 +77,8 @@ actual val platformModule: Module = module {
             deleteAccountUseCase = get(),
             snackbarController = get(),
             passwordValidator = get(),
-            usernameValidator = get()
+            usernameValidator = get(),
+            getUserUseCase = get()
         )
     }
 }


### PR DESCRIPTION
## Summary
- show a deletion warning and skip credentials when provider is Google
- keep provider info in `DeleteAccountState`
- watch user provider in `DeleteAccountViewModel`
- inject `GetUserUseCase` in Koin initializers

## Testing
- `./gradlew :shared:assemble` *(fails: unable to complete build)*

------
https://chatgpt.com/codex/tasks/task_e_6862c44778b48321abf6dd5488eb0888