### PR TITLE
Fix PendingIntent package name

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/NotificationPresenter.android.kt
@@ -129,10 +129,11 @@ actual class NotificationPresenter(private val context: Context) {
         context.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
 
     private fun createPendingIntent(): PendingIntent {
+        val packageName = context.packageName
         val intent = Intent().apply {
             component = ComponentName(
-                PACKAGE_NAME,
-                MAIN_ACTIVITY
+                packageName,
+                "$packageName.MainActivity"
             )
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         }
@@ -142,9 +143,6 @@ actual class NotificationPresenter(private val context: Context) {
     //TODO można dodać nawigację po kliknięciu do serwera
 
     companion object {
-        const val MAIN_ACTIVITY =
-            BuildConfig.LIBRARY_PACKAGE_NAME + ".android." + BuildConfig.FLAVOR + ".MainActivity"
-        const val PACKAGE_NAME = BuildConfig.LIBRARY_PACKAGE_NAME + ".android." + BuildConfig.FLAVOR
         const val DEFAULT_CHANNEL_ID = "notification_channel_name"
     }
 }


### PR DESCRIPTION
## Summary
- ensure the notification PendingIntent resolves MainActivity by using the runtime package name

## Testing
- `gradle --version`

------
https://chatgpt.com/codex/tasks/task_e_6866d8f05af4832193544e1fce3d74c6