### PR TITLE
Fix shimmer transition in settings

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import pl.cuyer.rusthub.android.designsystem.shimmer
+import androidx.compose.animation.AnimatedContent
+import pl.cuyer.rusthub.android.designsystem.defaultFadeTransition
 import androidx.compose.ui.draw.clip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -63,9 +65,9 @@ import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
 import pl.cuyer.rusthub.android.util.composeUtil.rememberCurrentLanguage
 import pl.cuyer.rusthub.android.util.composeUtil.stringResource
-import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.features.settings.SettingsAction
 import pl.cuyer.rusthub.presentation.features.settings.SettingsState
+import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.model.SubscriptionPlan
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
@@ -387,42 +389,50 @@ private fun AccountSection(
 
     val storeNavigator = koinInject<StoreNavigator>()
 
-    if (loading) {
-        AccountSectionShimmer()
-    } else if (subscribed) {
-        Text(
-            text = stringResource(
-                SharedRes.strings.you_are_subscribed,
-                stringResource(plan?.label ?: SharedRes.strings.pro)
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(bottom = spacing.xsmall)
-        )
-        planExpiration?.let {
-            Text(
-                text = stringResource(SharedRes.strings.subscription_expiration, it),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(bottom = spacing.xsmall)
-            )
-        }
-        status?.let {
-            Text(
-                text = stringResource(SharedRes.strings.status) + ": " + it,
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(bottom = spacing.xsmall)
-            )
-        }
-        AppTextButton(onClick = { storeNavigator.openSubscriptionManagement(SubscriptionPlan.SUBSCRIPTION_ID) }) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(stringResource(SharedRes.strings.manage_subscription))
-                Icon(
-                    imageVector = Icons.AutoMirrored.Default.ArrowRight,
-                    contentDescription = stringResource(SharedRes.strings.manage_subscription)
+    AnimatedContent(
+        targetState = loading,
+        transitionSpec = { defaultFadeTransition() }
+    ) { isLoading ->
+        if (isLoading) {
+            AccountSectionShimmer()
+        } else if (subscribed) {
+            Column(verticalArrangement = Arrangement.spacedBy(spacing.xsmall)) {
+                Text(
+                    text = stringResource(
+                        SharedRes.strings.you_are_subscribed,
+                        stringResource(plan?.label ?: SharedRes.strings.pro)
+                    ),
+                    style = MaterialTheme.typography.bodyMedium
                 )
+                planExpiration?.let {
+                    Text(
+                        text = stringResource(SharedRes.strings.subscription_expiration, it),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                status?.let {
+                    Text(
+                        text = stringResource(SharedRes.strings.status) + ": " + it,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+                AppTextButton(
+                    onClick = {
+                        storeNavigator.openSubscriptionManagement(SubscriptionPlan.SUBSCRIPTION_ID)
+                    }
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(stringResource(SharedRes.strings.manage_subscription))
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                            contentDescription = stringResource(SharedRes.strings.manage_subscription)
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- animate the account subscription shimmer with `AnimatedContent`
- flatten subscription fields directly in `SettingsState`
- update view model and screen composables to use the flattened state

## Testing
- `n/a`


------
https://chatgpt.com/codex/tasks/task_e_688be254e1e48321b4b76beb3fe9d798