### PR TITLE
Show expiry info for anonymous accounts

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -107,6 +107,7 @@ fun SettingsScreen(
                 username = state.value.username,
                 provider = state.value.provider,
                 subscribed = state.value.subscribed,
+                expirationDays = state.value.anonymousExpirationDays,
                 onAction = onAction
             )
         } else {
@@ -121,6 +122,7 @@ fun SettingsScreen(
                 username = state.value.username,
                 provider = state.value.provider,
                 subscribed = state.value.subscribed,
+                expirationDays = state.value.anonymousExpirationDays,
                 onAction = onAction
             )
         }
@@ -135,6 +137,7 @@ private fun SettingsScreenCompact(
     language: Language,
     provider: AuthProvider?,
     subscribed: Boolean,
+    expirationDays: Int?,
     onAction: (SettingsAction) -> Unit
 ) {
     Column(
@@ -144,7 +147,7 @@ private fun SettingsScreenCompact(
         GreetingSection(username)
         PreferencesSection(theme, language, onAction)
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
-        AccountSection(provider, subscribed, onAction)
+        AccountSection(provider, subscribed, expirationDays, onAction)
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
         OtherSection(onAction)
     }
@@ -158,6 +161,7 @@ private fun SettingsScreenExpanded(
     language: Language,
     provider: AuthProvider?,
     subscribed: Boolean,
+    expirationDays: Int?,
     onAction: (SettingsAction) -> Unit
 ) {
     Row(
@@ -173,7 +177,7 @@ private fun SettingsScreenExpanded(
             GreetingSection(username)
             PreferencesSection(theme, language, onAction)
             HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
-            AccountSection(provider, subscribed, onAction)
+            AccountSection(provider, subscribed, expirationDays, onAction)
         }
         Column(
             modifier = Modifier
@@ -231,6 +235,7 @@ private fun PreferencesSection(
 private fun AccountSection(
     provider: AuthProvider?,
     subscribed: Boolean,
+    expirationDays: Int?,
     onAction: (SettingsAction) -> Unit
 ) {
     Text(
@@ -278,6 +283,14 @@ private fun AccountSection(
     }
 
     if (provider == AuthProvider.ANONYMOUS) {
+        expirationDays?.let {
+            Text(
+                text = "Your temporary account expires in $it days. Upgrade to keep favourites and wipe alerts.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(bottom = spacing.small)
+            )
+        }
         AppTextButton(
             onClick = { onAction(SettingsAction.OnUpgradeAccount) }
         ) {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
@@ -10,5 +10,6 @@ data class SettingsState(
     val username: String? = null,
     val showSubscriptionDialog: Boolean = false,
     val provider: AuthProvider? = null,
-    val subscribed: Boolean = false
+    val subscribed: Boolean = false,
+    val anonymousExpirationDays: Int? = null
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -30,6 +30,7 @@ import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
+import pl.cuyer.rusthub.util.anonymousAccountExpiresInDays
 
 class SettingsViewModel(
     private val getSettingsUseCase: GetSettingsUseCase,
@@ -111,7 +112,14 @@ class SettingsViewModel(
             it.copy(
                 username = user?.username,
                 provider = user?.provider,
-                subscribed = user?.subscribed
+                subscribed = user?.subscribed,
+                anonymousExpirationDays = user?.let { u ->
+                    if (u.provider == AuthProvider.ANONYMOUS) {
+                        anonymousAccountExpiresInDays(u.accessToken)
+                    } else {
+                        null
+                    }
+                }
             )
         }
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/JwtUtils.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/JwtUtils.kt
@@ -1,0 +1,32 @@
+package pl.cuyer.rusthub.util
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+private val json = Json { ignoreUnknownKeys = true }
+
+@OptIn(ExperimentalEncodingApi::class)
+fun anonymousAccountExpiresInDays(token: String): Int? {
+    val parts = token.split(".")
+    if (parts.size < 2) return null
+    val payload = parts[1]
+        .replace('-', '+')
+        .replace('_', '/')
+        .let { if (it.length % 4 != 0) it.padEnd((it.length + 3) / 4 * 4, '=') else it }
+    return try {
+        val decoded = Base64.decode(payload).decodeToString()
+        val exp = json.parseToJsonElement(decoded).jsonObject["exp"]?.jsonPrimitive?.content?.toLong()
+            ?: return null
+        val expiration = Instant.fromEpochSeconds(exp)
+        val now = Clock.System.now()
+        val days = (expiration - now).inWholeDays
+        if (days >= 0) days.toInt() else null
+    } catch (_: Exception) {
+        null
+    }
+}


### PR DESCRIPTION
## Summary
- add expiration parsing from anonymous token
- compute remaining days in SettingsViewModel
- show account expiry warning if anonymous

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865582f85288321bec7219538029376