### PR TITLE
Add Google upgrade option

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/UpgradeAccountScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/UpgradeAccountScreen.kt
@@ -1,10 +1,21 @@
 package pl.cuyer.rusthub.android.feature.auth
 
+import android.app.Activity
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -12,26 +23,44 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.Flow
 import pl.cuyer.rusthub.android.designsystem.AppButton
 import pl.cuyer.rusthub.android.designsystem.AppSecureTextField
 import pl.cuyer.rusthub.android.designsystem.AppTextField
+import pl.cuyer.rusthub.android.designsystem.SignProviderButton
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.common.getImageByFileName
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeAction
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeState
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(
+    ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalSharedTransitionApi::class,
+    ExperimentalMaterial3Api::class,
+)
 @Composable
 fun UpgradeAccountScreen(
     uiEvent: Flow<UiEvent>,
@@ -40,78 +69,170 @@ fun UpgradeAccountScreen(
     onNavigateUp: () -> Unit = {},
 ) {
     val state = stateProvider()
+    val context = LocalContext.current
+    val focusManager = LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val windowSizeClass = calculateWindowSizeClass(context as Activity)
+    val isTabletMode = windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium
+
     ObserveAsEvents(uiEvent) { event ->
-        when (event) {
-            is UiEvent.NavigateUp -> onNavigateUp()
-            else -> Unit
-        }
+        if (event is UiEvent.NavigateUp) onNavigateUp()
     }
+
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("Upgrade account") },
                 navigationIcon = {
                     IconButton(onClick = { onAction(UpgradeAction.OnNavigateUp) }) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Navigate up"
-                        )
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate up")
                     }
                 },
-                scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(),
+                scrollBehavior = scrollBehavior
             )
         }
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(innerPadding)
-                .padding(spacing.medium),
-            verticalArrangement = Arrangement.spacedBy(spacing.medium)
-        ) {
-            AppTextField(
-                requestFocus = true,
-                value = state.value.username,
-                onValueChange = { onAction(UpgradeAction.OnUsernameChange(it)) },
-                labelText = "Username",
-                placeholderText = "Enter username",
-                isError = state.value.usernameError != null,
-                errorText = state.value.usernameError,
-                modifier = Modifier.fillMaxWidth(),
-                imeAction = ImeAction.Next,
-                keyboardType = KeyboardType.Text
-            )
-            AppTextField(
-                value = state.value.email,
-                onValueChange = { onAction(UpgradeAction.OnEmailChange(it)) },
-                labelText = "E-mail",
-                placeholderText = "Enter e-mail",
-                isError = state.value.emailError != null,
-                errorText = state.value.emailError,
-                modifier = Modifier.fillMaxWidth(),
-                imeAction = ImeAction.Next,
-                keyboardType = KeyboardType.Email
-            )
-            AppSecureTextField(
-                value = state.value.password,
-                onValueChange = { onAction(UpgradeAction.OnPasswordChange(it)) },
-                labelText = "Password",
-                placeholderText = "Enter password",
-                onSubmit = { onAction(UpgradeAction.OnSubmit) },
-                isError = state.value.passwordError != null,
-                errorText = state.value.passwordError,
-                modifier = Modifier.fillMaxWidth(),
-                imeAction = if (state.value.username.isNotBlank() && state.value.email.isNotBlank() && state.value.password.isNotBlank()) ImeAction.Send else ImeAction.Done,
-            )
-            AppButton(
-                onClick = { onAction(UpgradeAction.OnSubmit) },
-                isLoading = state.value.isLoading,
-                enabled = state.value.username.isNotBlank() && state.value.password.isNotBlank() && state.value.email.isNotBlank(),
-                modifier = Modifier.fillMaxWidth()
+        LookaheadScope {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .animateBounds(this)
+                    .clickable(interactionSource, null) { focusManager.clearFocus() }
             ) {
-                Text("Upgrade")
+                if (isTabletMode) {
+                    UpgradeScreenExpanded(state.value, onAction)
+                } else {
+                    UpgradeScreenCompact(state.value, onAction)
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun UpgradeScreenCompact(state: UpgradeState, onAction: (UpgradeAction) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(spacing.medium),
+        verticalArrangement = Arrangement.spacedBy(spacing.small)
+    ) {
+        UpgradeStaticContent()
+        UpgradeFields(state, onAction)
+        AppButton(
+            onClick = { onAction(UpgradeAction.OnSubmit) },
+            isLoading = state.isLoading,
+            enabled = state.username.isNotBlank() &&
+                state.password.isNotBlank() &&
+                state.email.isNotBlank(),
+            modifier = Modifier
+                .imePadding()
+                .fillMaxWidth()
+        ) { Text("Upgrade") }
+    }
+}
+
+@Composable
+private fun UpgradeScreenExpanded(state: UpgradeState, onAction: (UpgradeAction) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = spacing.medium),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        UpgradeStaticContent(modifier = Modifier.weight(1f))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.small)
+        ) {
+            UpgradeFields(state, onAction)
+            AppButton(
+                onClick = { onAction(UpgradeAction.OnSubmit) },
+                isLoading = state.isLoading,
+                enabled = state.username.isNotBlank() &&
+                    state.password.isNotBlank() &&
+                    state.email.isNotBlank(),
+                modifier = Modifier
+                    .imePadding()
+                    .fillMaxWidth()
+            ) { Text("Upgrade") }
+        }
+    }
+}
+
+@Composable
+private fun UpgradeStaticContent(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Icon(
+            modifier = Modifier.size(64.dp),
+            painter = painterResource(getImageByFileName("ic_padlock").drawableResId),
+            contentDescription = "Padlock Icon"
+        )
+        Spacer(Modifier.size(spacing.small))
+        Text(text = "Upgrade your account", style = MaterialTheme.typography.headlineLarge)
+        Spacer(Modifier.size(spacing.small))
+        Text(
+            text = "Provide credentials or connect Google account to upgrade.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+private fun UpgradeFields(state: UpgradeState, onAction: (UpgradeAction) -> Unit) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(spacing.small)) {
+        AppTextField(
+            requestFocus = true,
+            value = state.username,
+            onValueChange = { onAction(UpgradeAction.OnUsernameChange(it)) },
+            labelText = "Username",
+            placeholderText = "Enter username",
+            isError = state.usernameError != null,
+            errorText = state.usernameError,
+            modifier = Modifier.fillMaxWidth(),
+            imeAction = ImeAction.Next,
+            keyboardType = KeyboardType.Text
+        )
+        AppTextField(
+            value = state.email,
+            onValueChange = { onAction(UpgradeAction.OnEmailChange(it)) },
+            labelText = "E-mail",
+            placeholderText = "Enter e-mail",
+            isError = state.emailError != null,
+            errorText = state.emailError,
+            modifier = Modifier.fillMaxWidth(),
+            imeAction = ImeAction.Next,
+            keyboardType = KeyboardType.Email
+        )
+        AppSecureTextField(
+            value = state.password,
+            onValueChange = { onAction(UpgradeAction.OnPasswordChange(it)) },
+            labelText = "Password",
+            placeholderText = "Enter password",
+            onSubmit = { onAction(UpgradeAction.OnSubmit) },
+            isError = state.passwordError != null,
+            errorText = state.passwordError,
+            modifier = Modifier.fillMaxWidth(),
+            imeAction = if (
+                state.username.isNotBlank() &&
+                    state.email.isNotBlank() &&
+                    state.password.isNotBlank()
+            ) ImeAction.Send else ImeAction.Done
+        )
+        SignProviderButton(
+            image = getImageByFileName("ic_google").drawableResId,
+            contentDescription = "Google logo",
+            text = "Upgrade with Google",
+            modifier = Modifier.fillMaxWidth(),
+            isLoading = state.googleLoading,
+            backgroundColor = if (isSystemInDarkTheme()) Color.White else Color.Black,
+            contentColor = if (isSystemInDarkTheme()) Color.Black else Color.White,
+        ) { onAction(UpgradeAction.OnGoogleLogin) }
     }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -101,6 +101,9 @@ actual val platformModule: Module = module {
     viewModel {
         UpgradeViewModel(
             upgradeAccountUseCase = get(),
+            upgradeWithGoogleUseCase = get(),
+            getGoogleClientIdUseCase = get(),
+            googleAuthClient = get(),
             snackbarController = get(),
             usernameValidator = get(),
             passwordValidator = get(),

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
@@ -86,7 +86,13 @@ class AuthRepositoryImpl(
     ): Flow<Result<TokenPair>> {
         return safeApiCall<TokenPairDto> {
             httpClient.post(NetworkConstants.BASE_URL + "auth/upgrade") {
-                setBody(UpgradeRequest(username, email, password))
+                setBody(
+                    UpgradeRequest(
+                        username = username,
+                        password = password,
+                        email = email,
+                    )
+                )
             }
         }.map { result ->
             when (result) {
@@ -113,6 +119,20 @@ class AuthRepositoryImpl(
         return safeApiCall<TokenPairDto> {
             httpClient.post(NetworkConstants.BASE_URL + "auth/google") {
                 setBody(GoogleLoginRequest(token))
+            }
+        }.map { result ->
+            when (result) {
+                is Result.Success -> Result.Success(result.data.toDomain())
+                is Result.Error -> result
+                is Result.Loading -> Result.Loading
+            }
+        }
+    }
+
+    override fun upgradeWithGoogle(token: String): Flow<Result<TokenPair>> {
+        return safeApiCall<TokenPairDto> {
+            httpClient.post(NetworkConstants.BASE_URL + "auth/upgrade") {
+                setBody(UpgradeRequest(token = token))
             }
         }.map { result ->
             when (result) {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/UpgradeRequest.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/UpgradeRequest.kt
@@ -4,7 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UpgradeRequest(
-    val username: String,
-    val email: String,
-    val password: String
+    val username: String? = null,
+    val password: String? = null,
+    val email: String? = null,
+    val token: String? = null,
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
@@ -13,6 +13,7 @@ interface AuthRepository {
     fun upgrade(username: String, email: String, password: String): Flow<Result<TokenPair>>
     fun authAnonymously(): Flow<Result<AccessToken>>
     fun loginWithGoogle(token: String): Flow<Result<TokenPair>>
+    fun upgradeWithGoogle(token: String): Flow<Result<TokenPair>>
     fun logout(): Flow<Result<Unit>>
     fun deleteAccount(username: String, password: String): Flow<Result<Unit>>
     fun checkUserExists(email: String): Flow<Result<UserExistsInfo>>

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeWithGoogleUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeWithGoogleUseCase.kt
@@ -1,0 +1,40 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import app.cash.paging.ExperimentalPagingApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.MessagingTokenManager
+
+class UpgradeWithGoogleUseCase(
+    private val repository: AuthRepository,
+    private val dataSource: AuthDataSource,
+    private val tokenManager: MessagingTokenManager,
+) {
+    @OptIn(ExperimentalPagingApi::class)
+    operator fun invoke(token: String): Flow<Result<Unit>> = channelFlow {
+        repository.upgradeWithGoogle(token).collectLatest { result ->
+            when (result) {
+                is Result.Success -> {
+                    with(result.data) {
+                        dataSource.insertUser(
+                            email = email,
+                            username = username,
+                            accessToken = accessToken,
+                            refreshToken = refreshToken,
+                            provider = provider,
+                            subscribed = subscribed,
+                        )
+                        tokenManager.currentToken()
+                        send(Result.Success(Unit))
+                    }
+                }
+                is Result.Error -> send(Result.Error(result.exception))
+                is Result.Loading -> send(Result.Loading)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -61,6 +61,7 @@ import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSettingsUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleFavouriteUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleSubscriptionUseCase
+import pl.cuyer.rusthub.domain.usecase.UpgradeWithGoogleUseCase
 import pl.cuyer.rusthub.presentation.settings.SettingsController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.util.MessagingTokenManager
@@ -120,6 +121,7 @@ val appModule = module {
     single { LogoutUserUseCase(get(), get()) }
     single { DeleteAccountUseCase(get(), get()) }
     single { UpgradeAccountUseCase(get(), get(), get()) }
+    single { UpgradeWithGoogleUseCase(get(), get(), get()) }
     single { GetSettingsUseCase(get()) }
     single { SaveSettingsUseCase(get()) }
     single { SettingsController(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeAction.kt
@@ -6,4 +6,5 @@ sealed interface UpgradeAction {
     data class OnUsernameChange(val username: String) : UpgradeAction
     data class OnPasswordChange(val password: String) : UpgradeAction
     data object OnNavigateUp : UpgradeAction
+    data object OnGoogleLogin : UpgradeAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeState.kt
@@ -8,4 +8,5 @@ data class UpgradeState(
     val usernameError: String? = null,
     val passwordError: String? = null,
     val isLoading: Boolean = false,
+    val googleLoading: Boolean = false,
 )

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -81,6 +81,9 @@ actual val platformModule: Module = module {
     factory {
         UpgradeViewModel(
             upgradeAccountUseCase = get(),
+            upgradeWithGoogleUseCase = get(),
+            getGoogleClientIdUseCase = get(),
+            googleAuthClient = get(),
             snackbarController = get(),
             usernameValidator = get(),
             passwordValidator = get(),


### PR DESCRIPTION
## Summary
- add API model and use case for upgrading with Google
- wire new Google upgrade use case through Koin
- support Google upgrade in UpgradeViewModel and screen
- expose upgradeWithGoogle in AuthRepository implementation

## Testing
- `./gradlew help` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865696998548321849de32005438a82