### PR TITLE
Add About screen with app info and licenses

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.googleServices)
     alias(libs.plugins.crashlytics)
     alias(libs.plugins.performance)
+    alias(libs.plugins.ossLicenses)
 }
 
 composeCompiler {
@@ -22,7 +23,7 @@ android {
         applicationId = "pl.cuyer.rusthub.android"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 36
+        versionCode = 37
         versionName = project.property("VERSION_NAME") as String
         buildConfigField("String", "SERVERS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/4096035325\"")
         buildConfigField("String", "ITEMS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/1469871989\"")
@@ -152,6 +153,7 @@ dependencies {
     implementation(libs.google.play.app.update.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.play.services.ads)
+    implementation(libs.play.services.oss.licenses)
     coreLibraryDesugaring(libs.desugar.jdk.libs.v215)
     debugImplementation(libs.compose.ui.tooling)
 }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -69,5 +69,9 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:exported="false"
+            android:theme="@style/Theme.RustHub" />
     </application>
 </manifest>

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -72,6 +72,7 @@ import pl.cuyer.rusthub.presentation.features.item.ItemDetailsViewModel
 import pl.cuyer.rusthub.android.feature.settings.ChangePasswordScreen
 import pl.cuyer.rusthub.android.feature.settings.DeleteAccountScreen
 import pl.cuyer.rusthub.android.feature.settings.PrivacyPolicyScreen
+import pl.cuyer.rusthub.android.feature.about.AboutScreen
 import pl.cuyer.rusthub.android.feature.settings.SettingsScreen
 import pl.cuyer.rusthub.android.feature.subscription.SubscriptionScreen
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
@@ -107,6 +108,7 @@ import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings
 import pl.cuyer.rusthub.presentation.navigation.Subscription
 import pl.cuyer.rusthub.presentation.navigation.Terms
+import pl.cuyer.rusthub.presentation.navigation.About
 import pl.cuyer.rusthub.presentation.navigation.UpgradeAccount
 import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
@@ -413,6 +415,11 @@ private fun AppScaffold(
                         PrivacyPolicyScreen(
                             url = Urls.TERMS_URL,
                             title = stringResource(SharedRes.strings.terms_conditions),
+                            onNavigateUp = { backStack.removeLastOrNull() }
+                        )
+                    }
+                    entry<About> {
+                        AboutScreen(
                             onNavigateUp = { backStack.removeLastOrNull() }
                         )
                     }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/about/AboutScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/about/AboutScreen.kt
@@ -1,0 +1,186 @@
+package pl.cuyer.rusthub.android.feature.about
+
+import android.content.Intent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowRight
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.contentColorFor
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation3.runtime.NavKey
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+import org.koin.compose.koinInject
+import pl.cuyer.rusthub.BuildConfig
+import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.android.designsystem.AppTextButton
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.util.composeUtil.stringResource
+import pl.cuyer.rusthub.common.getImageByFileName
+import pl.cuyer.rusthub.util.AppInfo
+import pl.cuyer.rusthub.util.EmailSender
+import pl.cuyer.rusthub.util.UrlOpener
+import androidx.compose.foundation.Image
+import androidx.compose.ui.res.painterResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(onNavigateUp: () -> Unit) {
+    val urlOpener = koinInject<UrlOpener>()
+    val emailSender = koinInject<EmailSender>()
+    val context = LocalContext.current
+    val versionName = remember { AppInfo.versionName }
+    val versionCode = BuildConfig.VERSION_CODE
+    Scaffold(
+        containerColor = Color.Transparent,
+        contentColor = MaterialTheme.colorScheme.onBackground,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(stringResource(SharedRes.strings.about), fontWeight = FontWeight.SemiBold)
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(SharedRes.strings.navigate_up),
+                            tint = contentColorFor(TopAppBarDefaults.topAppBarColors().containerColor)
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
+                .verticalScroll(rememberScrollState())
+                .padding(spacing.medium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(spacing.medium)
+        ) {
+            Text(
+                text = stringResource(SharedRes.strings.app_info),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Start
+            )
+            Image(
+                painter = painterResource(id = getImageByFileName("rusthub_logo").drawableResId),
+                contentDescription = stringResource(SharedRes.strings.application_logo),
+                modifier = Modifier.size(96.dp)
+            )
+            Text(stringResource(SharedRes.strings.app_name), style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = stringResource(SharedRes.strings.app_version_build, versionName, versionCode),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = stringResource(SharedRes.strings.developer_info),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = spacing.medium),
+                textAlign = TextAlign.Start
+            )
+            Text(stringResource(SharedRes.strings.website) + ": rusthub.me")
+            Text(stringResource(SharedRes.strings.contact_email) + ": rusthubapplication@gmail.com")
+            AppTextButton(onClick = { urlOpener.openUrl("https://rusthub.me") }) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(stringResource(SharedRes.strings.website))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                        contentDescription = stringResource(SharedRes.strings.website)
+                    )
+                }
+            }
+            AppTextButton(onClick = {
+                emailSender.sendEmail("rusthubapplication@gmail.com", "RustHub - bug report")
+            }) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(stringResource(SharedRes.strings.report_bug))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                        contentDescription = stringResource(SharedRes.strings.report_bug_button)
+                    )
+                }
+            }
+            AppTextButton(onClick = {
+                emailSender.sendEmail("rusthubapplication@gmail.com", "RustHub - feature suggestion")
+            }) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(stringResource(SharedRes.strings.suggest_feature))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                        contentDescription = stringResource(SharedRes.strings.suggest_feature_button)
+                    )
+                }
+            }
+            AppTextButton(onClick = {
+                OssLicensesMenuActivity.setActivityTitle(stringResource(SharedRes.strings.licenses))
+                context.startActivity(Intent(context, OssLicensesMenuActivity::class.java))
+            }) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(stringResource(SharedRes.strings.open_source_licenses))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                        contentDescription = stringResource(SharedRes.strings.open_source_licenses_button)
+                    )
+                }
+            }
+
+            val facepunch = stringResource(SharedRes.strings.facepunch)
+            Text(
+                text = stringResource(SharedRes.strings.disclaimer_facepunch, facepunch),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -71,7 +71,6 @@ import pl.cuyer.rusthub.domain.model.AuthProvider
 import pl.cuyer.rusthub.presentation.model.SubscriptionPlan
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
-import pl.cuyer.rusthub.util.AppInfo
 import pl.cuyer.rusthub.util.StoreNavigator
 import pl.cuyer.rusthub.android.util.composeUtil.OnLifecycleEvent
 import androidx.lifecycle.Lifecycle
@@ -559,13 +558,22 @@ private fun OtherSection(onAction: (SettingsAction) -> Unit) {
         }
     }
 
-    val versionName = remember { AppInfo.versionName }
-    Text(
-        modifier = Modifier.fillMaxWidth(),
-        style = MaterialTheme.typography.bodySmall,
-        text = stringResource(SharedRes.strings.app_version, versionName),
-        textAlign = TextAlign.Center
-    )
+    AppTextButton(
+        onClick = { onAction(SettingsAction.OnAbout) }
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(stringResource(SharedRes.strings.about))
+            Icon(
+                imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                contentDescription = stringResource(SharedRes.strings.about_button)
+            )
+        }
+    }
+
 }
 
 @Composable

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ kotlin.incremental.multiplatform=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 # App version
-VERSION_NAME=0.0.36
+VERSION_NAME=0.0.37

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ protobufPlugin = "0.9.5"
 protobuf = "4.31.1"
 runtime = "1.9.0-rc01"
 userMessagingPlatform = "3.2.0"
+oss-licenses = "17.0.1"
+oss-license-plugin = "0.10.6"
 
 [libraries]
 
@@ -145,6 +147,7 @@ moko-permissions-notifications = { module = "dev.icerock.moko:permissions-notifi
 google-identity = { module = "com.google.android.libraries.identity.googleid:googleid", version.ref = "identity" }
 google-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "google-auth" }
 play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "play-services-ads" }
+play-services-oss-licenses = { module = "com.google.android.gms:play-services-oss-licenses", version.ref = "oss-licenses" }
 play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "play-review" }
 play-billing = { module = "com.android.billingclient:billing-ktx", version.ref = "play-billing" }
 certificate-transparency = { module = "com.appmattus.certificatetransparency:certificatetransparency-android", version.ref = "certificate-transparency" }
@@ -170,3 +173,4 @@ sqlDelightGradlePlugin = { id = "app.cash.sqldelight", version.ref = "sql-deligh
 mokoMultiplatformResources = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "moko-resources" }
 buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
+ossLicenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "oss-license-plugin" }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-        <string>0.0.3</string>
+        <string>0.0.4</string>
 	<key>CFBundleVersion</key>
-        <string>3</string>
+        <string>4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -94,6 +94,8 @@ actual val platformModule: Module = module {
     single { InAppUpdateManager(androidContext(), get(), get()) }
     single { ReviewRequester(androidContext()) }
     single { StoreNavigator(androidContext()) }
+    single { UrlOpener(androidContext()) }
+    single { EmailSender(androidContext()) }
     single { SystemDarkThemeObserver(androidContext()) }
     single { ConnectivityObserver(androidContext()) }
     single { GoogleAuthClient(androidContext()) }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/EmailSender.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/EmailSender.android.kt
@@ -1,0 +1,20 @@
+package pl.cuyer.rusthub.util
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+
+actual class EmailSender(private val context: Context) {
+    actual fun sendEmail(recipient: String, subject: String) {
+        val intent = Intent(Intent.ACTION_SENDTO).apply {
+            data = Uri.parse("mailto:")
+            putExtra(Intent.EXTRA_EMAIL, arrayOf(recipient))
+            putExtra(Intent.EXTRA_SUBJECT, subject)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val chooser = Intent.createChooser(intent, null).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(chooser)
+    }
+}

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/UrlOpener.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/UrlOpener.android.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.util
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+
+actual class UrlOpener(private val context: Context) {
+    actual fun openUrl(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri()).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -29,6 +29,8 @@ sealed interface SettingsAction {
     @Immutable
     data object OnResume : SettingsAction
     @Immutable
+    data object OnAbout : SettingsAction
+    @Immutable
     data class OnThemeChange(val theme: Theme) : SettingsAction
     @Immutable
     data class OnDynamicColorsChange(val enabled: Boolean) : SettingsAction

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -38,6 +38,7 @@ import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.Terms
 import pl.cuyer.rusthub.presentation.navigation.Subscription
+import pl.cuyer.rusthub.presentation.navigation.About
 import pl.cuyer.rusthub.presentation.navigation.ConfirmEmail
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.navigation.UpgradeAccount
@@ -122,6 +123,7 @@ class SettingsViewModel(
             SettingsAction.OnSubscribe -> Unit
             SettingsAction.OnPrivacyPolicy -> openPrivacyPolicy()
             SettingsAction.OnTerms -> openTerms()
+            SettingsAction.OnAbout -> navigateAbout()
             SettingsAction.OnDeleteAccount -> navigateDeleteAccount()
             SettingsAction.OnUpgradeAccount -> navigateUpgrade()
             SettingsAction.OnResume -> refreshSubscription()
@@ -342,6 +344,12 @@ class SettingsViewModel(
     private fun openTerms() {
         coroutineScope.launch {
             _uiEvent.send(UiEvent.Navigate(Terms))
+        }
+    }
+
+    private fun navigateAbout() {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(About))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -63,5 +63,8 @@ data class ResetPassword(val email: String) : NavKey
 data object Terms : NavKey
 
 @Serializable
+data object About : NavKey
+
+@Serializable
 @Immutable
 data class Subscription(val plan: SubscriptionPlan? = null) : NavKey

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/EmailSender.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/EmailSender.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+expect class EmailSender {
+    fun sendEmail(recipient: String, subject: String)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/UrlOpener.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/UrlOpener.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+expect class UrlOpener {
+    fun openUrl(url: String)
+}

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -174,6 +174,22 @@
     <string name="ranking">Ranking</string>
     <string name="rate_application">Rate application</string>
     <string name="rate_application_button">Rate application button</string>
+    <string name="about">About</string>
+    <string name="about_button">About button</string>
+    <string name="app_info">App info</string>
+    <string name="developer_info">Developer info</string>
+    <string name="website">Website</string>
+    <string name="contact_email">Contact email</string>
+    <string name="open_source_licenses">Open source licenses</string>
+    <string name="open_source_licenses_button">Open source licenses button</string>
+    <string name="report_bug">Report a bug</string>
+    <string name="report_bug_button">Report bug button</string>
+    <string name="suggest_feature">Suggest a feature</string>
+    <string name="suggest_feature_button">Suggest feature button</string>
+    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="facepunch" translatable="false">Facepunch</string>
+    <string name="disclaimer_facepunch">RustHub is not affiliated with nor endorsed by %1$s</string>
+    <string name="licenses">Licenses</string>
     <string name="rates">Rates</string>
     <string name="receive_notifications_about_map_and_full_wipes">Receive notifications about map and full wipes.</string>
     <string name="recent_searches">Recent searches</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -173,6 +173,22 @@
     <string name="ranking">Ranking</string>
     <string name="rate_application">App bewerten</string>
     <string name="rate_application_button">App-Bewerten-Button</string>
+    <string name="about">About</string>
+    <string name="about_button">About button</string>
+    <string name="app_info">App info</string>
+    <string name="developer_info">Developer info</string>
+    <string name="website">Website</string>
+    <string name="contact_email">Contact email</string>
+    <string name="open_source_licenses">Open source licenses</string>
+    <string name="open_source_licenses_button">Open source licenses button</string>
+    <string name="report_bug">Report a bug</string>
+    <string name="report_bug_button">Report bug button</string>
+    <string name="suggest_feature">Suggest a feature</string>
+    <string name="suggest_feature_button">Suggest feature button</string>
+    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="facepunch" translatable="false">Facepunch</string>
+    <string name="disclaimer_facepunch">RustHub steht in keiner Verbindung zu %1$s und wird nicht von ihnen unterstützt.</string>
+    <string name="licenses">Licenses</string>
     <string name="rates">Raten</string>
     <string name="receive_notifications_about_map_and_full_wipes">Erhalte Benachrichtigungen über Karten- und komplette Wipes.</string>
     <string name="recent_searches">Letzte Suchanfragen</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -173,6 +173,22 @@
     <string name="ranking">Classement</string>
     <string name="rate_application">Noter l'application</string>
     <string name="rate_application_button">Bouton de notation de l’application</string>
+    <string name="about">About</string>
+    <string name="about_button">About button</string>
+    <string name="app_info">App info</string>
+    <string name="developer_info">Developer info</string>
+    <string name="website">Website</string>
+    <string name="contact_email">Contact email</string>
+    <string name="open_source_licenses">Open source licenses</string>
+    <string name="open_source_licenses_button">Open source licenses button</string>
+    <string name="report_bug">Report a bug</string>
+    <string name="report_bug_button">Report bug button</string>
+    <string name="suggest_feature">Suggest a feature</string>
+    <string name="suggest_feature_button">Suggest feature button</string>
+    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="facepunch" translatable="false">Facepunch</string>
+    <string name="disclaimer_facepunch">RustHub n'est ni affilié ni approuvé par %1$s.</string>
+    <string name="licenses">Licenses</string>
     <string name="rates">Tarifs</string>
     <string name="receive_notifications_about_map_and_full_wipes">Recevez des notifications pour les wipes de carte et les wipes complets.</string>
     <string name="recent_searches">Recherches récentes</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -173,6 +173,22 @@
     <string name="ranking">Ranking</string>
     <string name="rate_application">Oceń aplikację</string>
     <string name="rate_application_button">Przycisk ocenienia aplikacji</string>
+    <string name="about">About</string>
+    <string name="about_button">About button</string>
+    <string name="app_info">App info</string>
+    <string name="developer_info">Developer info</string>
+    <string name="website">Website</string>
+    <string name="contact_email">Contact email</string>
+    <string name="open_source_licenses">Open source licenses</string>
+    <string name="open_source_licenses_button">Open source licenses button</string>
+    <string name="report_bug">Report a bug</string>
+    <string name="report_bug_button">Report bug button</string>
+    <string name="suggest_feature">Suggest a feature</string>
+    <string name="suggest_feature_button">Suggest feature button</string>
+    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="facepunch" translatable="false">Facepunch</string>
+    <string name="disclaimer_facepunch">RustHub nie jest powiązany ani wspierany przez %1$s.</string>
+    <string name="licenses">Licenses</string>
     <string name="rates">Rate'y</string>
     <string name="receive_notifications_about_map_and_full_wipes">Otrzymuj powiadomienia o wipe’ach map i pełnych wipe’ach.</string>
     <string name="recent_searches">Ostatnie wyszukiwania</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -173,6 +173,22 @@
     <string name="ranking">Рейтинг</string>
     <string name="rate_application">Оценить приложение</string>
     <string name="rate_application_button">Кнопка оценки приложения</string>
+    <string name="about">About</string>
+    <string name="about_button">About button</string>
+    <string name="app_info">App info</string>
+    <string name="developer_info">Developer info</string>
+    <string name="website">Website</string>
+    <string name="contact_email">Contact email</string>
+    <string name="open_source_licenses">Open source licenses</string>
+    <string name="open_source_licenses_button">Open source licenses button</string>
+    <string name="report_bug">Report a bug</string>
+    <string name="report_bug_button">Report bug button</string>
+    <string name="suggest_feature">Suggest a feature</string>
+    <string name="suggest_feature_button">Suggest feature button</string>
+    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="facepunch" translatable="false">Facepunch</string>
+    <string name="disclaimer_facepunch">RustHub не связан и не одобрен компанией %1$s.</string>
+    <string name="licenses">Licenses</string>
     <string name="rates">Ставки</string>
     <string name="receive_notifications_about_map_and_full_wipes">Получайте уведомления о вайпах карты и полных вайпах.</string>
     <string name="recent_searches">Недавние поиски</string>

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -75,6 +75,8 @@ actual val platformModule: Module = module {
     single { InAppUpdateManager() }
     single { ReviewRequester() }
     single { StoreNavigator() }
+    single { UrlOpener() }
+    single { EmailSender() }
     single { SystemDarkThemeObserver() }
     single { GoogleAuthClient() }
     single { StringProvider() }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/EmailSender.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/EmailSender.ios.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.util
+
+actual class EmailSender {
+    actual fun sendEmail(recipient: String, subject: String) {
+        // no-op for iOS
+    }
+}

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/UrlOpener.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/UrlOpener.ios.kt
@@ -1,0 +1,7 @@
+package pl.cuyer.rusthub.util
+
+actual class UrlOpener {
+    actual fun openUrl(url: String) {
+        // no-op for iOS
+    }
+}


### PR DESCRIPTION
## Summary
- implement AboutScreen with Facepunch disclaimer link
- remove version footer from Settings screen
- localize new disclaimer strings
- remove clickable link from Facepunch disclaimer text
- bump version code and name

## Testing
- `gradle` build and tests are skipped per repository guidelines

------
https://chatgpt.com/codex/tasks/task_e_688cc45f315c8321aa58652bd6aacb93