### PR TITLE
Add anonymous account upgrade flow

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -48,9 +48,11 @@ import pl.cuyer.rusthub.android.feature.settings.ChangePasswordScreen
 import pl.cuyer.rusthub.android.feature.settings.PrivacyPolicyScreen
 import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
 import pl.cuyer.rusthub.android.feature.settings.DeleteAccountScreen
+import pl.cuyer.rusthub.android.feature.auth.UpgradeAccountScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.common.Constants
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
+import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
@@ -60,6 +62,7 @@ import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.Credentials
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
+import pl.cuyer.rusthub.presentation.navigation.UpgradeAccount
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings
@@ -203,6 +206,20 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                             val viewModel = koinViewModel<DeleteAccountViewModel>()
                             val state = viewModel.state.collectAsStateWithLifecycle()
                             DeleteAccountScreen(
+                                onNavigateUp = { backStack.removeLastOrNull() },
+                                onNavigate = { dest ->
+                                    if (dest is Onboarding) backStack.clear()
+                                    backStack.add(dest)
+                                },
+                                uiEvent = viewModel.uiEvent,
+                                stateProvider = { state },
+                                onAction = viewModel::onAction
+                            )
+                        }
+                        entry<UpgradeAccount> {
+                            val viewModel = koinViewModel<UpgradeViewModel>()
+                            val state = viewModel.state.collectAsStateWithLifecycle()
+                            UpgradeAccountScreen(
                                 onNavigateUp = { backStack.removeLastOrNull() },
                                 onNavigate = { dest ->
                                     if (dest is Onboarding) backStack.clear()

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/UpgradeAccountScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/UpgradeAccountScreen.kt
@@ -1,0 +1,100 @@
+package pl.cuyer.rusthub.android.feature.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppSecureTextField
+import pl.cuyer.rusthub.android.designsystem.AppTextField
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeAction
+import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeState
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun UpgradeAccountScreen(
+    onNavigate: (NavKey) -> Unit,
+    uiEvent: Flow<UiEvent>,
+    stateProvider: () -> State<UpgradeState>,
+    onAction: (UpgradeAction) -> Unit,
+    onNavigateUp: () -> Unit = {},
+) {
+    val state = stateProvider()
+    ObserveAsEvents(uiEvent) { event ->
+        when (event) {
+            is UiEvent.Navigate -> onNavigate(event.destination)
+            is UiEvent.NavigateUp -> onNavigateUp()
+        }
+    }
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Upgrade account") },
+                navigationIcon = {
+                    IconButton(onClick = { onAction(UpgradeAction.OnNavigateUp) }) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate up")
+                    }
+                },
+                scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .padding(spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(spacing.medium)
+        ) {
+            AppTextField(
+                requestFocus = true,
+                value = state.value.username,
+                onValueChange = { onAction(UpgradeAction.OnUsernameChange(it)) },
+                labelText = "Username",
+                placeholderText = "Enter username",
+                isError = state.value.usernameError != null,
+                errorText = state.value.usernameError,
+                modifier = Modifier.fillMaxWidth()
+            )
+            AppSecureTextField(
+                value = state.value.password,
+                onValueChange = { onAction(UpgradeAction.OnPasswordChange(it)) },
+                labelText = "Password",
+                placeholderText = "Enter password",
+                onSubmit = { onAction(UpgradeAction.OnSubmit) },
+                isError = state.value.passwordError != null,
+                errorText = state.value.passwordError,
+                modifier = Modifier.fillMaxWidth()
+            )
+            AppButton(
+                onClick = { onAction(UpgradeAction.OnSubmit) },
+                isLoading = state.value.isLoading,
+                enabled = state.value.username.isNotBlank() && state.value.password.isNotBlank(),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Upgrade")
+            }
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -10,6 +10,7 @@ import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
+import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
@@ -95,6 +96,14 @@ actual val platformModule: Module = module {
             passwordValidator = get(),
             usernameValidator = get(),
             getUserUseCase = get()
+        )
+    }
+    viewModel {
+        UpgradeViewModel(
+            upgradeAccountUseCase = get(),
+            snackbarController = get(),
+            usernameValidator = get(),
+            passwordValidator = get()
         )
     }
     viewModel { (serverId: Long, serverName: String?) ->

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
@@ -80,13 +80,12 @@ class AuthRepositoryImpl(
     }
 
     override fun upgrade(
-        email: String,
         username: String,
         password: String
     ): Flow<Result<TokenPair>> {
         return safeApiCall<TokenPairDto> {
             httpClient.post(NetworkConstants.BASE_URL + "auth/upgrade") {
-                setBody(UpgradeRequest(email, username, password))
+                setBody(UpgradeRequest(username, password))
             }
         }.map { result ->
             when (result) {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/UpgradeRequest.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/UpgradeRequest.kt
@@ -1,7 +1,6 @@
 package pl.cuyer.rusthub.data.network.auth.model
 
 data class UpgradeRequest(
-    val email: String,
     val username: String,
     val password: String
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
@@ -10,7 +10,7 @@ interface AuthRepository {
     fun register(email: String, password: String, username: String): Flow<Result<TokenPair>>
     fun login(username: String, password: String): Flow<Result<TokenPair>>
     fun refresh(refreshToken: String): Flow<Result<TokenPair>>
-    fun upgrade(email: String, username: String, password: String): Flow<Result<TokenPair>>
+    fun upgrade(username: String, password: String): Flow<Result<TokenPair>>
     fun authAnonymously(): Flow<Result<AccessToken>>
     fun loginWithGoogle(token: String): Flow<Result<TokenPair>>
     fun logout(): Flow<Result<Unit>>

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeAccountUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeAccountUseCase.kt
@@ -1,0 +1,42 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import app.cash.paging.ExperimentalPagingApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.MessagingTokenManager
+
+class UpgradeAccountUseCase(
+    private val repository: AuthRepository,
+    private val dataSource: AuthDataSource,
+    private val tokenManager: MessagingTokenManager,
+) {
+    @OptIn(ExperimentalPagingApi::class)
+    operator fun invoke(username: String, password: String): Flow<Result<Unit>> = channelFlow {
+        repository.upgrade(username, password).collectLatest { result ->
+            when (result) {
+                is Result.Success -> {
+                    with(result.data) {
+                        dataSource.insertUser(
+                            email = email,
+                            username = username,
+                            accessToken = accessToken,
+                            refreshToken = refreshToken,
+                            provider = provider,
+                            subscribed = subscribed,
+                        )
+                        tokenManager.currentToken()
+                        send(Result.Success(Unit))
+                    }
+                }
+
+                is Result.Error -> send(Result.Error(result.exception))
+
+                is Result.Loading -> send(Result.Loading)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -53,6 +53,7 @@ import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginWithGoogleUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteAccountUseCase
+import pl.cuyer.rusthub.domain.usecase.UpgradeAccountUseCase
 import pl.cuyer.rusthub.domain.usecase.CheckUserExistsUseCase
 import pl.cuyer.rusthub.domain.usecase.RegisterUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
@@ -118,6 +119,7 @@ val appModule = module {
     single { GetUserUseCase(get()) }
     single { LogoutUserUseCase(get(), get()) }
     single { DeleteAccountUseCase(get(), get()) }
+    single { UpgradeAccountUseCase(get(), get(), get()) }
     single { GetSettingsUseCase(get()) }
     single { SaveSettingsUseCase(get()) }
     single { SettingsController(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeAction.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.presentation.features.auth.upgrade
+
+sealed interface UpgradeAction {
+    data object OnSubmit : UpgradeAction
+    data class OnUsernameChange(val username: String) : UpgradeAction
+    data class OnPasswordChange(val password: String) : UpgradeAction
+    data object OnNavigateUp : UpgradeAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeState.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.presentation.features.auth.upgrade
+
+data class UpgradeState(
+    val username: String = "",
+    val password: String = "",
+    val usernameError: String? = null,
+    val passwordError: String? = null,
+    val isLoading: Boolean = false,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeViewModel.kt
@@ -1,0 +1,105 @@
+package pl.cuyer.rusthub.presentation.features.auth.upgrade
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.usecase.UpgradeAccountUseCase
+import pl.cuyer.rusthub.presentation.navigation.ServerList
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.validator.PasswordValidator
+import pl.cuyer.rusthub.util.validator.UsernameValidator
+
+class UpgradeViewModel(
+    private val upgradeAccountUseCase: UpgradeAccountUseCase,
+    private val snackbarController: SnackbarController,
+    private val usernameValidator: UsernameValidator,
+    private val passwordValidator: PasswordValidator,
+) : BaseViewModel() {
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(UpgradeState())
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = UpgradeState()
+    )
+
+    private var submitJob: Job? = null
+
+    fun onAction(action: UpgradeAction) {
+        when (action) {
+            UpgradeAction.OnSubmit -> submit()
+            is UpgradeAction.OnUsernameChange -> updateUsername(action.username)
+            is UpgradeAction.OnPasswordChange -> updatePassword(action.password)
+            UpgradeAction.OnNavigateUp -> navigateUp()
+        }
+    }
+
+    private fun navigateUp() {
+        coroutineScope.launch { _uiEvent.send(UiEvent.NavigateUp) }
+    }
+
+    private fun updateUsername(username: String) {
+        _state.update { it.copy(username = username, usernameError = null) }
+    }
+
+    private fun updatePassword(password: String) {
+        _state.update { it.copy(password = password, passwordError = null) }
+    }
+
+    private fun submit() {
+        submitJob?.cancel()
+        submitJob = coroutineScope.launch {
+            val usernameResult = usernameValidator.validate(_state.value.username)
+            val passwordResult = passwordValidator.validate(_state.value.password)
+            _state.update {
+                it.copy(
+                    usernameError = usernameResult.errorMessage,
+                    passwordError = passwordResult.errorMessage,
+                )
+            }
+            if (!usernameResult.isValid || !passwordResult.isValid) {
+                snackbarController.sendEvent(
+                    SnackbarEvent("Please correct the errors above and try again.")
+                )
+                return@launch
+            }
+            upgradeAccountUseCase(_state.value.username, _state.value.password)
+                .onStart { updateLoading(true) }
+                .onCompletion { updateLoading(false) }
+                .catch { e -> showErrorSnackbar(e.message ?: "Unknown error") }
+                .collectLatest { result ->
+                    when (result) {
+                        is Result.Success -> _uiEvent.send(UiEvent.Navigate(ServerList))
+                        is Result.Error -> showErrorSnackbar(
+                            result.exception.message ?: "Unable to upgrade account"
+                        )
+                        else -> Unit
+                    }
+                }
+        }
+    }
+
+    private fun updateLoading(isLoading: Boolean) {
+        _state.update { it.copy(isLoading = isLoading) }
+    }
+
+    private fun showErrorSnackbar(message: String) {
+        coroutineScope.launch { snackbarController.sendEvent(SnackbarEvent(message)) }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -24,9 +24,9 @@ import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.LogoutUserUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.presentation.navigation.ChangePassword
-import pl.cuyer.rusthub.presentation.navigation.Credentials
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
+import pl.cuyer.rusthub.presentation.navigation.UpgradeAccount
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
@@ -68,7 +68,7 @@ class SettingsViewModel(
             SettingsAction.OnSubscribe -> showSubscriptionDialog(false)
             SettingsAction.OnPrivacyPolicy -> openPrivacyPolicy()
             SettingsAction.OnDeleteAccount -> navigateDeleteAccount()
-            SettingsAction.OnUpgradeAccount -> navigateRegister()
+            SettingsAction.OnUpgradeAccount -> navigateUpgrade()
         }
     }
 
@@ -88,9 +88,9 @@ class SettingsViewModel(
         }
     }
 
-    private fun navigateRegister() {
+    private fun navigateUpgrade() {
         coroutineScope.launch {
-            _uiEvent.send(UiEvent.Navigate(Credentials("", false)))
+            _uiEvent.send(UiEvent.Navigate(UpgradeAccount))
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -28,6 +28,9 @@ data object ChangePassword : NavKey
 data object DeleteAccount : NavKey
 
 @Serializable
+data object UpgradeAccount : NavKey
+
+@Serializable
 data class ServerDetails(
     val id: Long,
     val name: String

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -12,6 +12,7 @@ import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
+import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.util.ClipboardHandler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
@@ -75,6 +76,14 @@ actual val platformModule: Module = module {
             passwordValidator = get(),
             usernameValidator = get(),
             getUserUseCase = get()
+        )
+    }
+    factory {
+        UpgradeViewModel(
+            upgradeAccountUseCase = get(),
+            snackbarController = get(),
+            usernameValidator = get(),
+            passwordValidator = get()
         )
     }
 }


### PR DESCRIPTION
## Summary
- implement repository and request changes for anonymous account upgrade
- add `UpgradeAccountUseCase`
- create upgrade screen, state, action and viewmodel
- navigate to the upgrade screen from Settings
- wire up viewmodel in Koin modules and Android navigation

## Testing
- `./gradlew --version`
- `./gradlew assemble -x sign -x :androidApp:packageRelease` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686560f8cba8832184cfc2c883473f69