### PR TITLE
Add UI mapper in domain

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerUiMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ServerUiMapper.kt
@@ -1,0 +1,84 @@
+package pl.cuyer.rusthub.domain.model
+
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import pl.cuyer.rusthub.presentation.model.ServerInfoUi
+import pl.cuyer.rusthub.util.formatLocalDateTime
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+fun ServerInfo.toUiModel(): ServerInfoUi {
+    return ServerInfoUi(
+        id = id,
+        name = name,
+        wipe = wipe,
+        ranking = ranking,
+        modded = modded,
+        playerCount = playerCount,
+        serverCapacity = serverCapacity,
+        mapName = mapName,
+        cycle = cycle,
+        serverFlag = serverFlag,
+        region = region,
+        maxGroup = maxGroup,
+        difficulty = difficulty,
+        wipeSchedule = wipeSchedule,
+        isOfficial = isOfficial,
+        serverIp = serverIp,
+        mapImage = mapImage,
+        description = description,
+        serverStatus = serverStatus,
+        wipeType = wipeType,
+        blueprints = blueprints,
+        kits = kits,
+        decay = decay,
+        upkeep = upkeep,
+        rates = rates,
+        seed = seed,
+        mapSize = mapSize,
+        monuments = monuments,
+        averageFps = averageFps,
+        lastWipe = wipe?.let { formatLastWipe(it) },
+        nextWipe = nextWipe?.let { formatNextWipe(it) },
+        nextMapWipe = nextMapWipe?.let { formatNextWipe(it) },
+        pve = pve,
+        website = website,
+        isPremium = isPremium,
+        mapUrl = mapUrl,
+        headerImage = headerImage,
+        isFavorite = isFavorite,
+        isSubscribed = isSubscribed
+    )
+}
+
+fun formatLastWipe(wipeInstant: Instant): String {
+    val now = Clock.System.now()
+    val duration = now - wipeInstant
+    val localDateTime = wipeInstant.toLocalDateTime(TimeZone.currentSystemDefault())
+    val formattedDate = formatLocalDateTime(localDateTime)
+
+    val timeAgo = when {
+        duration.inWholeDays >= 1 -> "${duration.inWholeDays} days ago"
+        duration.inWholeHours >= 1 -> "${duration.inWholeHours} hours ago"
+        else -> "${duration.inWholeMinutes} minutes ago"
+    }
+
+    return "$formattedDate ($timeAgo)"
+}
+
+fun formatNextWipe(wipeInstant: Instant): String {
+    val now = Clock.System.now()
+    val duration = wipeInstant - now
+    val localDateTime = wipeInstant.toLocalDateTime(TimeZone.currentSystemDefault())
+    val formattedDate = formatLocalDateTime(localDateTime)
+
+    val inTime = when {
+        duration.inWholeDays >= 1 -> "in ${duration.inWholeDays} days"
+        duration.inWholeHours >= 1 -> "in ${duration.inWholeHours} hours"
+        duration.inWholeMinutes >= 0 -> "in ${duration.inWholeMinutes} minutes"
+        else -> "soon"
+    }
+
+    return "$formattedDate ($inTime)"
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetPagedServersUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetPagedServersUseCase.kt
@@ -5,6 +5,9 @@ import app.cash.paging.ExperimentalPagingApi
 import app.cash.paging.PagingConfig
 import app.cash.paging.PagingData
 import database.ServerEntity
+import kotlinx.coroutines.flow.map
+import pl.cuyer.rusthub.data.local.mapper.toServerInfo
+import pl.cuyer.rusthub.domain.model.ServerInfo
 import kotlinx.coroutines.flow.Flow
 import pl.cuyer.rusthub.domain.repository.RemoteKeyDataSource
 import pl.cuyer.rusthub.domain.repository.filters.FiltersDataSource
@@ -21,7 +24,7 @@ class GetPagedServersUseCase(
     @OptIn(ExperimentalPagingApi::class)
     operator fun invoke(
         searchQuery: String?
-    ): Flow<PagingData<ServerEntity>> {
+    ): Flow<PagingData<ServerInfo>> {
         return Pager(
             config = PagingConfig(
                 pageSize = 40,
@@ -39,6 +42,8 @@ class GetPagedServersUseCase(
                     searchQuery
                 )
             }
-        ).flow
+        ).flow.map { pagingData ->
+            pagingData.map { it.toServerInfo() }
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -31,7 +31,7 @@ import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleFavouriteUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleSubscriptionUseCase
 import pl.cuyer.rusthub.presentation.model.ServerInfoUi
-import pl.cuyer.rusthub.presentation.model.toUi
+import pl.cuyer.rusthub.domain.model.toUiModel
 import pl.cuyer.rusthub.presentation.navigation.Subscription
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.Duration
@@ -226,7 +226,7 @@ class ServerDetailsViewModel(
     private fun observeServerDetails(serverId: Long): Job {
         serverDetailsJob?.cancel()
         return getServerDetailsUseCase(serverId)
-            .map { it?.toUi() }
+            .map { it?.toUiModel() }
             .flowOn(Dispatchers.Default)
             .onEach { mappedDetails ->
                 updateDetails(mappedDetails)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerViewModel.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.common.BaseViewModel
-import pl.cuyer.rusthub.data.local.mapper.toServerInfo
 import pl.cuyer.rusthub.domain.model.SearchQuery
 import pl.cuyer.rusthub.domain.model.ServerFilter
 import pl.cuyer.rusthub.domain.model.ServerQuery
@@ -43,6 +42,7 @@ import pl.cuyer.rusthub.presentation.model.SearchQueryUi
 import pl.cuyer.rusthub.presentation.model.ServerInfoUi
 import pl.cuyer.rusthub.presentation.model.toDomain
 import pl.cuyer.rusthub.presentation.model.toUi
+import pl.cuyer.rusthub.domain.model.toUiModel
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.Duration
@@ -90,7 +90,7 @@ class ServerViewModel(
             getPagedServersUseCase(
                 searchQuery = query
             ).map { pagingData ->
-                pagingData.map { it.toServerInfo().toUi() }
+                pagingData.map { it.toUiModel() }
             }.flowOn(Dispatchers.Default)
         }.cachedIn(coroutineScope)
             .catch { e -> sendSnackbarEvent("Error occurred during fetching servers.") }


### PR DESCRIPTION
## Summary
- provide domain mapper from `ServerInfo` to `ServerInfoUi`
- return domain models in `GetPagedServersUseCase`
- call new mapper inside `ServerViewModel` and `ServerDetailsViewModel`

## Testing
- `./gradlew :shared:compileKotlinJvm` *(fails: unresolved reference)*

------
https://chatgpt.com/codex/tasks/task_e_68711145e9748321b06fe23baa81703e