### PR TITLE
Add overflow actions on server screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.NotificationsNone
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -22,6 +24,8 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -31,9 +35,12 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
@@ -104,18 +111,64 @@ fun ServerDetailsScreen(
                     )
                 },
                 actions = {
-                    IconButton(onClick = { onAction(ServerDetailsAction.OnToggleFavourite) }) {
-                        val icon =
-                            if (state.details?.isFavorite == true) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder
-                        Icon(icon, contentDescription = null)
+                    var expanded by remember { mutableStateOf(false) }
+                    val rotation by animateFloatAsState(if (expanded) 90f else 0f)
+                    IconButton(onClick = { expanded = !expanded }) {
+                        Icon(
+                            Icons.Default.MoreVert,
+                            contentDescription = null,
+                            modifier = Modifier.rotate(rotation)
+                        )
                     }
-                    IconButton(onClick = { onAction(ServerDetailsAction.OnSubscribe) }) {
-                        val icon = if (state.details?.isSubscribed == true) {
-                            Icons.Filled.Notifications
-                        } else {
-                            Icons.Outlined.NotificationsNone
-                        }
-                        Icon(icon, contentDescription = null)
+                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    if (state.details?.isFavorite == true) "Remove from favourites" else "Add to favourites"
+                                )
+                            },
+                            onClick = {
+                                expanded = false
+                                onAction(ServerDetailsAction.OnToggleFavourite)
+                            },
+                            leadingIcon = {
+                                val icon = if (state.details?.isFavorite == true) {
+                                    Icons.Filled.Favorite
+                                } else {
+                                    Icons.Outlined.FavoriteBorder
+                                }
+                                Icon(icon, contentDescription = null)
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    if (state.details?.isSubscribed == true) "Turn off notifications" else "Turn on notifications"
+                                )
+                            },
+                            onClick = {
+                                expanded = false
+                                onAction(ServerDetailsAction.OnSubscribe)
+                            },
+                            leadingIcon = {
+                                val icon = if (state.details?.isSubscribed == true) {
+                                    Icons.Filled.Notifications
+                                } else {
+                                    Icons.Outlined.NotificationsNone
+                                }
+                                Icon(icon, contentDescription = null)
+                            }
+                        )
+                        DropdownMenuItem(
+                            text = { Text("Share") },
+                            onClick = {
+                                expanded = false
+                                onAction(ServerDetailsAction.OnShare)
+                            },
+                            leadingIcon = {
+                                Icon(Icons.Default.Share, contentDescription = null)
+                            }
+                        )
                     }
                 },
                 scrollBehavior = scrollBehavior

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -25,12 +25,14 @@ import pl.cuyer.rusthub.util.StoreNavigator
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.TokenRefresher
+import pl.cuyer.rusthub.util.ShareHandler
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory(androidContext()).create() }
     single { HttpClientFactory(get(), get()).create() }
     single { TokenRefresher(get()) }
     single { ClipboardHandler(get()) }
+    single { ShareHandler(get()) }
     single { SyncScheduler(get()) }
     single { SubscriptionSyncScheduler(get()) }
     single { MessagingTokenScheduler(get()) }
@@ -120,7 +122,8 @@ actual val platformModule: Module = module {
             serverName = serverName,
             serverId = serverId,
             clipboardHandler = get(),
-            snackbarController = get()
+            snackbarController = get(),
+            shareHandler = get()
         )
     }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/ShareHandler.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/ShareHandler.android.kt
@@ -1,0 +1,18 @@
+package pl.cuyer.rusthub.util
+
+import android.content.Context
+import android.content.Intent
+
+actual class ShareHandler(private val context: Context) {
+    actual fun share(text: String) {
+        val sendIntent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val chooser = Intent.createChooser(sendIntent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(chooser)
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsAction.kt
@@ -6,4 +6,5 @@ sealed interface ServerDetailsAction {
     data object OnSubscribe : ServerDetailsAction
     data object OnDismissSubscriptionDialog : ServerDetailsAction
     data object OnDismissNotificationInfo : ServerDetailsAction
+    data object OnShare : ServerDetailsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -37,10 +37,12 @@ import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
 import pl.cuyer.rusthub.util.ClipboardHandler
+import pl.cuyer.rusthub.util.ShareHandler
 
 class ServerDetailsViewModel(
     private val clipboardHandler: ClipboardHandler,
     private val snackbarController: SnackbarController,
+    private val shareHandler: ShareHandler,
     private val getServerDetailsUseCase: GetServerDetailsUseCase,
     private val toggleFavouriteUseCase: ToggleFavouriteUseCase,
     private val toggleSubscriptionUseCase: ToggleSubscriptionUseCase,
@@ -74,6 +76,7 @@ class ServerDetailsViewModel(
             ServerDetailsAction.OnDismissSubscriptionDialog -> showSubscriptionDialog(false)
             ServerDetailsAction.OnDismissNotificationInfo -> showNotificationInfo(false)
             ServerDetailsAction.OnSubscribe -> handleSubscribeAction()
+            ServerDetailsAction.OnShare -> shareServer()
         }
     }
 
@@ -103,6 +106,12 @@ class ServerDetailsViewModel(
                 )
             )
         }
+    }
+
+    private fun shareServer() {
+        val ip = state.value.details?.serverIp ?: return
+        val name = state.value.serverName ?: "Rust Server"
+        shareHandler.share("Join $name at $ip")
     }
 
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/ShareHandler.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/ShareHandler.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+expect class ShareHandler {
+    fun share(text: String)
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -20,12 +20,14 @@ import pl.cuyer.rusthub.util.StoreNavigator
 import pl.cuyer.rusthub.util.SubscriptionSyncScheduler
 import pl.cuyer.rusthub.util.SyncScheduler
 import pl.cuyer.rusthub.util.TokenRefresher
+import pl.cuyer.rusthub.util.ShareHandler
 
 actual val platformModule: Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
     single { HttpClientFactory(get(), get()).create() }
     single { TokenRefresher(get()) }
     single { ClipboardHandler() }
+    single { ShareHandler() }
     single { SyncScheduler() }
     single { SubscriptionSyncScheduler() }
     single { MessagingTokenScheduler() }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/ShareHandler.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/ShareHandler.ios.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.util
+
+actual class ShareHandler {
+    actual fun share(text: String) {
+        // no-op for iOS
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ShareHandler` with expect/actual implementations
- register `ShareHandler` in Koin modules
- extend `ServerDetailsViewModel` and action sealed class to support sharing
- replace favourite/subscribe icons with overflow menu in `ServerDetailsScreen`
- animate the overflow icon when expanded

## Testing
- No tests run per repository guidelines

------
https://chatgpt.com/codex/tasks/task_e_6866a7cb96d88321ac7208693942bf1b