### PR TITLE
Add subscription screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -51,6 +51,7 @@ import pl.cuyer.rusthub.android.feature.settings.ChangePasswordScreen
 import pl.cuyer.rusthub.android.feature.settings.DeleteAccountScreen
 import pl.cuyer.rusthub.android.feature.settings.PrivacyPolicyScreen
 import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
+import pl.cuyer.rusthub.android.feature.subscription.SubscriptionScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.common.Constants
 import pl.cuyer.rusthub.presentation.features.auth.confirm.ConfirmEmailViewModel
@@ -69,6 +70,8 @@ import pl.cuyer.rusthub.presentation.navigation.Credentials
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
+import pl.cuyer.rusthub.presentation.navigation.Subscription
+import pl.cuyer.rusthub.presentation.navigation.Terms
 import pl.cuyer.rusthub.presentation.navigation.ResetPassword
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
@@ -278,6 +281,20 @@ fun NavigationRoot(startDestination: NavKey = Onboarding) {
                             PrivacyPolicyScreen(
                                 url = Constants.PRIVACY_POLICY_URL,
                                 onNavigateUp = { backStack.removeLastOrNull() }
+                            )
+                        }
+                        entry<Terms> {
+                            PrivacyPolicyScreen(
+                                url = Constants.TERMS_URL,
+                                title = "Terms & conditions",
+                                onNavigateUp = { backStack.removeLastOrNull() }
+                            )
+                        }
+                        entry<Subscription> {
+                            SubscriptionScreen(
+                                onNavigateUp = { backStack.removeLastOrNull() },
+                                onPrivacyPolicy = { backStack.add(PrivacyPolicy) },
+                                onTerms = { backStack.add(Terms) }
                             )
                         }
                     },

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -63,9 +63,9 @@ import org.koin.compose.koinInject
 import pl.cuyer.rusthub.android.designsystem.NotificationInfoDialog
 import pl.cuyer.rusthub.android.designsystem.ServerDetail
 import pl.cuyer.rusthub.android.designsystem.ServerWebsite
-import pl.cuyer.rusthub.android.designsystem.SubscriptionDialog
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.domain.model.Flag
 import pl.cuyer.rusthub.domain.model.Flag.Companion.toDrawable
 import pl.cuyer.rusthub.domain.model.ServerStatus
@@ -87,6 +87,10 @@ fun ServerDetailsScreen(
     val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
     val lazyListState = rememberLazyListState()
     val state = stateProvider().value
+
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
 
     val permissionsController = koinInject<PermissionsController>()
     BindEffect(permissionsController)
@@ -178,11 +182,6 @@ fun ServerDetailsScreen(
         }
     ) { innerPadding ->
         if (state.details != null) {
-            SubscriptionDialog(
-                showDialog = state.showSubscriptionDialog,
-                onConfirm = { onAction(ServerDetailsAction.OnSubscribe) },
-                onDismiss = { onAction(ServerDetailsAction.OnDismissSubscriptionDialog) }
-            )
             LazyColumn(
                 state = lazyListState,
                 modifier = Modifier

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/PrivacyPolicyScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/PrivacyPolicyScreen.kt
@@ -18,11 +18,11 @@ import androidx.compose.ui.viewinterop.AndroidView
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun PrivacyPolicyScreen(url: String, onNavigateUp: () -> Unit) {
+fun PrivacyPolicyScreen(url: String, onNavigateUp: () -> Unit, title: String = "Privacy policy") {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Privacy policy") },
+                title = { Text(title) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateUp) {
                         Icon(

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -41,7 +41,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.koin.compose.koinInject
 import pl.cuyer.rusthub.android.designsystem.AppExposedDropdownMenu
 import pl.cuyer.rusthub.android.designsystem.AppTextButton
-import pl.cuyer.rusthub.android.designsystem.SubscriptionDialog
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
@@ -102,11 +101,6 @@ fun SettingsScreen(
                         .align(Alignment.Center)
                 )
             }
-            SubscriptionDialog(
-                showDialog = state.value.showSubscriptionDialog,
-                onConfirm = { onAction(SettingsAction.OnSubscribe) },
-                onDismiss = { onAction(SettingsAction.OnDismissSubscriptionDialog) }
-            )
             if (isTabletMode) {
                 SettingsScreenExpanded(
                     theme = state.value.theme,

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
@@ -1,0 +1,224 @@
+package pl.cuyer.rusthub.android.feature.subscription
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.graphics.vector.ImageVector
+import pl.cuyer.rusthub.android.designsystem.AppButton
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
+import pl.cuyer.rusthub.android.theme.spacing
+
+private data class Benefit(val icon: ImageVector, val title: String, val desc: String)
+
+private val benefits = listOf(
+    Benefit(Icons.Default.Star, "Unlimited favourites", "Save as many servers as you like."),
+    Benefit(Icons.Default.Notifications, "Unlimited notifications", "Get notified about all your servers."),
+    Benefit(Icons.Default.Check, "Support development", "Help us keep improving Rust Hub.")
+)
+
+private enum class Plan(val label: String) { MONTHLY("Monthly"), YEARLY("Yearly"), LIFETIME("Lifetime") }
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
+@Composable
+fun SubscriptionScreen(
+    onNavigateUp: () -> Unit,
+    onPrivacyPolicy: () -> Unit,
+    onTerms: () -> Unit
+) {
+    var selectedPlan by remember { mutableStateOf(Plan.MONTHLY) }
+    val pagerState = rememberPagerState(pageCount = { benefits.size })
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Rust Hub Pro") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Navigate up")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(spacing.medium),
+            verticalArrangement = Arrangement.spacedBy(spacing.medium)
+        ) {
+            HorizontalPager(state = pagerState) { page ->
+                val benefit = benefits[page]
+                Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(benefit.icon, contentDescription = null)
+                    Spacer(Modifier.width(spacing.medium))
+                    Column {
+                        Text(benefit.title, style = MaterialTheme.typography.titleMedium)
+                        Text(benefit.desc, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                }
+            }
+            CarouselAutoPlayHandler(pagerState, benefits.size)
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.small)) {
+                Plan.values().forEach { plan ->
+                    ElevatedCard(
+                        onClick = { selectedPlan = plan },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .padding(spacing.medium)
+                                .fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(plan.label, style = MaterialTheme.typography.titleMedium)
+                            if (selectedPlan == plan) {
+                                Icon(Icons.Default.Check, contentDescription = null)
+                            }
+                        }
+                    }
+                }
+            }
+            AppButton(modifier = Modifier.fillMaxWidth(), onClick = {}) { Text("Subscribe to ${selectedPlan.label}") }
+            AppTextButton(onClick = onNavigateUp) { Text("Not now") }
+            Text(
+                text = "Cancel anytime. Subscription renews automatically unless canceled 24 hours before end of period. Manage or cancel through store settings. Rust Hub Pro Lifetime is a one time purchase.",
+                style = MaterialTheme.typography.bodySmall
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing.medium)) {
+                AppTextButton(onClick = onPrivacyPolicy) { Text("Privacy policy") }
+                AppTextButton(onClick = onTerms) { Text("Terms & conditions") }
+            }
+            ComparisonSection()
+            FaqSection()
+        }
+    }
+}
+
+@Composable
+private fun ComparisonSection() {
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.small)) {
+        Text("Free vs Pro", style = MaterialTheme.typography.titleMedium)
+        FlowRow(maxItemsInEachRow = 2, horizontalArrangement = Arrangement.spacedBy(spacing.large)) {
+            Column {
+                Text("Free", style = MaterialTheme.typography.titleSmall)
+                Text("Up to 3 server notifications")
+                Text("Up to 3 favourite servers")
+            }
+            Column {
+                Text("Pro", style = MaterialTheme.typography.titleSmall)
+                Text("Unlimited notifications")
+                Text("Unlimited favourites")
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+private fun FaqSection() {
+    val faqs = listOf(
+        "What does Rust Hub Pro include?" to "Unlimited favourites and notifications.",
+        "Is Rust Hub Pro a one-time payment or will it renew automatically?" to "Monthly and yearly plans renew automatically.",
+        "Can I cancel my subscription anytime?" to "Yes, you can cancel anytime in store settings.",
+        "Can I switch subscription plans?" to "You can change plans in the store settings.",
+        "What happens if i switch devices or platforms?" to "Restore your purchase on the new device.",
+        "How does Rusthub Pro Lifetime plan work?" to "One time payment giving permanent access."
+    )
+    Column(verticalArrangement = Arrangement.spacedBy(spacing.small)) {
+        Text("FAQ", style = MaterialTheme.typography.titleMedium)
+        faqs.forEach { (q, a) ->
+            var expanded by remember { mutableStateOf(false) }
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { expanded = !expanded }
+                        .padding(spacing.medium)
+                        .animateContentSize(),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(q, style = MaterialTheme.typography.titleSmall)
+                        Icon(
+                            imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                            contentDescription = null
+                        )
+                    }
+                    AnimatedVisibility(expanded) {
+                        Text(a, style = MaterialTheme.typography.bodySmall, modifier = Modifier.padding(top = spacing.small))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CarouselAutoPlayHandler(pagerState: PagerState, carouselSize: Int, delayMillis: Long = 5000L) {
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    val interactions = remember(pagerState.interactionSource) {
+        pagerState.interactionSource.interactions
+            .flowWithLifecycle(lifecycleOwner.lifecycle, androidx.lifecycle.Lifecycle.State.STARTED)
+    }
+    val scope = rememberCoroutineScope()
+    var cooldownKey by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(interactions) {
+        interactions.collectLatest { interaction ->
+            when (interaction) {
+                is DragInteraction.Start,
+                is DragInteraction.Stop,
+                is DragInteraction.Cancel -> cooldownKey++
+            }
+        }
+    }
+
+    LaunchedEffect(pagerState.currentPage, cooldownKey) {
+        delay(delayMillis)
+        val nextPage = (pagerState.currentPage + 1) % carouselSize
+        scope.launch { pagerState.animateScrollToPage(nextPage) }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/common/Constants.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/common/Constants.kt
@@ -4,5 +4,5 @@ object Constants {
     const val DEFAULT_KEY = "default"
     const val SERVERS_VALIDITY_TIMEOUT = 1 //hours
     const val PRIVACY_POLICY_URL = "https://github.com/Cuyer/RustHub_KMM/blob/main/PRIVACY_POLICY.md"
-    const val GOOGLE_CLIENT_ID = "CHANGE_ME"
-}
+    const val TERMS_URL = "https://github.com/Cuyer/RustHub_KMM/blob/main/TERMS.md"
+    const val GOOGLE_CLIENT_ID = "CHANGE_ME"}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -32,6 +32,7 @@ import pl.cuyer.rusthub.domain.usecase.ToggleFavouriteUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleSubscriptionUseCase
 import pl.cuyer.rusthub.presentation.model.ServerInfoUi
 import pl.cuyer.rusthub.presentation.model.toUi
+import pl.cuyer.rusthub.presentation.navigation.Subscription
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
@@ -73,7 +74,7 @@ class ServerDetailsViewModel(
         when (action) {
             is ServerDetailsAction.OnSaveToClipboard -> saveIpToClipboard(action.ipAddress)
             ServerDetailsAction.OnToggleFavourite -> toggleFavourite()
-            ServerDetailsAction.OnDismissSubscriptionDialog -> showSubscriptionDialog(false)
+            ServerDetailsAction.OnDismissSubscriptionDialog -> Unit
             ServerDetailsAction.OnDismissNotificationInfo -> showNotificationInfo(false)
             ServerDetailsAction.OnSubscribe -> handleSubscribeAction()
             ServerDetailsAction.OnShare -> shareServer()
@@ -137,7 +138,7 @@ class ServerDetailsViewModel(
                             )
                         }
                         is Result.Error -> when (result.exception) {
-                            is FavoriteLimitException -> showSubscriptionDialog(true)
+                            is FavoriteLimitException -> navigateSubscription()
                             else -> showErrorSnackbar("Error occurred when trying to ${if (add) "add" else "remove"} server from favourites")
                         }
                         Result.Loading -> Unit
@@ -171,7 +172,7 @@ class ServerDetailsViewModel(
                             )
                         }
                         is Result.Error -> when (result.exception) {
-                            is SubscriptionLimitException -> showSubscriptionDialog(true)
+                            is SubscriptionLimitException -> navigateSubscription()
                             else -> showErrorSnackbar("Error occurred when trying to ${if (subscribed) "subscribe" else "unsubscribe"} from notifications")
                         }
                         Result.Loading -> Unit
@@ -185,6 +186,12 @@ class ServerDetailsViewModel(
             it.copy(
                 showSubscriptionDialog = show
             )
+        }
+    }
+
+    private fun navigateSubscription() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(Subscription))
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -32,6 +32,7 @@ import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
+import pl.cuyer.rusthub.presentation.navigation.Subscription
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.navigation.UpgradeAccount
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
@@ -73,9 +74,9 @@ class SettingsViewModel(
             SettingsAction.OnChangePasswordClick -> navigateChangePassword()
             SettingsAction.OnNotificationsClick -> permissionsController.openAppSettings()
             SettingsAction.OnLogout -> logout()
-            SettingsAction.OnSubscriptionClick -> showSubscriptionDialog(true)
-            SettingsAction.OnDismissSubscriptionDialog -> showSubscriptionDialog(false)
-            SettingsAction.OnSubscribe -> showSubscriptionDialog(false)
+            SettingsAction.OnSubscriptionClick -> navigateSubscription()
+            SettingsAction.OnDismissSubscriptionDialog -> Unit
+            SettingsAction.OnSubscribe -> Unit
             SettingsAction.OnPrivacyPolicy -> openPrivacyPolicy()
             SettingsAction.OnDeleteAccount -> navigateDeleteAccount()
             SettingsAction.OnUpgradeAccount -> navigateUpgrade()
@@ -181,6 +182,12 @@ class SettingsViewModel(
     private fun navigateDeleteAccount() {
         coroutineScope.launch {
             _uiEvent.send(UiEvent.Navigate(DeleteAccount))
+        }
+    }
+
+    private fun navigateSubscription() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(Subscription))
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -44,3 +44,9 @@ data object PrivacyPolicy : NavKey
 
 @Serializable
 data class ResetPassword(val email: String) : NavKey
+
+@Serializable
+data object Terms : NavKey
+
+@Serializable
+data object Subscription : NavKey


### PR DESCRIPTION
## Summary
- add new `Subscription` and `Terms` destinations
- implement `SubscriptionScreen` with benefits carousel, plans, comparison and FAQ
- link privacy policy and terms through navigation
- route subscription triggers from settings and server details to new screen
- update `PrivacyPolicyScreen` to allow custom title

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e79cfb2bc8321a24f6c9229d2a59f