### PR TITLE
Add change password screen and logic

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -53,6 +53,7 @@ import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.common.Constants
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
+import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordViewModel
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
@@ -227,7 +228,14 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                             )
                         }
                         entry<ChangePassword> {
-                            ChangePasswordScreen(onNavigateUp = { backStack.removeLastOrNull() })
+                            val viewModel = koinViewModel<ChangePasswordViewModel>()
+                            val state = viewModel.state.collectAsStateWithLifecycle()
+                            ChangePasswordScreen(
+                                onNavigateUp = { backStack.removeLastOrNull() },
+                                uiEvent = viewModel.uiEvent,
+                                stateProvider = { state },
+                                onAction = viewModel::onAction
+                            )
                         }
 
                         entry<PrivacyPolicy> {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/ChangePasswordScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/ChangePasswordScreen.kt
@@ -1,27 +1,81 @@
 package pl.cuyer.rusthub.android.feature.settings
 
-import androidx.compose.foundation.layout.Box
+import android.app.Activity
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppSecureTextField
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.common.getImageByFileName
+import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordAction
+import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordState
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(
+    ExperimentalMaterial3Api::class, ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalSharedTransitionApi::class
+)
 @Composable
-fun ChangePasswordScreen(onNavigateUp: () -> Unit) {
+fun ChangePasswordScreen(
+    onNavigateUp: () -> Unit,
+    uiEvent: Flow<UiEvent>,
+    stateProvider: () -> State<ChangePasswordState>,
+    onAction: (ChangePasswordAction) -> Unit
+) {
+    val state = stateProvider()
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.NavigateUp) onNavigateUp()
+    }
+
+    val context = LocalContext.current
+    val windowSizeClass = calculateWindowSizeClass(context as Activity)
+    val isTabletMode = windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium
+    val interactionSource = remember { MutableInteractionSource() }
+    val focusManager = LocalFocusManager.current
+
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Change password") },
+                title = { },
                 navigationIcon = {
                     IconButton(onClick = onNavigateUp) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
@@ -30,13 +84,165 @@ fun ChangePasswordScreen(onNavigateUp: () -> Unit) {
             )
         }
     ) { innerPadding ->
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-            contentAlignment = Alignment.Center
-        ) {
-            Text("Feature coming soon")
+        LookaheadScope {
+            if (isTabletMode) {
+                ChangePasswordScreenExpanded(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .padding(spacing.medium)
+                        .animateBounds(this)
+                        .clickable(interactionSource, null) { focusManager.clearFocus() },
+                    state = state.value,
+                    onAction = onAction
+                )
+            } else {
+                ChangePasswordScreenCompact(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(innerPadding)
+                        .padding(spacing.medium)
+                        .animateBounds(this)
+                        .clickable(interactionSource, null) { focusManager.clearFocus() },
+                    state = state.value,
+                    onAction = onAction
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun ChangePasswordScreenCompact(
+    modifier: Modifier = Modifier,
+    state: ChangePasswordState,
+    onAction: (ChangePasswordAction) -> Unit
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacing.small)
+    ) {
+        val focusManager = LocalFocusManager.current
+        ChangePasswordStaticContent()
+        ChangePasswordFields(
+            oldPassword = state.oldPassword,
+            newPassword = state.newPassword,
+            oldPasswordError = state.oldPasswordError,
+            newPasswordError = state.newPasswordError,
+            onAction = onAction
+        )
+        AppButton(
+            modifier = Modifier
+                .imePadding()
+                .fillMaxWidth(),
+            isLoading = state.isLoading,
+            onClick = {
+                focusManager.clearFocus()
+                onAction(ChangePasswordAction.OnChange)
+            }
+        ) { Text("Change password") }
+    }
+}
+
+@Composable
+private fun ChangePasswordScreenExpanded(
+    modifier: Modifier = Modifier,
+    state: ChangePasswordState,
+    onAction: (ChangePasswordAction) -> Unit
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ChangePasswordStaticContent(modifier = Modifier.weight(1f))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.small)
+        ) {
+            val focusManager = LocalFocusManager.current
+            ChangePasswordFields(
+                oldPassword = state.oldPassword,
+                newPassword = state.newPassword,
+                oldPasswordError = state.oldPasswordError,
+                newPasswordError = state.newPasswordError,
+                onAction = onAction
+            )
+            AppButton(
+                modifier = Modifier
+                    .imePadding()
+                    .fillMaxWidth(),
+                isLoading = state.isLoading,
+                onClick = {
+                    focusManager.clearFocus()
+                    onAction(ChangePasswordAction.OnChange)
+                }
+            ) { Text("Change password") }
+        }
+    }
+}
+
+@Composable
+private fun ChangePasswordStaticContent(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Icon(
+            modifier = Modifier.size(64.dp),
+            painter = painterResource(getImageByFileName("ic_padlock").drawableResId),
+            contentDescription = "Padlock Icon"
+        )
+        Spacer(modifier = Modifier.height(spacing.small))
+        Text(
+            text = "Change password",
+            style = MaterialTheme.typography.headlineLarge
+        )
+        Spacer(modifier = Modifier.height(spacing.small))
+        Text(
+            text = "Enter your current password and pick a new one.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+private fun ChangePasswordFields(
+    oldPassword: String,
+    newPassword: String,
+    oldPasswordError: String?,
+    newPasswordError: String?,
+    onAction: (ChangePasswordAction) -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(spacing.small)
+    ) {
+        val focusManager = LocalFocusManager.current
+        AppSecureTextField(
+            requestFocus = true,
+            value = oldPassword,
+            onValueChange = { onAction(ChangePasswordAction.OnOldPasswordChange(it)) },
+            labelText = "Old password",
+            placeholderText = "Enter old password",
+            isError = oldPasswordError != null,
+            errorText = oldPasswordError,
+            modifier = Modifier.fillMaxWidth(),
+            imeAction = ImeAction.Next
+        )
+        AppSecureTextField(
+            value = newPassword,
+            onValueChange = { onAction(ChangePasswordAction.OnNewPasswordChange(it)) },
+            labelText = "New password",
+            placeholderText = "Enter new password",
+            onSubmit = {
+                focusManager.clearFocus()
+                onAction(ChangePasswordAction.OnChange)
+            },
+            isError = newPasswordError != null,
+            errorText = newPasswordError,
+            modifier = Modifier.fillMaxWidth(),
+            imeAction = if (oldPassword.isNotBlank() && newPassword.isNotBlank()) ImeAction.Send else ImeAction.Done
+        )
     }
 }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -11,6 +11,7 @@ import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
+import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordViewModel
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
@@ -99,6 +100,13 @@ actual val platformModule: Module = module {
             snackbarController = get(),
             passwordValidator = get(),
             getUserUseCase = get()
+        )
+    }
+    viewModel {
+        ChangePasswordViewModel(
+            changePasswordUseCase = get(),
+            snackbarController = get(),
+            passwordValidator = get(),
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.Json
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.data.network.auth.model.AccessTokenDto
 import pl.cuyer.rusthub.data.network.auth.model.DeleteAccountRequest
+import pl.cuyer.rusthub.data.network.auth.model.ChangePasswordRequest
 import pl.cuyer.rusthub.data.network.auth.model.GoogleLoginRequest
 import pl.cuyer.rusthub.data.network.auth.model.LoginRequest
 import pl.cuyer.rusthub.data.network.auth.model.RefreshRequest
@@ -159,6 +160,20 @@ class AuthRepositoryImpl(
         return safeApiCall<Unit> {
             httpClient.post(NetworkConstants.BASE_URL + "auth/delete") {
                 setBody(DeleteAccountRequest(password))
+            }
+        }.map { result ->
+            when (result) {
+                is Result.Success -> Result.Success(Unit)
+                is Result.Error -> result
+                Result.Loading -> Result.Loading
+            }
+        }
+    }
+
+    override fun changePassword(oldPassword: String, newPassword: String): Flow<Result<Unit>> {
+        return safeApiCall<Unit> {
+            httpClient.post(NetworkConstants.BASE_URL + "auth/password") {
+                setBody(ChangePasswordRequest(oldPassword, newPassword))
             }
         }.map { result ->
             when (result) {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/ChangePasswordRequest.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/ChangePasswordRequest.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.data.network.auth.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChangePasswordRequest(
+    val oldPassword: String,
+    val newPassword: String
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
@@ -16,5 +16,6 @@ interface AuthRepository {
     fun upgradeWithGoogle(token: String): Flow<Result<TokenPair>>
     fun logout(): Flow<Result<Unit>>
     fun deleteAccount(password: String): Flow<Result<Unit>>
+    fun changePassword(oldPassword: String, newPassword: String): Flow<Result<Unit>>
     fun checkUserExists(email: String): Flow<Result<UserExistsInfo>>
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ChangePasswordUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ChangePasswordUseCase.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+
+class ChangePasswordUseCase(
+    private val repository: AuthRepository
+) {
+    operator fun invoke(oldPassword: String, newPassword: String): Flow<Result<Unit>> =
+        repository.changePassword(oldPassword, newPassword)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -122,6 +122,7 @@ val appModule = module {
     single { GetUserUseCase(get()) }
     single { LogoutUserUseCase(get(), get(), get()) }
     single { DeleteAccountUseCase(get(), get(), get()) }
+    single { ChangePasswordUseCase(get()) }
     single { UpgradeAccountUseCase(get(), get(), get(), get()) }
     single { UpgradeWithGoogleUseCase(get(), get(), get(), get()) }
     single { GetSettingsUseCase(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ChangePasswordAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ChangePasswordAction.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.presentation.features.auth.password
+
+sealed interface ChangePasswordAction {
+    data object OnChange : ChangePasswordAction
+    data class OnOldPasswordChange(val password: String) : ChangePasswordAction
+    data class OnNewPasswordChange(val password: String) : ChangePasswordAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ChangePasswordState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ChangePasswordState.kt
@@ -1,0 +1,9 @@
+package pl.cuyer.rusthub.presentation.features.auth.password
+
+data class ChangePasswordState(
+    val oldPassword: String = "",
+    val newPassword: String = "",
+    val oldPasswordError: String? = null,
+    val newPasswordError: String? = null,
+    val isLoading: Boolean = false
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ChangePasswordViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ChangePasswordViewModel.kt
@@ -1,0 +1,102 @@
+package pl.cuyer.rusthub.presentation.features.auth.password
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.usecase.ChangePasswordUseCase
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.validator.PasswordValidator
+
+class ChangePasswordViewModel(
+    private val changePasswordUseCase: ChangePasswordUseCase,
+    private val snackbarController: SnackbarController,
+    private val passwordValidator: PasswordValidator,
+) : BaseViewModel() {
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(ChangePasswordState())
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = ChangePasswordState()
+    )
+
+    private var changeJob: Job? = null
+
+    fun onAction(action: ChangePasswordAction) {
+        when (action) {
+            ChangePasswordAction.OnChange -> change()
+            is ChangePasswordAction.OnOldPasswordChange -> updateOldPassword(action.password)
+            is ChangePasswordAction.OnNewPasswordChange -> updateNewPassword(action.password)
+        }
+    }
+
+    private fun updateOldPassword(password: String) {
+        _state.update { it.copy(oldPassword = password, oldPasswordError = null) }
+    }
+
+    private fun updateNewPassword(password: String) {
+        _state.update { it.copy(newPassword = password, newPasswordError = null) }
+    }
+
+    private fun change() {
+        changeJob?.cancel()
+        changeJob = coroutineScope.launch {
+            val oldPassword = _state.value.oldPassword
+            val newPassword = _state.value.newPassword
+            val oldResult = passwordValidator.validate(oldPassword)
+            val newResult = passwordValidator.validate(newPassword)
+            _state.update {
+                it.copy(
+                    oldPasswordError = oldResult.errorMessage,
+                    newPasswordError = newResult.errorMessage
+                )
+            }
+            if (!oldResult.isValid || !newResult.isValid) {
+                snackbarController.sendEvent(
+                    SnackbarEvent(message = "Please correct the errors above and try again.")
+                )
+                return@launch
+            }
+            changePasswordUseCase(oldPassword, newPassword)
+                .onStart { updateLoading(true) }
+                .onCompletion { updateLoading(false) }
+                .catch { e -> showErrorSnackbar(e.message ?: "Unknown error") }
+                .collectLatest { result ->
+                    when (result) {
+                        is Result.Success -> {
+                            snackbarController.sendEvent(
+                                SnackbarEvent(message = "Password changed successfully")
+                            )
+                            _uiEvent.send(UiEvent.NavigateUp)
+                        }
+                        is Result.Error -> showErrorSnackbar(result.exception.message ?: "Unable to change password")
+                        else -> Unit
+                    }
+                }
+        }
+    }
+
+    private fun updateLoading(isLoading: Boolean) {
+        _state.update { it.copy(isLoading = isLoading) }
+    }
+
+    private suspend fun showErrorSnackbar(message: String) {
+        snackbarController.sendEvent(SnackbarEvent(message = message))
+    }
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -8,6 +8,7 @@ import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
+import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordViewModel
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
@@ -77,6 +78,13 @@ actual val platformModule: Module = module {
             snackbarController = get(),
             passwordValidator = get(),
             getUserUseCase = get()
+        )
+    }
+    factory {
+        ChangePasswordViewModel(
+            changePasswordUseCase = get(),
+            snackbarController = get(),
+            passwordValidator = get(),
         )
     }
     factory {


### PR DESCRIPTION
## Summary
- implement change password screen with vertical and horizontal layouts
- add ChangePasswordViewModel and related state/actions
- create ChangePasswordUseCase and network request
- hook feature into Koin and navigation

## Testing
- `./gradlew assembleDebug` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866be0f650483218051138768260bd5