### PR TITLE
Fix: handle plan load failure

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
@@ -280,6 +280,7 @@ fun SubscriptionScreen(
                         onTerms = onTerms,
                         products = state.value.products,
                         isLoading = state.value.isLoading,
+                        hasProductsError = state.value.hasProductsError,
                         currentPlan = state.value.currentPlan,
                         onAction = onAction
                     )
@@ -294,6 +295,7 @@ fun SubscriptionScreen(
                         onTerms = onTerms,
                         products = state.value.products,
                         isLoading = state.value.isLoading,
+                        hasProductsError = state.value.hasProductsError,
                         currentPlan = state.value.currentPlan,
                         onAction = onAction
                     )
@@ -326,6 +328,7 @@ private fun SubscriptionScreenCompact(
     onTerms: () -> Unit,
     products: Map<SubscriptionPlan, BillingProduct>,
     isLoading: Boolean,
+    hasProductsError: Boolean,
     currentPlan: SubscriptionPlan?,
     onAction: (SubscriptionAction) -> Unit
 ) {
@@ -338,19 +341,21 @@ private fun SubscriptionScreenCompact(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         BenefitCarousel(pagerState = pagerState)
-        AnimatedContent(
-            targetState = isLoading,
-            transitionSpec = { defaultFadeTransition() }
-        ) { loading ->
-            if (loading) {
-                PlanSelectorShimmer(Modifier.fillMaxWidth())
-            } else {
-                PlanSelector(
-                    selectedPlan = selectedPlan,
-                    onPlanSelect = onPlanSelect,
-                    products = products,
-                    currentPlan = currentPlan
-                )
+        if (!hasProductsError) {
+            AnimatedContent(
+                targetState = isLoading,
+                transitionSpec = { defaultFadeTransition() }
+            ) { loading ->
+                if (loading) {
+                    PlanSelectorShimmer(Modifier.fillMaxWidth())
+                } else {
+                    PlanSelector(
+                        selectedPlan = selectedPlan,
+                        onPlanSelect = onPlanSelect,
+                        products = products,
+                        currentPlan = currentPlan
+                    )
+                }
             }
         }
         SubscribeActions(selectedPlan, onNavigateUp, onPrivacyPolicy, onTerms, currentPlan, isLoading) {
@@ -374,6 +379,7 @@ private fun SubscriptionScreenExpanded(
     onTerms: () -> Unit,
     products: Map<SubscriptionPlan, BillingProduct>,
     isLoading: Boolean,
+    hasProductsError: Boolean,
     currentPlan: SubscriptionPlan?,
     onAction: (SubscriptionAction) -> Unit
 ) {
@@ -390,19 +396,21 @@ private fun SubscriptionScreenExpanded(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             BenefitCarousel(pagerState = pagerState)
-            AnimatedContent(
-                targetState = isLoading,
-                transitionSpec = { defaultFadeTransition() }
-            ) { loading ->
-                if (loading) {
-                    PlanSelectorShimmer(Modifier.fillMaxWidth())
-                } else {
-                    PlanSelector(
-                        selectedPlan = selectedPlan,
-                        onPlanSelect = onPlanSelect,
-                        products = products,
-                        currentPlan = currentPlan
-                    )
+            if (!hasProductsError) {
+                AnimatedContent(
+                    targetState = isLoading,
+                    transitionSpec = { defaultFadeTransition() }
+                ) { loading ->
+                    if (loading) {
+                        PlanSelectorShimmer(Modifier.fillMaxWidth())
+                    } else {
+                        PlanSelector(
+                            selectedPlan = selectedPlan,
+                            onPlanSelect = onPlanSelect,
+                            products = products,
+                            currentPlan = currentPlan
+                        )
+                    }
                 }
             }
             SubscribeActions(selectedPlan, onNavigateUp, onPrivacyPolicy, onTerms, currentPlan, isLoading) {

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -428,4 +428,6 @@
     <string name="ads_consent_error">Unable to obtain ad consent</string>
     <string name="ad_label">Ad</string>
     <string name="rated">Rated %1$s</string>
+    <string name="error_fetching_subscription_plans">Failed to load subscription plans.</string>
+    <string name="refresh">Refresh</string>
 </resources>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -426,4 +426,6 @@
     <string name="ads_consent_error">Fehler beim Abrufen der Anzeigenzustimmung</string>
     <string name="ad_label">Anzeige</string>
     <string name="rated">Bewertet %1$s</string>
+    <string name="error_fetching_subscription_plans">Abonnementpläne konnten nicht geladen werden.</string>
+    <string name="refresh">Aktualisieren</string>
 </resources>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -424,4 +424,6 @@
     <string name="ads_consent_error">Impossible d'obtenir le consentement pour les publicités</string>
     <string name="ad_label">Annonce</string>
     <string name="rated">Noté %1$s</string>
+    <string name="error_fetching_subscription_plans">Échec du chargement des offres d'abonnement.</string>
+    <string name="refresh">Rafraîchir</string>
 </resources>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -422,4 +422,6 @@
     <string name="ads_consent_error">Nie można uzyskać zgody na reklamy</string>
     <string name="ad_label">Reklama</string>
     <string name="rated">Ocena %1$s</string>
+    <string name="error_fetching_subscription_plans">Nie udało się załadować planów subskrypcji.</string>
+    <string name="refresh">Odśwież</string>
 </resources>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -424,4 +424,6 @@
     <string name="ads_consent_error">Не удалось получить согласие на рекламу</string>
     <string name="ad_label">Реклама</string>
     <string name="rated">Оценка %1$s</string>
+    <string name="error_fetching_subscription_plans">Не удалось загрузить тарифы подписки.</string>
+    <string name="refresh">Обновить</string>
 </resources>


### PR DESCRIPTION
## Summary
- mark subscription plan load errors in state
- show snackbar with Refresh action on plan load failure
- hide plan selector UI when plans fail to load
- add new translations for error and refresh strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d0ff081748321a56380d2d4c6407f