### PR TITLE
Add animated loading transitions

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,6 +32,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import pl.cuyer.rusthub.android.feature.startup.StartupScreen
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.util.composeUtil.isSystemInDarkTheme
+import pl.cuyer.rusthub.android.designsystem.defaultFadeTransition
 import pl.cuyer.rusthub.domain.model.Theme
 import pl.cuyer.rusthub.presentation.features.startup.StartupViewModel
 import pl.cuyer.rusthub.util.InAppUpdateManager
@@ -115,13 +117,18 @@ class MainActivity : AppCompatActivity() {
             ) {
                 val state = startupViewModel.state.collectAsStateWithLifecycle()
                 RustHubBackground {
-                    if (state.value.isLoading) {
-                        StartupScreen(
-                            showSkip = { state.value.showSkip },
-                            onSkip = { startupViewModel.skipFetching() }
-                        )
-                    } else {
-                        NavigationRoot(startDestination = state.value.startDestination)
+                    AnimatedContent(
+                        targetState = state.value.isLoading,
+                        transitionSpec = { defaultFadeTransition() }
+                    ) { isLoading ->
+                        if (isLoading) {
+                            StartupScreen(
+                                showSkip = { state.value.showSkip },
+                                onSkip = { startupViewModel.skipFetching() }
+                            )
+                        } else {
+                            NavigationRoot(startDestination = state.value.startDestination)
+                        }
                     }
                 }
             }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSearchTopBar.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSearchTopBar.kt
@@ -2,6 +2,7 @@ package pl.cuyer.rusthub.android.designsystem
 
 
 import android.app.Activity
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.Spring
@@ -69,6 +70,7 @@ import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
 import pl.cuyer.rusthub.android.util.composeUtil.stringResource
 import pl.cuyer.rusthub.android.designsystem.SearchHistoryShimmer
+import pl.cuyer.rusthub.android.designsystem.defaultFadeTransition
 import pl.cuyer.rusthub.presentation.model.SearchQueryUi
 import dev.icerock.moko.resources.StringResource
 
@@ -231,13 +233,17 @@ private fun SearchHistorySuggestions(
     onSearchTriggered: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    if (isLoadingSearchHistory()) {
-        SearchHistoryShimmer(modifier = Modifier.fillMaxWidth())
-    } else {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(spacing.xxmedium)
-        ) {
+    AnimatedContent(
+        targetState = isLoadingSearchHistory(),
+        transitionSpec = { defaultFadeTransition() }
+    ) { loading ->
+        if (loading) {
+            SearchHistoryShimmer(modifier = Modifier.fillMaxWidth())
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(spacing.xxmedium)
+            ) {
             item(key = "label", contentType = "label") {
                 AnimatedVisibility(
                     visible = searchQueryUi().isNotEmpty(),

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/ConfirmEmailScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/auth/ConfirmEmailScreen.kt
@@ -2,6 +2,7 @@ package pl.cuyer.rusthub.android.feature.auth
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateBounds
 import androidx.compose.foundation.Image
@@ -59,6 +60,7 @@ import pl.cuyer.rusthub.android.util.composeUtil.stringResource
 import pl.cuyer.rusthub.android.designsystem.AppButton
 import pl.cuyer.rusthub.android.designsystem.AppTextButton
 import pl.cuyer.rusthub.android.designsystem.shimmer
+import pl.cuyer.rusthub.android.designsystem.defaultFadeTransition
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
@@ -132,25 +134,30 @@ fun ConfirmEmailScreen(
                 .clickable(interactionSource, null) { focusManager.clearFocus() },
             contentAlignment = Alignment.Center
         ) {
-            if (state.value.resendLoading) {
-                if (isTabletMode) {
-                    ConfirmEmailShimmerExpanded()
+            AnimatedContent(
+                targetState = state.value.resendLoading,
+                transitionSpec = { defaultFadeTransition() }
+            ) { loading ->
+                if (loading) {
+                    if (isTabletMode) {
+                        ConfirmEmailShimmerExpanded()
+                    } else {
+                        ConfirmEmailShimmerCompact()
+                    }
                 } else {
-                    ConfirmEmailShimmerCompact()
-                }
-            } else {
-                if (isTabletMode) {
-                    ConfirmEmailScreenExpanded(
-                        email = { state.value.email },
-                        isLoading = { state.value.isLoading },
-                        onAction = onAction
-                    )
-                } else {
-                    ConfirmEmailScreenCompact(
-                        email = { state.value.email },
-                        isLoading = { state.value.isLoading },
-                        onAction = onAction
-                    )
+                    if (isTabletMode) {
+                        ConfirmEmailScreenExpanded(
+                            email = { state.value.email },
+                            isLoading = { state.value.isLoading },
+                            onAction = onAction
+                        )
+                    } else {
+                        ConfirmEmailScreenCompact(
+                            email = { state.value.email },
+                            isLoading = { state.value.isLoading },
+                            onAction = onAction
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- animate startup screen and navigation swap
- animate search history progress
- animate resend email progress

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688beda6b2c483219f24a607453f6ffe