### PR TITLE
Fix: handle nullable instants

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/util/serializers/InstantSerializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/util/serializers/InstantSerializer.kt
@@ -6,20 +6,34 @@ import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 //TODO illegal input null
 @OptIn(ExperimentalTime::class)
-object InstantSerializer : KSerializer<Instant> {
+object InstantSerializer : KSerializer<Instant?> {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("kotlin.time.Instant", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, value: Instant) {
-        encoder.encodeString(value.toString())
+    override fun serialize(encoder: Encoder, value: Instant?) {
+        if (value != null) {
+            encoder.encodeString(value.toString())
+        } else {
+            encoder.encodeNull()
+        }
     }
 
-    override fun deserialize(decoder: Decoder): Instant {
-        return Instant.parse(decoder.decodeString())
-    }
-}
+    override fun deserialize(decoder: Decoder): Instant? {
+        val input = decoder as? JsonDecoder
+            ?: error("InstantSerializer only works with Json format")
+
+        val element = input.decodeJsonElement()
+
+        return when (element) {
+            is JsonPrimitive -> element.contentOrNull?.let { Instant.parse(it) }
+            else -> null
+        }
+    }}


### PR DESCRIPTION
## Summary
- revert prior workaround for null server responses
- allow InstantSerializer to parse null values

## Testing
- `./gradlew --version`
- `./gradlew assemble` *(fails: SigningConfig with name 'development' not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6eeae864832194d556c6356c0431