### PR TITLE
Fix: clear auth tokens using Ktor API

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -21,6 +21,7 @@ import pl.cuyer.rusthub.util.GoogleAuthClient
 import pl.cuyer.rusthub.util.LogoutScheduler
 import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.util.MessagingTokenScheduler
+import pl.cuyer.rusthub.util.TokenRefresher
 import pl.cuyer.rusthub.util.StoreNavigator
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 import pl.cuyer.rusthub.util.SyncScheduler
@@ -28,6 +29,7 @@ import pl.cuyer.rusthub.util.SyncScheduler
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory(androidContext()).create() }
     single { HttpClientFactory(get(), get()).create() }
+    single { TokenRefresher(get()) }
     single { ClipboardHandler(get()) }
     single { SyncScheduler(get()) }
     single { SubscriptionSyncScheduler(get()) }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/TokenRefresher.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/TokenRefresher.android.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerAuthProvider
+
+actual class TokenRefresher(private val httpClient: HttpClient) {
+    actual fun clear() {
+        httpClient.plugin(Auth).providers
+            .filterIsInstance<BearerAuthProvider>()
+            .forEach { it.clearToken() }
+    }
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/AuthAnonymouslyUseCase.kt
@@ -8,11 +8,13 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class AuthAnonymouslyUseCase(
     private val client: AuthRepository,
     private val dataSource: AuthDataSource,
     private val tokenManager: MessagingTokenManager,
+    private val tokenRefresher: TokenRefresher,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(): Flow<Result<Unit>> = channelFlow {
@@ -28,6 +30,7 @@ class AuthAnonymouslyUseCase(
                             provider = provider,
                             subscribed = subscribed
                         )
+                        tokenRefresher.clear()
                         tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/DeleteAccountUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/DeleteAccountUseCase.kt
@@ -6,16 +6,19 @@ import kotlinx.coroutines.flow.collectLatest
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class DeleteAccountUseCase(
     private val repository: AuthRepository,
     private val dataSource: AuthDataSource,
+    private val tokenRefresher: TokenRefresher,
 ) {
     operator fun invoke(username: String, password: String): Flow<Result<Unit>> = channelFlow {
         repository.deleteAccount(username, password).collectLatest { result ->
             when (result) {
                 is Result.Success -> {
                     dataSource.deleteUser()
+                    tokenRefresher.clear()
                     send(Result.Success(Unit))
                 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginUserUseCase.kt
@@ -8,11 +8,13 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class LoginUserUseCase(
     private val client: AuthRepository,
     private val dataSource: AuthDataSource,
     private val tokenManager: MessagingTokenManager,
+    private val tokenRefresher: TokenRefresher,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(
@@ -31,6 +33,7 @@ class LoginUserUseCase(
                             provider = provider,
                             subscribed = subscribed
                         )
+                        tokenRefresher.clear()
                         tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginWithGoogleUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LoginWithGoogleUseCase.kt
@@ -8,11 +8,13 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class LoginWithGoogleUseCase(
     private val client: AuthRepository,
     private val dataSource: AuthDataSource,
     private val tokenManager: MessagingTokenManager,
+    private val tokenRefresher: TokenRefresher,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(token: String): Flow<Result<Unit>> = channelFlow {
@@ -28,6 +30,7 @@ class LoginWithGoogleUseCase(
                             provider = provider,
                             subscribed = subscribed
                         )
+                        tokenRefresher.clear()
                         tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LogoutUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/LogoutUserUseCase.kt
@@ -2,13 +2,16 @@ package pl.cuyer.rusthub.domain.usecase
 
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.util.LogoutScheduler
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class LogoutUserUseCase(
     private val dataSource: AuthDataSource,
-    private val scheduler: LogoutScheduler
+    private val scheduler: LogoutScheduler,
+    private val tokenRefresher: TokenRefresher,
 ) {
     suspend operator fun invoke() {
         dataSource.deleteUser()
+        tokenRefresher.clear()
         scheduler.schedule()
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RegisterUserUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RegisterUserUseCase.kt
@@ -8,11 +8,13 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class RegisterUserUseCase(
     private val client: AuthRepository,
     private val dataSource: AuthDataSource,
-    private val tokenManager: MessagingTokenManager
+    private val tokenManager: MessagingTokenManager,
+    private val tokenRefresher: TokenRefresher,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(
@@ -36,6 +38,7 @@ class RegisterUserUseCase(
                             provider = provider,
                             subscribed = subscribed
                         )
+                        tokenRefresher.clear()
                         tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeAccountUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeAccountUseCase.kt
@@ -8,11 +8,13 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class UpgradeAccountUseCase(
     private val repository: AuthRepository,
     private val dataSource: AuthDataSource,
     private val tokenManager: MessagingTokenManager,
+    private val tokenRefresher: TokenRefresher,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(username: String, email: String, password: String): Flow<Result<Unit>> = channelFlow {
@@ -28,6 +30,7 @@ class UpgradeAccountUseCase(
                             provider = provider,
                             subscribed = subscribed,
                         )
+                        tokenRefresher.clear()
                         tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeWithGoogleUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/UpgradeWithGoogleUseCase.kt
@@ -8,11 +8,13 @@ import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
 import pl.cuyer.rusthub.util.MessagingTokenManager
+import pl.cuyer.rusthub.util.TokenRefresher
 
 class UpgradeWithGoogleUseCase(
     private val repository: AuthRepository,
     private val dataSource: AuthDataSource,
     private val tokenManager: MessagingTokenManager,
+    private val tokenRefresher: TokenRefresher,
 ) {
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(token: String): Flow<Result<Unit>> = channelFlow {
@@ -28,6 +30,7 @@ class UpgradeWithGoogleUseCase(
                             provider = provider,
                             subscribed = subscribed,
                         )
+                        tokenRefresher.clear()
                         tokenManager.currentToken()
                         send(Result.Success(Unit))
                     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -27,6 +27,7 @@ import pl.cuyer.rusthub.data.network.subscription.SubscriptionClientImpl
 import pl.cuyer.rusthub.domain.repository.RemoteKeyDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthDataSource
 import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+import pl.cuyer.rusthub.util.TokenRefresher
 import pl.cuyer.rusthub.domain.repository.favourite.FavouriteSyncDataSource
 import pl.cuyer.rusthub.domain.repository.favourite.network.FavouriteRepository
 import pl.cuyer.rusthub.domain.repository.filters.FiltersDataSource
@@ -99,6 +100,7 @@ val appModule = module {
     singleOf(::AuthRepositoryImpl) bind AuthRepository::class
     singleOf(::AuthDataSourceImpl) bind AuthDataSource::class
     singleOf(::ConfigRepositoryImpl) bind ConfigRepository::class
+    single { TokenRefresher(get()) }
     single { EmailValidator }
     single { PasswordValidator }
     single { UsernameValidator }
@@ -111,17 +113,17 @@ val appModule = module {
     single { GetSearchQueriesUseCase(get()) }
     single { DeleteSearchQueriesUseCase(get()) }
     single { GetServerDetailsUseCase(get()) }
-    single { RegisterUserUseCase(get(), get(), get()) }
-    single { LoginUserUseCase(get(), get(), get()) }
-    single { LoginWithGoogleUseCase(get(), get(), get()) }
+    single { RegisterUserUseCase(get(), get(), get(), get()) }
+    single { LoginUserUseCase(get(), get(), get(), get()) }
+    single { LoginWithGoogleUseCase(get(), get(), get(), get()) }
     single { GetGoogleClientIdUseCase(get()) }
-    single { AuthAnonymouslyUseCase(get(), get(), get()) }
+    single { AuthAnonymouslyUseCase(get(), get(), get(), get()) }
     single { CheckUserExistsUseCase(get()) }
     single { GetUserUseCase(get()) }
-    single { LogoutUserUseCase(get(), get()) }
-    single { DeleteAccountUseCase(get(), get()) }
-    single { UpgradeAccountUseCase(get(), get(), get()) }
-    single { UpgradeWithGoogleUseCase(get(), get(), get()) }
+    single { LogoutUserUseCase(get(), get(), get()) }
+    single { DeleteAccountUseCase(get(), get(), get()) }
+    single { UpgradeAccountUseCase(get(), get(), get(), get()) }
+    single { UpgradeWithGoogleUseCase(get(), get(), get(), get()) }
     single { GetSettingsUseCase(get()) }
     single { SaveSettingsUseCase(get()) }
     single { SettingsController(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/TokenRefresher.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/TokenRefresher.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.util
+
+import io.ktor.client.HttpClient
+
+expect class TokenRefresher(httpClient: HttpClient) {
+    fun clear()
+}
+

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -21,10 +21,12 @@ import pl.cuyer.rusthub.util.GoogleAuthClient
 import pl.cuyer.rusthub.util.MessagingTokenScheduler
 import pl.cuyer.rusthub.util.LogoutScheduler
 import dev.icerock.moko.permissions.PermissionsController
+import pl.cuyer.rusthub.util.TokenRefresher
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
     single { HttpClientFactory(get(), get()).create() }
+    single { TokenRefresher(get()) }
     single { ClipboardHandler() }
     single { SyncScheduler() }
     single { SubscriptionSyncScheduler() }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/TokenRefresher.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/TokenRefresher.ios.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.util
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerAuthProvider
+
+actual class TokenRefresher(private val httpClient: HttpClient) {
+    actual fun clear() {
+        httpClient.plugin(Auth).providers
+            .filterIsInstance<BearerAuthProvider>()
+            .forEach { it.clearToken() }
+    }
+}
+


### PR DESCRIPTION
## Summary
- rename TokenRefresher API to `clear` to match Ktor's `clearToken`
- use `clear()` in upgrade and login flows
- ensure platform initializers provide TokenRefresher

## Testing
- `./gradlew tasks --no-daemon` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686585be60d88321aaf68e6b26160f4a