### PR TITLE
Add next-wipe ordering and prevent invalid subscriptions

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Order.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Order.kt
@@ -8,7 +8,8 @@ import androidx.compose.runtime.Immutable
 enum class Order {
     WIPE,
     RANK,
-    PLAYER_COUNT;
+    PLAYER_COUNT,
+    NEXT_WIPE;
 
     companion object {
         fun fromDisplayName(displayName: String, stringProvider: StringProvider): Order? {
@@ -22,4 +23,5 @@ fun Order.displayName(stringProvider: StringProvider): String =
         Order.WIPE -> stringProvider.get(SharedRes.strings.last_wipe)
         Order.RANK -> stringProvider.get(SharedRes.strings.ranking)
         Order.PLAYER_COUNT -> stringProvider.get(SharedRes.strings.player_count)
+        Order.NEXT_WIPE -> stringProvider.get(SharedRes.strings.closest_wipe)
     }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -310,6 +310,13 @@ class ServerDetailsViewModel(
                 showUnconfirmedSnackbar()
                 return@launch
             }
+            val details = state.value.details
+            if (details?.nextWipe == null && details?.nextMapWipe == null) {
+                snackbarController.sendEvent(
+                    SnackbarEvent(stringProvider.get(SharedRes.strings.no_wipe_for_subscription))
+                )
+                return@launch
+            }
             try {
                 permissionsController.providePermission(Permission.REMOTE_NOTIFICATION)
                 toggleSubscription()

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -144,6 +144,7 @@
     <string name="new_password">New password</string>
     <string name="next_map_wipe">Next map wipe</string>
     <string name="next_wipe">Next wipe</string>
+    <string name="closest_wipe">Closest wipe</string>
     <string name="no">No</string>
     <string name="no_filters_available">No filters available</string>
     <string name="no_kits">No kits</string>
@@ -353,6 +354,7 @@
     <string name="error_remove_favourite">An error occurred when trying to remove server from favourites</string>
     <string name="error_subscribe_notifications">An error occurred when trying to subscribe to notifications</string>
     <string name="error_unsubscribe_notifications">An error occurred when trying to unsubscribe from notifications</string>
+    <string name="no_wipe_for_subscription">Cannot subscribe - server has no wipe schedule</string>
     <string name="email_not_confirmed">Email not confirmed</string>
     <string name="resend">Resend</string>
     <string name="error_fetching_server_data">An error occurred while fetching data about the server.</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -143,6 +143,7 @@
     <string name="new_password">Neues Passwort</string>
     <string name="next_map_wipe">Nächster Karten-Wipe</string>
     <string name="next_wipe">Nächster Wipe</string>
+    <string name="closest_wipe">Nächster Wipe</string>
     <string name="no">Nein</string>
     <string name="no_filters_available">Keine Filter verfügbar</string>
     <string name="no_kits">Keine Kits</string>
@@ -351,6 +352,7 @@
     <string name="error_remove_favourite">Beim Entfernen aus den Favoriten ist ein Fehler aufgetreten</string>
     <string name="error_subscribe_notifications">Beim Abonnieren der Benachrichtigungen ist ein Fehler aufgetreten</string>
     <string name="error_unsubscribe_notifications">Beim Abbestellen der Benachrichtigungen ist ein Fehler aufgetreten</string>
+    <string name="no_wipe_for_subscription">Abonnieren nicht möglich - kein Wipe-Plan</string>
     <string name="email_not_confirmed">E-Mail nicht bestätigt</string>
     <string name="resend">Erneut senden</string>
     <string name="error_fetching_server_data">Beim Laden der Serverdaten ist ein Fehler aufgetreten.</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -143,6 +143,7 @@
     <string name="new_password">Nouveau mot de passe</string>
     <string name="next_map_wipe">Prochain wipe de carte</string>
     <string name="next_wipe">Prochain wipe</string>
+    <string name="closest_wipe">Prochain wipe</string>
     <string name="no">Non</string>
     <string name="no_filters_available">Aucun filtre disponible</string>
     <string name="no_kits">Aucun kit</string>
@@ -351,6 +352,7 @@
     <string name="error_remove_favourite">Erreur lors de la suppression des favoris</string>
     <string name="error_subscribe_notifications">Erreur lors de l’abonnement aux notifications</string>
     <string name="error_unsubscribe_notifications">Erreur lors de la désactivation des notifications</string>
+    <string name="no_wipe_for_subscription">Impossible de s’abonner - aucune date de wipe</string>
     <string name="email_not_confirmed">E-mail non confirmé</string>
     <string name="resend">Renvoyer</string>
     <string name="error_fetching_server_data">Erreur lors de la récupération des données du serveur.</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -143,6 +143,7 @@
     <string name="new_password">Nowe hasło</string>
     <string name="next_map_wipe">Następny wipe mapy</string>
     <string name="next_wipe">Następny wipe</string>
+    <string name="closest_wipe">Najbliższy wipe</string>
     <string name="no">Nie</string>
     <string name="no_filters_available">Brak filtrów</string>
     <string name="no_kits">Brak zestawów</string>
@@ -351,6 +352,7 @@
     <string name="error_remove_favourite">Błąd usuwania z ulubionych</string>
     <string name="error_subscribe_notifications">Błąd subskrybowania powiadomień</string>
     <string name="error_unsubscribe_notifications">Błąd wyłączania powiadomień</string>
+    <string name="no_wipe_for_subscription">Nie można subskrybować - brak daty wipe</string>
     <string name="email_not_confirmed">E-mail niepotwierdzony</string>
     <string name="resend">Wyślij ponownie</string>
     <string name="error_fetching_server_data">Błąd pobierania danych o serwerze.</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -143,6 +143,7 @@
     <string name="new_password">Новый пароль</string>
     <string name="next_map_wipe">Следующий вайп карты</string>
     <string name="next_wipe">Следующий вайп</string>
+    <string name="closest_wipe">Следующий вайп</string>
     <string name="no">Нет</string>
     <string name="no_filters_available">Нет фильтров</string>
     <string name="no_kits">Нет наборов</string>
@@ -351,6 +352,7 @@
     <string name="error_remove_favourite">Ошибка при удалении из избранного</string>
     <string name="error_subscribe_notifications">Ошибка при подписке на уведомления</string>
     <string name="error_unsubscribe_notifications">Ошибка при отмене уведомлений</string>
+    <string name="no_wipe_for_subscription">Невозможно подписаться - нет даты вайпа</string>
     <string name="email_not_confirmed">E-mail не подтверждён</string>
     <string name="resend">Отправить ещё раз</string>
     <string name="error_fetching_server_data">Ошибка при получении данных о сервере.</string>


### PR DESCRIPTION
## Summary
- add `NEXT_WIPE` order option with string resources
- show snackbar when subscribing to server without wipe schedule

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_688cf3c4b75483218e95d9cd3992af8f