### PR TITLE
Fix: synchronize token refresh and logout

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -26,6 +26,8 @@ import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.coroutines.CancellationException
 import pl.cuyer.rusthub.common.user.UserEvent
@@ -63,6 +65,8 @@ actual class HttpClientFactory actual constructor(
     private val tokenRefresher: TokenRefresher,
     private val userEventController: UserEventController
 )  {
+    private val refreshMutex = Mutex()
+    private val deleteMutex = Mutex()
     actual fun create(): HttpClient {
         return HttpClient(OkHttp) {
             engine {
@@ -81,58 +85,40 @@ actual class HttpClientFactory actual constructor(
                         }
                     }
                     refreshTokens {
-                        val user = authDataSource.getUserOnce()
-                        val oldRefresh = oldTokens?.refreshToken
-                        if (user?.provider == AuthProvider.ANONYMOUS || oldRefresh.isNullOrBlank()) {
-                            try {
-                                if (user != null) {
-                                    authDataSource.deleteUser()
-                                    withContext(Dispatchers.Main.immediate) {
-                                        userEventController.sendEvent(UserEvent.LoggedOut)
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                if (e is CancellationException) throw e
-                                CrashReporter.recordException(e)
+                        refreshMutex.withLock {
+                            val user = authDataSource.getUserOnce()
+                            val oldRefresh = oldTokens?.refreshToken
+                            if (user?.provider == AuthProvider.ANONYMOUS || oldRefresh.isNullOrBlank()) {
+                                logoutOnce()
+                                return@withLock null
                             }
-                            return@refreshTokens null
-                        }
 
-                        val response = client.post("${NetworkConstants.BASE_URL}auth/refresh") {
-                            markAsRefreshTokenRequest()
-                            contentType(ContentType.Application.Json)
-                            setBody(RefreshRequest(oldRefresh))
-                        }
-
-                        if (response.status.isSuccess()) {
-                            val newTokens: TokenPairDto = response.body()
-                            val confirmed = newTokens.emailConfirmed
-                                ?: authDataSource.getUserOnce()?.emailConfirmed
-                                ?: false
-                            authDataSource.insertUser(
-                                email = newTokens.email,
-                                username = newTokens.username,
-                                accessToken = newTokens.accessToken,
-                                refreshToken = newTokens.refreshToken,
-                                obfuscatedId = newTokens.obfuscatedId,
-                                provider = AuthProvider.valueOf(newTokens.provider),
-                                subscribed = newTokens.subscribed,
-                                emailConfirmed = confirmed
-                            )
-                            BearerTokens(newTokens.accessToken, newTokens.refreshToken)
-                        } else {
-                            try {
-                                if (authDataSource.getUserOnce() != null) {
-                                    authDataSource.deleteUser()
-                                    withContext(Dispatchers.Main.immediate) {
-                                        userEventController.sendEvent(UserEvent.LoggedOut)
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                if (e is CancellationException) throw e
-                                CrashReporter.recordException(e)
+                            val response = client.post("${NetworkConstants.BASE_URL}auth/refresh") {
+                                markAsRefreshTokenRequest()
+                                contentType(ContentType.Application.Json)
+                                setBody(RefreshRequest(oldRefresh))
                             }
-                            null
+
+                            if (response.status.isSuccess()) {
+                                val newTokens: TokenPairDto = response.body()
+                                val confirmed = newTokens.emailConfirmed
+                                    ?: authDataSource.getUserOnce()?.emailConfirmed
+                                    ?: false
+                                authDataSource.insertUser(
+                                    email = newTokens.email,
+                                    username = newTokens.username,
+                                    accessToken = newTokens.accessToken,
+                                    refreshToken = newTokens.refreshToken,
+                                    obfuscatedId = newTokens.obfuscatedId,
+                                    provider = AuthProvider.valueOf(newTokens.provider),
+                                    subscribed = newTokens.subscribed,
+                                    emailConfirmed = confirmed
+                                )
+                                BearerTokens(newTokens.accessToken, newTokens.refreshToken)
+                            } else {
+                                logoutOnce()
+                                null
+                            }
                         }
                     }
                 }
@@ -166,6 +152,22 @@ actual class HttpClientFactory actual constructor(
             }
         }
 
+    }
+
+    private suspend fun logoutOnce() {
+        try {
+            deleteMutex.withLock {
+                if (authDataSource.getUserOnce() != null) {
+                    authDataSource.deleteUser()
+                    withContext(Dispatchers.Main.immediate) {
+                        userEventController.sendEvent(UserEvent.LoggedOut)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            CrashReporter.recordException(e)
+        }
     }
 
 }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
@@ -26,6 +26,8 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.io.IOException
 import kotlinx.serialization.json.Json
 import kotlinx.coroutines.CancellationException
@@ -61,6 +63,8 @@ actual class HttpClientFactory actual constructor(
     private val tokenRefresher: TokenRefresher,
     private val userEventController: UserEventController
 ) {
+    private val refreshMutex = Mutex()
+    private val deleteMutex = Mutex()
     actual fun create(): HttpClient {
         return HttpClient(Darwin) {
             install(ContentNegotiation) {
@@ -74,58 +78,40 @@ actual class HttpClientFactory actual constructor(
                         }
                     }
                     refreshTokens {
-                        val user = authDataSource.getUserOnce()
-                        val oldRefresh = oldTokens?.refreshToken
-                        if (user?.provider == AuthProvider.ANONYMOUS || oldRefresh.isNullOrBlank()) {
-                            try {
-                                if (user != null) {
-                                    authDataSource.deleteUser()
-                                    withContext(Dispatchers.Main.immediate) {
-                                        userEventController.sendEvent(UserEvent.LoggedOut)
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                if (e is CancellationException) throw e
-                                CrashReporter.recordException(e)
+                        refreshMutex.withLock {
+                            val user = authDataSource.getUserOnce()
+                            val oldRefresh = oldTokens?.refreshToken
+                            if (user?.provider == AuthProvider.ANONYMOUS || oldRefresh.isNullOrBlank()) {
+                                logoutOnce()
+                                return@withLock null
                             }
-                            return@refreshTokens null
-                        }
 
-                        val response = client.post("${NetworkConstants.BASE_URL}auth/refresh") {
-                            markAsRefreshTokenRequest()
-                            contentType(ContentType.Application.Json)
-                            setBody(RefreshRequest(oldRefresh))
-                        }
-
-                        if (response.status.isSuccess()) {
-                            val newTokens: TokenPairDto = response.body()
-                            val confirmed = newTokens.emailConfirmed
-                                ?: authDataSource.getUserOnce()?.emailConfirmed
-                                ?: false
-                            authDataSource.insertUser(
-                                email = newTokens.email,
-                                username = newTokens.username,
-                                accessToken = newTokens.accessToken,
-                                refreshToken = newTokens.refreshToken,
-                                obfuscatedId = newTokens.obfuscatedId,
-                                provider = AuthProvider.valueOf(newTokens.provider),
-                                subscribed = newTokens.subscribed,
-                                emailConfirmed = confirmed
-                            )
-                            BearerTokens(newTokens.accessToken, newTokens.refreshToken)
-                        } else {
-                            try {
-                                if (authDataSource.getUserOnce() != null) {
-                                    authDataSource.deleteUser()
-                                    withContext(Dispatchers.Main.immediate) {
-                                        userEventController.sendEvent(UserEvent.LoggedOut)
-                                    }
-                                }
-                            } catch (e: Exception) {
-                                if (e is CancellationException) throw e
-                                CrashReporter.recordException(e)
+                            val response = client.post("${NetworkConstants.BASE_URL}auth/refresh") {
+                                markAsRefreshTokenRequest()
+                                contentType(ContentType.Application.Json)
+                                setBody(RefreshRequest(oldRefresh))
                             }
-                            null
+
+                            if (response.status.isSuccess()) {
+                                val newTokens: TokenPairDto = response.body()
+                                val confirmed = newTokens.emailConfirmed
+                                    ?: authDataSource.getUserOnce()?.emailConfirmed
+                                    ?: false
+                                authDataSource.insertUser(
+                                    email = newTokens.email,
+                                    username = newTokens.username,
+                                    accessToken = newTokens.accessToken,
+                                    refreshToken = newTokens.refreshToken,
+                                    obfuscatedId = newTokens.obfuscatedId,
+                                    provider = AuthProvider.valueOf(newTokens.provider),
+                                    subscribed = newTokens.subscribed,
+                                    emailConfirmed = confirmed
+                                )
+                                BearerTokens(newTokens.accessToken, newTokens.refreshToken)
+                            } else {
+                                logoutOnce()
+                                null
+                            }
                         }
                     }
                     sendWithoutRequest { request ->
@@ -163,6 +149,22 @@ actual class HttpClientFactory actual constructor(
             }
         }
 
+    }
+
+    private suspend fun logoutOnce() {
+        try {
+            deleteMutex.withLock {
+                if (authDataSource.getUserOnce() != null) {
+                    authDataSource.deleteUser()
+                    withContext(Dispatchers.Main.immediate) {
+                        userEventController.sendEvent(UserEvent.LoggedOut)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            CrashReporter.recordException(e)
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- prevent concurrent logout when multiple requests receive 401
- ensure only one token refresh call happens at a time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bd56616ac83219b13a2f9bb642ca9