### PR TITLE
Add password reset support

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -50,11 +50,13 @@ import pl.cuyer.rusthub.android.feature.settings.ChangePasswordScreen
 import pl.cuyer.rusthub.android.feature.settings.DeleteAccountScreen
 import pl.cuyer.rusthub.android.feature.settings.PrivacyPolicyScreen
 import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
+import pl.cuyer.rusthub.android.feature.auth.ResetPasswordScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.common.Constants
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
 import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordViewModel
+import pl.cuyer.rusthub.presentation.features.auth.password.ResetPasswordViewModel
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.auth.confirm.ConfirmEmailViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
@@ -67,6 +69,7 @@ import pl.cuyer.rusthub.presentation.navigation.ConfirmEmail
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
+import pl.cuyer.rusthub.presentation.navigation.ResetPassword
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings
@@ -242,6 +245,17 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                                     backStack.add(dest)
                                 },
                                 onNavigateUp = { backStack.removeLastOrNull() }
+                            )
+                        }
+                        entry<ResetPassword> { key ->
+                            val viewModel: ResetPasswordViewModel =
+                                koinViewModel { parametersOf(key.email) }
+                            val state = viewModel.state.collectAsStateWithLifecycle()
+                            ResetPasswordScreen(
+                                onNavigateUp = { backStack.removeLastOrNull() },
+                                uiEvent = viewModel.uiEvent,
+                                stateProvider = { state },
+                                onAction = viewModel::onAction
                             )
                         }
                         entry<ChangePassword> {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/CredentialsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/CredentialsScreen.kt
@@ -366,7 +366,7 @@ private fun CredentialsFields(
             if (userExists) {
                 TextButton(
                     modifier = Modifier.align(Alignment.End),
-                    onClick = {}
+                    onClick = { onAction(CredentialsAction.OnForgotPassword) }
                 ) { Text(text = "Forgot password?") }
             }
         }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/ResetPasswordScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/ResetPasswordScreen.kt
@@ -1,0 +1,227 @@
+package pl.cuyer.rusthub.android.feature.auth
+
+import android.app.Activity
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppTextField
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.common.getImageByFileName
+import pl.cuyer.rusthub.presentation.features.auth.password.ResetPasswordAction
+import pl.cuyer.rusthub.presentation.features.auth.password.ResetPasswordState
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+
+@OptIn(
+    ExperimentalMaterial3Api::class,
+    ExperimentalMaterial3WindowSizeClassApi::class,
+    ExperimentalSharedTransitionApi::class
+)
+@Composable
+fun ResetPasswordScreen(
+    onNavigateUp: () -> Unit,
+    uiEvent: Flow<UiEvent>,
+    stateProvider: () -> State<ResetPasswordState>,
+    onAction: (ResetPasswordAction) -> Unit
+) {
+    val state = stateProvider()
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.NavigateUp) onNavigateUp()
+    }
+
+    val context = LocalContext.current
+    val windowSizeClass = calculateWindowSizeClass(context as Activity)
+    val isTabletMode = windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium
+    val interactionSource = remember { MutableInteractionSource() }
+    val focusManager = LocalFocusManager.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        LookaheadScope {
+            if (isTabletMode) {
+                ResetPasswordScreenExpanded(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                        .padding(spacing.medium)
+                        .animateBounds(this)
+                        .clickable(interactionSource, null) { focusManager.clearFocus() },
+                    state = state.value,
+                    onAction = onAction
+                )
+            } else {
+                ResetPasswordScreenCompact(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(innerPadding)
+                        .padding(spacing.medium)
+                        .animateBounds(this)
+                        .clickable(interactionSource, null) { focusManager.clearFocus() },
+                    state = state.value,
+                    onAction = onAction
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResetPasswordScreenCompact(
+    modifier: Modifier = Modifier,
+    state: ResetPasswordState,
+    onAction: (ResetPasswordAction) -> Unit
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(spacing.small)
+    ) {
+        val focusManager = LocalFocusManager.current
+        ResetPasswordStaticContent()
+        ResetPasswordField(
+            email = state.email,
+            emailError = state.emailError,
+            onAction = onAction
+        )
+        AppButton(
+            modifier = Modifier
+                .imePadding()
+                .fillMaxWidth(),
+            enabled = state.email.isNotBlank(),
+            isLoading = state.isLoading,
+            onClick = {
+                focusManager.clearFocus()
+                onAction(ResetPasswordAction.OnSend)
+            }
+        ) { Text("Send email") }
+    }
+}
+
+@Composable
+private fun ResetPasswordScreenExpanded(
+    modifier: Modifier = Modifier,
+    state: ResetPasswordState,
+    onAction: (ResetPasswordAction) -> Unit
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ResetPasswordStaticContent(modifier = Modifier.weight(1f))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacing.small)
+        ) {
+            val focusManager = LocalFocusManager.current
+            ResetPasswordField(
+                email = state.email,
+                emailError = state.emailError,
+                onAction = onAction
+            )
+            AppButton(
+                modifier = Modifier
+                    .imePadding()
+                    .fillMaxWidth(),
+                isLoading = state.isLoading,
+                onClick = {
+                    focusManager.clearFocus()
+                    onAction(ResetPasswordAction.OnSend)
+                }
+            ) { Text("Send email") }
+        }
+    }
+}
+
+@Composable
+private fun ResetPasswordStaticContent(modifier: Modifier = Modifier) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Icon(
+            modifier = Modifier.size(64.dp),
+            painter = painterResource(getImageByFileName("ic_padlock").drawableResId),
+            contentDescription = "Padlock Icon"
+        )
+        Spacer(modifier = Modifier.height(spacing.small))
+        Text(
+            text = "Reset password",
+            style = MaterialTheme.typography.headlineLarge
+        )
+        Spacer(modifier = Modifier.height(spacing.small))
+        Text(
+            text = "Enter your email to receive password reset link.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+private fun ResetPasswordField(
+    email: String,
+    emailError: String?,
+    onAction: (ResetPasswordAction) -> Unit
+) {
+    AppTextField(
+        requestFocus = true,
+        value = email,
+        onValueChange = { onAction(ResetPasswordAction.OnEmailChange(it)) },
+        labelText = "Email",
+        placeholderText = "Enter your email",
+        keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
+        imeAction = if (email.isNotBlank()) ImeAction.Send else ImeAction.Done,
+        onSubmit = { onAction(ResetPasswordAction.OnSend) },
+        isError = emailError != null,
+        errorText = emailError,
+        modifier = Modifier.fillMaxWidth()
+    )
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -12,6 +12,7 @@ import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
 import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordViewModel
+import pl.cuyer.rusthub.presentation.features.auth.password.ResetPasswordViewModel
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.auth.confirm.ConfirmEmailViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
@@ -107,6 +108,14 @@ actual val platformModule: Module = module {
             changePasswordUseCase = get(),
             snackbarController = get(),
             passwordValidator = get(),
+        )
+    }
+    viewModel { (email: String) ->
+        ResetPasswordViewModel(
+            email = email,
+            requestPasswordResetUseCase = get(),
+            snackbarController = get(),
+            emailValidator = get()
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/AuthRepositoryImpl.kt
@@ -16,6 +16,7 @@ import pl.cuyer.rusthub.data.network.auth.model.GoogleLoginRequest
 import pl.cuyer.rusthub.data.network.auth.model.LoginRequest
 import pl.cuyer.rusthub.data.network.auth.model.RefreshRequest
 import pl.cuyer.rusthub.data.network.auth.model.RegisterRequest
+import pl.cuyer.rusthub.data.network.auth.model.ForgotPasswordRequest
 import pl.cuyer.rusthub.data.network.auth.model.TokenPairDto
 import pl.cuyer.rusthub.data.network.auth.model.UpgradeRequest
 import pl.cuyer.rusthub.data.network.auth.model.UserExistsResponseDto
@@ -194,6 +195,20 @@ class AuthRepositoryImpl(
                 is Result.Success -> Result.Success(result.data.toDomain())
                 is Result.Error -> result
                 is Result.Loading -> Result.Loading
+            }
+        }
+    }
+
+    override fun requestPasswordReset(email: String): Flow<Result<Unit>> {
+        return safeApiCall<Unit> {
+            httpClient.post(NetworkConstants.BASE_URL + "forgot-password") {
+                setBody(ForgotPasswordRequest(email))
+            }
+        }.map { result ->
+            when (result) {
+                is Result.Success -> Result.Success(Unit)
+                is Result.Error -> result
+                Result.Loading -> Result.Loading
             }
         }
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/ForgotPasswordRequest.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/auth/model/ForgotPasswordRequest.kt
@@ -1,0 +1,8 @@
+package pl.cuyer.rusthub.data.network.auth.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ForgotPasswordRequest(
+    val email: String
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/auth/AuthRepository.kt
@@ -18,4 +18,5 @@ interface AuthRepository {
     fun deleteAccount(password: String): Flow<Result<Unit>>
     fun changePassword(oldPassword: String, newPassword: String): Flow<Result<Unit>>
     fun checkUserExists(email: String): Flow<Result<UserExistsInfo>>
+    fun requestPasswordReset(email: String): Flow<Result<Unit>>
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RequestPasswordResetUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/RequestPasswordResetUseCase.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.repository.auth.AuthRepository
+
+class RequestPasswordResetUseCase(
+    private val repository: AuthRepository
+) {
+    operator fun invoke(email: String): Flow<Result<Unit>> =
+        repository.requestPasswordReset(email)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -70,6 +70,7 @@ import pl.cuyer.rusthub.domain.usecase.UpgradeAccountUseCase
 import pl.cuyer.rusthub.domain.usecase.UpgradeWithGoogleUseCase
 import pl.cuyer.rusthub.domain.usecase.CheckEmailConfirmedUseCase
 import pl.cuyer.rusthub.domain.usecase.ResendConfirmationUseCase
+import pl.cuyer.rusthub.domain.usecase.RequestPasswordResetUseCase
 import pl.cuyer.rusthub.presentation.settings.SettingsController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.util.MessagingTokenManager
@@ -131,6 +132,7 @@ val appModule = module {
     single { LogoutUserUseCase(get(), get(), get()) }
     single { DeleteAccountUseCase(get(), get(), get()) }
     single { ChangePasswordUseCase(get()) }
+    single { RequestPasswordResetUseCase(get()) }
     single { UpgradeAccountUseCase(get(), get(), get(), get()) }
     single { UpgradeWithGoogleUseCase(get(), get(), get(), get()) }
     single { GetSettingsUseCase(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsAction.kt
@@ -4,6 +4,7 @@ sealed interface CredentialsAction {
     data object OnSubmit : CredentialsAction
     data class OnUsernameChange(val username: String) : CredentialsAction
     data class OnPasswordChange(val password: String) : CredentialsAction
+    data object OnForgotPassword : CredentialsAction
     data object OnNavigateUp : CredentialsAction
     data object OnGoogleLogin : CredentialsAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsViewModel.kt
@@ -26,6 +26,7 @@ import pl.cuyer.rusthub.domain.usecase.GetGoogleClientIdUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginWithGoogleUseCase
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.ConfirmEmail
+import pl.cuyer.rusthub.presentation.navigation.ResetPassword
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
@@ -69,6 +70,7 @@ class CredentialsViewModel(
             CredentialsAction.OnGoogleLogin -> startGoogleLogin()
             is CredentialsAction.OnUsernameChange -> updateUsername(action.username)
             is CredentialsAction.OnPasswordChange -> updatePassword(action.password)
+            CredentialsAction.OnForgotPassword -> navigateResetPassword()
             CredentialsAction.OnNavigateUp -> navigateUp()
         }
     }
@@ -76,6 +78,12 @@ class CredentialsViewModel(
     private fun navigateUp() {
         coroutineScope.launch {
             _uiEvent.send(UiEvent.NavigateUp)
+        }
+    }
+
+    private fun navigateResetPassword() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(ResetPassword(_state.value.email)))
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ResetPasswordAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ResetPasswordAction.kt
@@ -1,0 +1,6 @@
+package pl.cuyer.rusthub.presentation.features.auth.password
+
+sealed interface ResetPasswordAction {
+    data object OnSend : ResetPasswordAction
+    data class OnEmailChange(val email: String) : ResetPasswordAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ResetPasswordState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ResetPasswordState.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.presentation.features.auth.password
+
+data class ResetPasswordState(
+    val email: String = "",
+    val emailError: String? = null,
+    val isLoading: Boolean = false
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ResetPasswordViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/password/ResetPasswordViewModel.kt
@@ -1,0 +1,91 @@
+package pl.cuyer.rusthub.presentation.features.auth.password
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.common.Result
+import pl.cuyer.rusthub.domain.usecase.RequestPasswordResetUseCase
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.validator.EmailValidator
+
+class ResetPasswordViewModel(
+    email: String,
+    private val requestPasswordResetUseCase: RequestPasswordResetUseCase,
+    private val snackbarController: SnackbarController,
+    private val emailValidator: EmailValidator,
+) : BaseViewModel() {
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val _state = MutableStateFlow(ResetPasswordState(email = email))
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = ResetPasswordState(email = email)
+    )
+
+    private var sendJob: Job? = null
+
+    fun onAction(action: ResetPasswordAction) {
+        when (action) {
+            ResetPasswordAction.OnSend -> send()
+            is ResetPasswordAction.OnEmailChange -> updateEmail(action.email)
+        }
+    }
+
+    private fun updateEmail(email: String) {
+        _state.update { it.copy(email = email, emailError = null) }
+    }
+
+    private fun send() {
+        sendJob?.cancel()
+        sendJob = coroutineScope.launch {
+            val email = _state.value.email
+            val emailResult = emailValidator.validate(email)
+            _state.update { it.copy(emailError = emailResult.errorMessage) }
+            if (!emailResult.isValid) {
+                snackbarController.sendEvent(
+                    SnackbarEvent("Please correct the errors above and try again.")
+                )
+                return@launch
+            }
+            requestPasswordResetUseCase(email)
+                .onStart { updateLoading(true) }
+                .onCompletion { updateLoading(false) }
+                .catch { e -> showErrorSnackbar(e.message ?: "Unknown error") }
+                .collectLatest { result ->
+                    when (result) {
+                        is Result.Success -> {
+                            snackbarController.sendEvent(
+                                SnackbarEvent("Reset email sent")
+                            )
+                            _uiEvent.send(UiEvent.NavigateUp)
+                        }
+                        is Result.Error -> showErrorSnackbar(result.exception.message ?: "Unable to send reset email")
+                        else -> Unit
+                    }
+                }
+        }
+    }
+
+    private fun updateLoading(isLoading: Boolean) {
+        _state.update { it.copy(isLoading = isLoading) }
+    }
+
+    private suspend fun showErrorSnackbar(message: String) {
+        snackbarController.sendEvent(SnackbarEvent(message = message))
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -41,3 +41,6 @@ data class ServerDetails(
 
 @Serializable
 data object PrivacyPolicy : NavKey
+
+@Serializable
+data class ResetPassword(val email: String) : NavKey

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -9,6 +9,7 @@ import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.features.auth.credentials.CredentialsViewModel
 import pl.cuyer.rusthub.presentation.features.auth.delete.DeleteAccountViewModel
 import pl.cuyer.rusthub.presentation.features.auth.password.ChangePasswordViewModel
+import pl.cuyer.rusthub.presentation.features.auth.password.ResetPasswordViewModel
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.settings.SettingsViewModel
@@ -93,6 +94,14 @@ actual val platformModule: Module = module {
             changePasswordUseCase = get(),
             snackbarController = get(),
             passwordValidator = get(),
+        )
+    }
+    factory { (email: String) ->
+        ResetPasswordViewModel(
+            email = email,
+            requestPasswordResetUseCase = get(),
+            snackbarController = get(),
+            emailValidator = get()
         )
     }
     factory {


### PR DESCRIPTION
## Summary
- add API model and use-case for requesting password reset
- implement repository call
- create ResetPasswordViewModel and UI
- hook up button in credentials screen
- wire viewmodel and navigation in Koin modules

## Testing
- `./gradlew :shared:assemble` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd68776b883219370075d0d3a4c3c