### PR TITLE
Fix clearing server filters

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ClearFiltersUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/ClearFiltersUseCase.kt
@@ -1,6 +1,7 @@
 package pl.cuyer.rusthub.domain.usecase
 
 import app.cash.paging.ExperimentalPagingApi
+import pl.cuyer.rusthub.domain.model.ServerQuery
 import pl.cuyer.rusthub.domain.repository.filters.FiltersDataSource
 
 class ClearFiltersUseCase(
@@ -8,6 +9,5 @@ class ClearFiltersUseCase(
 ) {
     @OptIn(ExperimentalPagingApi::class)
     suspend operator fun invoke() {
-        return dataSource.clearFilters()
-    }
-}
+        dataSource.upsertFilters(ServerQuery())
+    }}


### PR DESCRIPTION
## Summary
- update `ClearFiltersUseCase` to upsert an empty `ServerQuery` instead of deleting filters

## Testing
- `./gradlew :shared:compileKotlinJvm` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d12cbd924832188ae8127efd8001b