### PR TITLE
Fix NPE in GreetingSection

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -554,12 +554,12 @@ private fun OtherSection(onAction: (SettingsAction) -> Unit) {
 @Composable
 private fun GreetingSection(username: String?) {
     AnimatedContent(
-        targetState = username != null,
+        targetState = username,
         transitionSpec = { defaultFadeTransition() }
-    ) { exist ->
-        if (exist) {
+    ) { name ->
+        if (name != null) {
             Text(
-                text = stringResource(SharedRes.strings.hello_username, username!!),
+                text = stringResource(SharedRes.strings.hello_username, name),
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
                 style = MaterialTheme.typography.headlineSmall,


### PR DESCRIPTION
## Summary
- prevent crash when username becomes `null`

## Testing
- `gradle` build/test skipped per instructions

------
https://chatgpt.com/codex/tasks/task_e_688c6d8b12e883219ca98e7a44b0af00