### PR TITLE
Add terms button & animated subscribe text

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -526,6 +526,23 @@ private fun OtherSection(onAction: (SettingsAction) -> Unit) {
     }
 
     AppTextButton(
+        onClick = { onAction(SettingsAction.OnTerms) }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(stringResource(SharedRes.strings.terms_conditions))
+            Icon(
+                imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                contentDescription = stringResource(SharedRes.strings.terms_conditions_button)
+            )
+        }
+    }
+
+    AppTextButton(
         onClick = { storeNavigator.openStore() }
     ) {
         Row(

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
@@ -5,6 +5,7 @@ import androidx.activity.compose.LocalActivity
 import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateBounds
@@ -582,7 +583,11 @@ private fun SubscribeActions(
                     contentColor = MaterialTheme.colorScheme.onBackground
                 ),
                 enabled = !samePlan && !lifetimeOwned
-            ) { Text(text) }
+            ) {
+                Crossfade(targetState = text) { value ->
+                    Text(value)
+                }
+            }
         }
     }
     AppTextButton(onClick = onNavigateUp) {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -21,6 +21,8 @@ sealed interface SettingsAction {
     @Immutable
     data object OnPrivacyPolicy : SettingsAction
     @Immutable
+    data object OnTerms : SettingsAction
+    @Immutable
     data object OnDeleteAccount : SettingsAction
     @Immutable
     data object OnUpgradeAccount : SettingsAction

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -36,6 +36,7 @@ import pl.cuyer.rusthub.presentation.navigation.ChangePassword
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
+import pl.cuyer.rusthub.presentation.navigation.Terms
 import pl.cuyer.rusthub.presentation.navigation.Subscription
 import pl.cuyer.rusthub.presentation.navigation.ConfirmEmail
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
@@ -120,6 +121,7 @@ class SettingsViewModel(
             SettingsAction.OnDismissSubscriptionDialog -> Unit
             SettingsAction.OnSubscribe -> Unit
             SettingsAction.OnPrivacyPolicy -> openPrivacyPolicy()
+            SettingsAction.OnTerms -> openTerms()
             SettingsAction.OnDeleteAccount -> navigateDeleteAccount()
             SettingsAction.OnUpgradeAccount -> navigateUpgrade()
             SettingsAction.OnResume -> refreshSubscription()
@@ -334,6 +336,12 @@ class SettingsViewModel(
     private fun openPrivacyPolicy() {
         coroutineScope.launch {
             _uiEvent.send(UiEvent.Navigate(PrivacyPolicy))
+        }
+    }
+
+    private fun openTerms() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(Terms))
         }
     }
 }

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -244,6 +244,7 @@
     <string name="no_ads_desc">Enjoy an ad-free experience.</string>
     <string name="no_ads_icon_desc">No ads icon</string>
     <string name="terms_conditions">Terms &amp; conditions</string>
+    <string name="terms_conditions_button">Terms &amp; conditions button</string>
     <string name="faq_lifetime_answer">The RustHub Pro Lifetime plan is a one time purchase. You will have access to RustHub Pro forever.\n\nIf you are already subscribed to a monthly or yearly plan and want to switch to a lifetime plan, make sure to cancel your monthly or yearly subscription after you purchase the lifetime plan to avoid any recurring charges.</string>
     <string name="faq_renew_answer">The RustHub Pro monthly and yearly plans are subscriptions that renew automatically at the end of your subscription term to avoid any interruption to your service. If you cancel your subscription, you will continue to have access to RustHub Pro until your subscription expires. The RustHub Pro Lifetime plan is a one time purchase.</string>
     <string name="theme">Theme</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -243,6 +243,7 @@
     <string name="no_ads_desc">Genieße eine werbefreie Nutzung.</string>
     <string name="no_ads_icon_desc">Keine Werbung Symbol</string>
     <string name="terms_conditions">AGB</string>
+    <string name="terms_conditions_button">AGB-Button</string>
     <string name="faq_lifetime_answer">Der RustHub Pro Lifetime-Plan ist ein einmaliger Kauf. Du hast dauerhaft Zugriff auf RustHub Pro. Wenn du bereits ein monatliches oder jährliches Abo hast und auf Lifetime wechseln willst, kündige das alte Abo nach dem Kauf des Lifetime-Plans, um doppelte Zahlungen zu vermeiden.</string>
     <string name="faq_renew_answer">Die monatlichen und jährlichen RustHub Pro-Pläne sind Abos, die sich automatisch verlängern. Nach einer Kündigung bleibt der Zugriff bis zum Ende des Abos erhalten. Lifetime ist ein einmaliger Kauf.</string>
     <string name="theme">Thema</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -243,6 +243,7 @@
     <string name="no_ads_desc">Profitez sans publicité.</string>
     <string name="no_ads_icon_desc">Icône sans pub</string>
     <string name="terms_conditions">Conditions générales</string>
+    <string name="terms_conditions_button">Bouton conditions générales</string>
     <string name="faq_lifetime_answer">Le plan RustHub Pro Lifetime est un achat unique. Vous aurez un accès à vie à RustHub Pro.\n\nSi vous avez déjà un abonnement mensuel ou annuel et que vous souhaitez passer au Lifetime, pensez à annuler votre ancien abonnement pour éviter toute facturation récurrente.</string>
     <string name="faq_renew_answer">Les formules mensuelles et annuelles de RustHub Pro sont des abonnements qui se renouvellent automatiquement. Après annulation, vous gardez l'accès à RustHub Pro jusqu'à la fin de la période en cours. La formule Lifetime est un achat unique.</string>
     <string name="theme">Thème</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -243,6 +243,7 @@
     <string name="no_ads_desc">Korzystaj z aplikacji bez reklam.</string>
     <string name="no_ads_icon_desc">Ikona brak reklam</string>
     <string name="terms_conditions">Regulamin</string>
+    <string name="terms_conditions_button">Przycisk regulaminu</string>
     <string name="faq_lifetime_answer">Plan RustHub Pro Lifetime to jednorazowy zakup. Uzyskujesz dostęp do RustHub Pro na zawsze. Jeśli masz już aktywną subskrypcję miesięczną lub roczną i chcesz przejść na plan Lifetime, po jego zakupie pamiętaj o anulowaniu dotychczasowej subskrypcji, aby uniknąć dalszych opłat cyklicznych.</string>
     <string name="faq_renew_answer">Plany RustHub Pro miesięczny i roczny to subskrypcje, które odnawiają się automatycznie po zakończeniu okresu subskrypcji, aby uniknąć przerw w działaniu usługi. Jeśli anulujesz subskrypcję, będziesz mieć dostęp do RustHub Pro aż do wygaśnięcia obecnej subskrypcji. Plan RustHub Pro Lifetime to jednorazowy zakup.</string>
     <string name="theme">Motyw</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -243,6 +243,7 @@
     <string name="no_ads_desc">Наслаждайтесь без рекламы.</string>
     <string name="no_ads_icon_desc">Иконка без рекламы</string>
     <string name="terms_conditions">Условия использования</string>
+    <string name="terms_conditions_button">Кнопка условий использования</string>
     <string name="faq_lifetime_answer">План RustHub Pro Lifetime — единоразовая покупка. Доступ к RustHub Pro навсегда. Если у вас уже есть месячная или годовая подписка и вы хотите перейти на Lifetime, не забудьте отменить предыдущую подписку, чтобы избежать двойных списаний.</string>
     <string name="faq_renew_answer">Месячные и годовые планы RustHub Pro — это подписки с автопродлением. После отмены подписки вы пользуетесь сервисом до конца оплаченного периода. Lifetime — это разовая покупка.</string>
     <string name="theme">Тема</string>


### PR DESCRIPTION
## Summary
- add Terms button in Settings
- support OnTerms action in domain
- show crossfade animation for subscribe button text
- translate new `terms_conditions_button` string for all locales

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cc1163a1c832186a7a5d61cd5b99d