### PR TITLE
Add logout progress indicator

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowRight
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
@@ -184,6 +186,18 @@ fun SettingsScreen(
                     },
                     onDismiss = { showLanguageSheet = false }
                 )
+            }
+            if (state.value.isLoggingOut) {
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(
+                            MaterialTheme.colorScheme.background.copy(alpha = 0.6f)
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
@@ -19,6 +19,7 @@ data class SettingsState(
     val subscriptionStatus: String? = null,
     val anonymousExpiration: String? = null,
     val isLoading: Boolean = false,
+    val isLoggingOut: Boolean = false,
     val theme: Theme = Theme.SYSTEM,
     val dynamicColors: Boolean = false,
     val useSystemColors: Boolean = true,

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -221,8 +221,8 @@ class SettingsViewModel(
         logoutJob?.cancel()
         logoutJob = coroutineScope.launch {
             logoutUserUseCase()
-                .onStart { updateLoading(true) }
-                .onCompletion { updateLoading(false) }
+                .onStart { updateLoggingOut(true) }
+                .onCompletion { updateLoggingOut(false) }
                 .catchAndLog { e ->
                     showErrorSnackbar(e.toUserMessage(stringProvider))
                 }
@@ -240,6 +240,10 @@ class SettingsViewModel(
                     }
                 }
         }
+    }
+
+    private fun updateLoggingOut(loading: Boolean) {
+        _state.update { it.copy(isLoggingOut = loading) }
     }
 
     private fun updateLoading(isLoading: Boolean) {


### PR DESCRIPTION
## Summary
- add `isLoggingOut` flag to `SettingsState`
- show progress overlay when logging out
- track logout progress in `SettingsViewModel`

## Testing
- `gradle lint` *(fails: build disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688bdd4e87908321bc6937165773b2bb