### PR TITLE
Implement unified credentials flow

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -40,8 +40,7 @@ import app.cash.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
-import pl.cuyer.rusthub.android.feature.auth.LoginScreen
-import pl.cuyer.rusthub.android.feature.auth.RegisterScreen
+import pl.cuyer.rusthub.android.feature.auth.CredentialsScreen
 import pl.cuyer.rusthub.android.feature.onboarding.OnboardingScreen
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
@@ -51,18 +50,16 @@ import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
 import pl.cuyer.rusthub.android.feature.settings.DeleteAccountScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.common.Constants
-import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
-import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
+import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
 import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
 import pl.cuyer.rusthub.presentation.navigation.ChangePassword
-import pl.cuyer.rusthub.presentation.navigation.Login
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.Credentials
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
-import pl.cuyer.rusthub.presentation.navigation.Register
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings
@@ -144,23 +141,10 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                                 }
                             )
                         }
-                        entry<Login> {
-                            val viewModel = koinViewModel<LoginViewModel>()
+                        entry<Credentials> { key ->
+                            val viewModel: CredentialsViewModel = koinViewModel { parametersOf(key.email, key.exists) }
                             val state = viewModel.state.collectAsStateWithLifecycle()
-                            LoginScreen(
-                                stateProvider = { state },
-                                uiEvent = viewModel.uiEvent,
-                                onAction = viewModel::onAction,
-                                onNavigate = { dest ->
-                                    backStack.clear()
-                                    backStack.add(dest)
-                                }
-                            )
-                        }
-                        entry<Register> {
-                            val viewModel = koinViewModel<RegisterViewModel>()
-                            val state = viewModel.state.collectAsStateWithLifecycle()
-                            RegisterScreen(
+                            CredentialsScreen(
                                 stateProvider = { state },
                                 uiEvent = viewModel.uiEvent,
                                 onAction = viewModel::onAction,

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/CredentialsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/CredentialsScreen.kt
@@ -1,0 +1,113 @@
+package pl.cuyer.rusthub.android.feature.auth
+
+import android.app.Activity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppSecureTextField
+import pl.cuyer.rusthub.android.designsystem.AppTextField
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsAction
+import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsState
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun CredentialsScreen(
+    onNavigate: (NavKey) -> Unit,
+    uiEvent: Flow<UiEvent>,
+    stateProvider: () -> State<CredentialsState>,
+    onAction: (CredentialsAction) -> Unit,
+) {
+    val state = stateProvider()
+    val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
+    calculateWindowSizeClass(context as Activity)
+
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) { focusManager.clearFocus() },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(spacing.medium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.medium, Alignment.CenterVertically)
+        ) {
+            if (state.value.email.isBlank()) {
+                AppTextField(
+                    value = state.value.email,
+                    onValueChange = { onAction(CredentialsAction.OnEmailChange(it)) },
+                    labelText = "Email",
+                    placeholderText = "Enter your email",
+                    isError = state.value.emailError != null,
+                    errorText = state.value.emailError,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            } else {
+                Text(text = state.value.email, style = MaterialTheme.typography.titleMedium)
+            }
+            if (!state.value.userExists) {
+                AppTextField(
+                    value = state.value.username,
+                    onValueChange = { onAction(CredentialsAction.OnUsernameChange(it)) },
+                    labelText = "Username",
+                    placeholderText = "Enter your username",
+                    isError = state.value.usernameError != null,
+                    errorText = state.value.usernameError,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+            AppSecureTextField(
+                value = state.value.password,
+                onValueChange = { onAction(CredentialsAction.OnPasswordChange(it)) },
+                labelText = "Password",
+                placeholderText = "Enter your password",
+                onSubmit = { onAction(CredentialsAction.OnSubmit) },
+                isError = state.value.passwordError != null,
+                errorText = state.value.passwordError,
+                modifier = Modifier.fillMaxWidth()
+            )
+            AppButton(
+                onClick = { onAction(CredentialsAction.OnSubmit) },
+                isLoading = state.value.isLoading,
+                modifier = Modifier.fillMaxWidth()
+            ) { Text("Continue") }
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -7,8 +7,7 @@ import org.koin.dsl.module
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
-import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
-import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
+import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
@@ -41,30 +40,20 @@ actual val platformModule: Module = module {
     viewModel {
         OnboardingViewModel(
             authAnonymouslyUseCase = get(),
+            checkUserExistsUseCase = get(),
             snackbarController = get(),
         )
     }
-    viewModel {
-        LoginViewModel(
+    viewModel { (email: String, exists: Boolean) ->
+        CredentialsViewModel(
+            email = email,
+            userExists = exists,
             loginUserUseCase = get(),
-            loginWithGoogleUseCase = get(),
-            getGoogleClientIdUseCase = get(),
-            googleAuthClient = get(),
-            snackbarController = get(),
-            passwordValidator = get(),
-            usernameValidator = get()
-        )
-    }
-    viewModel {
-        RegisterViewModel(
             registerUserUseCase = get(),
-            loginWithGoogleUseCase = get(),
-            getGoogleClientIdUseCase = get(),
-            googleAuthClient = get(),
             snackbarController = get(),
-            emailValidator = get(),
             passwordValidator = get(),
-            usernameValidator = get()
+            usernameValidator = get(),
+            emailValidator = get(),
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package pl.cuyer.rusthub.data.network.auth
 
 import io.ktor.client.HttpClient
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.request.parameter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
@@ -13,6 +15,7 @@ import pl.cuyer.rusthub.data.network.auth.model.LoginRequest
 import pl.cuyer.rusthub.data.network.auth.model.RefreshRequest
 import pl.cuyer.rusthub.data.network.auth.model.RegisterRequest
 import pl.cuyer.rusthub.data.network.auth.model.GoogleLoginRequest
+import pl.cuyer.rusthub.data.network.auth.model.UserExistsResponseDto
 import pl.cuyer.rusthub.data.network.auth.model.TokenPairDto
 import pl.cuyer.rusthub.data.network.auth.model.UpgradeRequest
 import pl.cuyer.rusthub.data.network.auth.model.mapper.toDomain
@@ -141,6 +144,20 @@ class AuthRepositoryImpl(
                 is Result.Success -> Result.Success(Unit)
                 is Result.Error -> result
                 Result.Loading -> Result.Loading
+            }
+        }
+    }
+
+    override fun checkUserExists(email: String): Flow<Result<Boolean>> {
+        return safeApiCall<UserExistsResponseDto> {
+            httpClient.get(NetworkConstants.BASE_URL + "auth/email-exists") {
+                parameter("email", email)
+            }
+        }.map { result ->
+            when (result) {
+                is Result.Success -> Result.Success(result.data.exists)
+                is Result.Error -> result
+                is Result.Loading -> Result.Loading
             }
         }
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/UserExistsResponseDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/UserExistsResponseDto.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.data.network.auth.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserExistsResponseDto(
+    val exists: Boolean
+)
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
@@ -14,4 +14,5 @@ interface AuthRepository {
     fun loginWithGoogle(token: String): Flow<Result<TokenPair>>
     fun logout(): Flow<Result<Unit>>
     fun deleteAccount(username: String, password: String): Flow<Result<Unit>>
+    fun checkUserExists(email: String): Flow<Result<Boolean>>
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/CheckUserExistsUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/CheckUserExistsUseCase.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+
+class CheckUserExistsUseCase(
+    private val repository: AuthRepository
+) {
+    operator fun invoke(email: String): Flow<Result<Boolean>> = repository.checkUserExists(email)
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -53,6 +53,7 @@ import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginWithGoogleUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteAccountUseCase
+import pl.cuyer.rusthub.domain.usecase.CheckUserExistsUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
@@ -113,6 +114,7 @@ val appModule = module {
     single { LoginWithGoogleUseCase(get(), get(), get()) }
     single { GetGoogleClientIdUseCase(get()) }
     single { AuthAnonymouslyUseCase(get(), get(), get()) }
+    single { CheckUserExistsUseCase(get()) }
     single { GetUserUseCase(get()) }
     single { LogoutUserUseCase(get(), get()) }
     single { DeleteAccountUseCase(get(), get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsAction.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.presentation.features.auth.credentials
+
+sealed interface CredentialsAction {
+    data object OnSubmit : CredentialsAction
+    data class OnEmailChange(val email: String) : CredentialsAction
+    data class OnUsernameChange(val username: String) : CredentialsAction
+    data class OnPasswordChange(val password: String) : CredentialsAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsState.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.presentation.features.auth.credentials
+
+data class CredentialsState(
+    val email: String,
+    val userExists: Boolean,
+    val username: String = "",
+    val password: String = "",
+    val emailError: String? = null,
+    val usernameError: String? = null,
+    val passwordError: String? = null,
+    val isLoading: Boolean = false
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsViewModel.kt
@@ -1,0 +1,135 @@
+package pl.cuyer.rusthub.presentation.features.auth.credentials
+
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.exception.InvalidCredentialsException
+import pl.cuyer.rusthub.domain.exception.UserAlreadyExistsException
+import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
+import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
+import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.validator.EmailValidator
+import pl.cuyer.rusthub.util.validator.PasswordValidator
+import pl.cuyer.rusthub.util.validator.UsernameValidator
+import pl.cuyer.rusthub.util.validator.ValidationResult
+
+class CredentialsViewModel(
+    email: String,
+    private val userExists: Boolean,
+    private val loginUserUseCase: LoginUserUseCase,
+    private val registerUserUseCase: RegisterUserUseCase,
+    private val snackbarController: SnackbarController,
+    private val passwordValidator: PasswordValidator,
+    private val usernameValidator: UsernameValidator,
+    private val emailValidator: EmailValidator,
+) : BaseViewModel() {
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(CredentialsState(email = email, userExists = userExists))
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = CredentialsState(email = email, userExists = userExists)
+    )
+
+    private var submitJob: Job? = null
+
+    fun onAction(action: CredentialsAction) {
+        when (action) {
+            CredentialsAction.OnSubmit -> submit()
+            is CredentialsAction.OnEmailChange -> updateEmail(action.email)
+            is CredentialsAction.OnUsernameChange -> updateUsername(action.username)
+            is CredentialsAction.OnPasswordChange -> updatePassword(action.password)
+        }
+    }
+
+    private fun submit() {
+        submitJob?.cancel()
+        submitJob = coroutineScope.launch {
+            val password = _state.value.password
+            val passwordResult = passwordValidator.validate(password)
+            var usernameResult = ValidationResult(true)
+            if (!userExists) {
+                usernameResult = usernameValidator.validate(_state.value.username)
+            }
+            _state.update { it.copy(passwordError = passwordResult.errorMessage, usernameError = usernameResult.errorMessage) }
+            if (!passwordResult.isValid || !usernameResult.isValid) {
+                snackbarController.sendEvent(SnackbarEvent("Please correct the errors above and try again."))
+                return@launch
+            }
+            val currentEmail = _state.value.email
+            val emailResult = if (currentEmail.isBlank()) emailValidator.validate(currentEmail) else ValidationResult(true)
+            _state.update { it.copy(emailError = emailResult.errorMessage) }
+            if (!emailResult.isValid) {
+                snackbarController.sendEvent(SnackbarEvent("Please correct the errors above and try again."))
+                return@launch
+            }
+            if (userExists) {
+                loginUserUseCase(currentEmail, password)
+            } else {
+                registerUserUseCase(currentEmail, password, _state.value.username)
+            }
+                .onStart { updateLoading(true) }
+                .onCompletion { updateLoading(false) }
+                .catch { e -> showErrorSnackbar(e.message ?: "Unknown error") }
+                .collectLatest { result ->
+                    ensureActive()
+                    when (result) {
+                        is Result.Success -> navigate(ServerList)
+                        is Result.Error -> handleError(result.exception)
+                        else -> Unit
+                    }
+                }
+        }
+    }
+
+    private fun handleError(exception: Throwable) {
+        when (exception) {
+            is InvalidCredentialsException -> showErrorSnackbar("Provided credentials are incorrect.")
+            is UserAlreadyExistsException -> showErrorSnackbar("User already exists.")
+            else -> showErrorSnackbar("Error occurred during authentication")
+        }
+    }
+
+    private fun updateUsername(username: String) {
+        _state.update { it.copy(username = username, usernameError = null) }
+    }
+
+    private fun updateEmail(email: String) {
+        _state.update { it.copy(email = email, emailError = null) }
+    }
+
+    private fun updatePassword(password: String) {
+        _state.update { it.copy(password = password, passwordError = null) }
+    }
+
+    private fun updateLoading(isLoading: Boolean) {
+        _state.update { it.copy(isLoading = isLoading) }
+    }
+
+    private fun navigate(destination: NavKey) {
+        coroutineScope.launch { _uiEvent.send(UiEvent.Navigate(destination)) }
+    }
+
+    private fun showErrorSnackbar(message: String) {
+        coroutineScope.launch { snackbarController.sendEvent(SnackbarEvent(message = message)) }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/onboarding/OnboardingAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/onboarding/OnboardingAction.kt
@@ -1,7 +1,9 @@
 package pl.cuyer.rusthub.presentation.features.onboarding
 
 sealed interface OnboardingAction {
-    data object OnLoginClick : OnboardingAction
-    data object OnRegisterClick : OnboardingAction
     data object OnContinueAsGuest : OnboardingAction
+    data class OnEmailChange(val email: String) : OnboardingAction
+    data object OnContinueWithEmail : OnboardingAction
+    data object OnGoogleLogin : OnboardingAction
+    data object OnShowOtherOptions : OnboardingAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/onboarding/OnboardingState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/onboarding/OnboardingState.kt
@@ -1,5 +1,8 @@
 package pl.cuyer.rusthub.presentation.features.onboarding
 
 data class OnboardingState(
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
+    val email: String = "",
+    val emailError: String? = null,
+    val showOtherOptions: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -27,7 +27,7 @@ import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
-import pl.cuyer.rusthub.presentation.navigation.Register
+import pl.cuyer.rusthub.presentation.navigation.Credentials
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
 
@@ -89,7 +89,7 @@ class SettingsViewModel(
 
     private fun navigateRegister() {
         coroutineScope.launch {
-            _uiEvent.send(UiEvent.Navigate(Register))
+            _uiEvent.send(UiEvent.Navigate(Credentials("", false)))
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -6,11 +6,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object Onboarding : NavKey
 
-@Serializable
-data object Login : NavKey
 
 @Serializable
-data object Register : NavKey
+data class Credentials(
+    val email: String,
+    val exists: Boolean
+) : NavKey
 
 @Serializable
 data object ServerList : NavKey

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -5,8 +5,7 @@ import org.koin.dsl.module
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
-import pl.cuyer.rusthub.presentation.features.auth.login.LoginViewModel
-import pl.cuyer.rusthub.presentation.features.auth.register.RegisterViewModel
+import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.domain.usecase.LoginWithGoogleUseCase
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
@@ -36,30 +35,20 @@ actual val platformModule: Module = module {
     factory {
         OnboardingViewModel(
             authAnonymouslyUseCase = get(),
+            checkUserExistsUseCase = get(),
             snackbarController = get(),
         )
     }
-    factory {
-        LoginViewModel(
+    factory { (email: String, exists: Boolean) ->
+        CredentialsViewModel(
+            email = email,
+            userExists = exists,
             loginUserUseCase = get(),
-            loginWithGoogleUseCase = get(),
-            getGoogleClientIdUseCase = get(),
-            googleAuthClient = get(),
-            snackbarController = get(),
-            passwordValidator = get(),
-            usernameValidator = get()
-        )
-    }
-    factory {
-        RegisterViewModel(
             registerUserUseCase = get(),
-            loginWithGoogleUseCase = get(),
-            getGoogleClientIdUseCase = get(),
-            googleAuthClient = get(),
             snackbarController = get(),
-            emailValidator = get(),
             passwordValidator = get(),
-            usernameValidator = get()
+            usernameValidator = get(),
+            emailValidator = get(),
         )
     }
     factory {


### PR DESCRIPTION
## Summary
- merge login and register flows into a Credentials screen
- adjust onboarding to launch Credentials after checking email
- update navigation and dependency injection
- change email existence check to GET auth/email-exists

## Testing
- `./gradlew lint` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643026234483219aa1cc00d1ced16e