### PR TITLE
Add user subscription tracking

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -60,7 +60,8 @@ actual class HttpClientFactory actual constructor(
                                 username = newTokens.username,
                                 accessToken = newTokens.accessToken,
                                 refreshToken = newTokens.refreshToken,
-                                provider = AuthProvider.valueOf(newTokens.provider)
+                                provider = AuthProvider.valueOf(newTokens.provider),
+                                subscribed = newTokens.subscribed
                             )
                             BearerTokens(newTokens.accessToken, newTokens.refreshToken)
                         } else {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
@@ -25,6 +25,7 @@ class AuthDataSourceImpl(
         accessToken: String,
         refreshToken: String?,
         provider: AuthProvider,
+        subscribed: Boolean,
     ) {
         withContext(Dispatchers.IO) {
             queries.insertUser(
@@ -33,7 +34,8 @@ class AuthDataSourceImpl(
                 username = username,
                 accessToken = accessToken,
                 refreshToken = refreshToken,
-                provider = provider.name
+                provider = provider.name,
+                subscribed = if (subscribed) 1L else 0L
             )
         }
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -186,7 +186,8 @@ fun UserEntity.toUser(): User = User(
     username,
     access_token,
     refresh_token,
-    AuthProvider.valueOf(provider)
+    AuthProvider.valueOf(provider),
+    subscribed = subscribed == 1L
 )
 
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/AccessTokenDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/AccessTokenDto.kt
@@ -6,5 +6,6 @@ import kotlinx.serialization.Serializable
 data class AccessTokenDto(
     val accessToken: String,
     val username: String,
-    val provider: String
+    val provider: String,
+    val subscribed: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/TokenPairDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/TokenPairDto.kt
@@ -8,5 +8,6 @@ data class TokenPairDto(
     val refreshToken: String,
     val username: String,
     val email: String,
-    val provider: String
+    val provider: String,
+    val subscribed: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/mapper/AuthNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/mapper/AuthNetworkMapper.kt
@@ -12,7 +12,8 @@ fun AccessTokenDto.toDomain(): AccessToken {
     return AccessToken(
         accessToken = accessToken,
         username = username,
-        provider = AuthProvider.valueOf(provider)
+        provider = AuthProvider.valueOf(provider),
+        subscribed = subscribed
     )
 }
 
@@ -22,7 +23,8 @@ fun TokenPairDto.toDomain(): TokenPair {
         refreshToken = refreshToken,
         username = username,
         email = email,
-        provider = AuthProvider.valueOf(provider)
+        provider = AuthProvider.valueOf(provider),
+        subscribed = subscribed
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/AccessToken.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/AccessToken.kt
@@ -3,5 +3,6 @@ package pl.cuyer.rusthub.domain.model
 data class AccessToken(
     val accessToken: String,
     val username: String,
-    val provider: AuthProvider
+    val provider: AuthProvider,
+    val subscribed: Boolean,
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/TokenPair.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/TokenPair.kt
@@ -5,5 +5,6 @@ data class TokenPair(
     val refreshToken: String,
     val username: String,
     val email: String,
-    val provider: AuthProvider
+    val provider: AuthProvider,
+    val subscribed: Boolean,
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/User.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/User.kt
@@ -6,4 +6,5 @@ data class User(
     val accessToken: String,
     val refreshToken: String?,
     val provider: AuthProvider,
+    val subscribed: Boolean,
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthDataSource.kt
@@ -11,6 +11,7 @@ interface AuthDataSource {
         accessToken: String,
         refreshToken: String?,
         provider: AuthProvider,
+        subscribed: Boolean,
     )
 
     suspend fun deleteUser()

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
@@ -25,7 +25,8 @@ class AuthAnonymouslyUseCase(
                             username = username,
                             accessToken = accessToken,
                             refreshToken = null,
-                            provider = provider
+                            provider = provider,
+                            subscribed = subscribed
                         )
                         tokenManager.currentToken()
                         send(Result.Success(Unit))

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
@@ -28,7 +28,8 @@ class LoginUserUseCase(
                             refreshToken = refreshToken,
                             username = this.username,
                             email = email,
-                            provider = provider
+                            provider = provider,
+                            subscribed = subscribed
                         )
                         tokenManager.currentToken()
                         send(Result.Success(Unit))

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginWithGoogleUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginWithGoogleUseCase.kt
@@ -25,7 +25,8 @@ class LoginWithGoogleUseCase(
                             username = username,
                             accessToken = accessToken,
                             refreshToken = refreshToken,
-                            provider = provider
+                            provider = provider,
+                            subscribed = subscribed
                         )
                         tokenManager.currentToken()
                         send(Result.Success(Unit))

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RegisterUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RegisterUserUseCase.kt
@@ -33,7 +33,8 @@ class RegisterUserUseCase(
                             refreshToken = refreshToken,
                             username = username,
                             email = email,
-                            provider = provider
+                            provider = provider,
+                            subscribed = subscribed
                         )
                         tokenManager.currentToken()
                         send(Result.Success(Unit))

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -538,21 +538,23 @@ CREATE TABLE userEntity (
   username      TEXT   NOT NULL,
   access_token  TEXT   NOT NULL,
   refresh_token TEXT,
-  provider TEXT NOT NULL DEFAULT 'LOCAL'
+  provider TEXT NOT NULL DEFAULT 'LOCAL',
+  subscribed INTEGER NOT NULL DEFAULT 0
 );
 
 insertUser:
 INSERT INTO userEntity (
-id, email, username, access_token, refresh_token, provider
+id, email, username, access_token, refresh_token, provider, subscribed
 ) VALUES (
-  :id, :email, :username, :accessToken, :refreshToken, :provider
+  :id, :email, :username, :accessToken, :refreshToken, :provider, :subscribed
 )
 ON CONFLICT(id) DO UPDATE SET
   email = excluded.email,
   username = excluded.username,
   access_token  = excluded.access_token,
   refresh_token = excluded.refresh_token,
-  provider = excluded.provider;
+  provider = excluded.provider,
+  subscribed = excluded.subscribed;
 
 deleteUser:
 DELETE FROM userEntity;

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
@@ -26,6 +26,7 @@ import pl.cuyer.rusthub.data.network.auth.model.RefreshRequest
 import pl.cuyer.rusthub.data.network.auth.model.TokenPairDto
 import pl.cuyer.rusthub.data.network.util.NetworkConstants
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+import pl.cuyer.rusthub.domain.model.AuthProvider
 import platform.Foundation.NSLocale
 import platform.Foundation.currentLocale
 import platform.Foundation.languageCode
@@ -61,7 +62,9 @@ actual class HttpClientFactory actual constructor(
                                 email = newTokens.email,
                                 username = newTokens.username,
                                 accessToken = newTokens.accessToken,
-                                refreshToken = newTokens.refreshToken
+                                refreshToken = newTokens.refreshToken,
+                                provider = AuthProvider.valueOf(newTokens.provider),
+                                subscribed = newTokens.subscribed
                             )
                             BearerTokens(newTokens.accessToken, newTokens.refreshToken)
                         } else null


### PR DESCRIPTION
## Summary
- persist `subscribed` status for users
- expose subscription info in auth models
- map new property through network mappers and use-cases
- include subscription when refreshing tokens

## Testing
- `./gradlew -q assemble` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865577e953c83218997461469239f08