### PR TITLE
Fix status bar icons when overriding theme

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
@@ -27,6 +27,10 @@ class MainActivity : ComponentActivity() {
         }
 
         enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.auto(
+                lightScrim,
+                darkScrim
+            ),
             navigationBarStyle = SystemBarStyle.auto(
                 lightScrim,
                 darkScrim
@@ -38,6 +42,28 @@ class MainActivity : ComponentActivity() {
         setContent {
             val state = startupViewModel.state.collectAsStateWithLifecycle()
             val appTheme = settingsController.theme.collectAsStateWithLifecycle()
+
+            val darkTheme = when (appTheme.value) {
+                pl.cuyer.rusthub.domain.model.Theme.LIGHT -> false
+                pl.cuyer.rusthub.domain.model.Theme.DARK -> true
+                pl.cuyer.rusthub.domain.model.Theme.SYSTEM -> androidx.compose.foundation.isSystemInDarkTheme()
+            }
+
+            androidx.compose.runtime.LaunchedEffect(darkTheme) {
+                enableEdgeToEdge(
+                    statusBarStyle = if (darkTheme) {
+                        SystemBarStyle.dark(darkScrim)
+                    } else {
+                        SystemBarStyle.light(lightScrim)
+                    },
+                    navigationBarStyle = if (darkTheme) {
+                        SystemBarStyle.dark(darkScrim)
+                    } else {
+                        SystemBarStyle.light(lightScrim)
+                    }
+                )
+            }
+
             KoinContext {
                 RustHubTheme(theme = appTheme.value) {
                     if (!state.value.isLoading) {


### PR DESCRIPTION
## Summary
- adjust `enableEdgeToEdge` to set the status bar style
- update the system bar styles whenever the user theme changes

## Testing
- `gradle --version`

------
https://chatgpt.com/codex/tasks/task_e_686d135085a48321a3444747f754aec3