### PR TITLE
Handle one-time purchases in billing endpoint

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/purchase/mapper/PurchaseNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/purchase/mapper/PurchaseNetworkMapper.kt
@@ -2,18 +2,26 @@ package pl.cuyer.rusthub.data.network.purchase.mapper
 
 import kotlinx.datetime.Instant
 import pl.cuyer.rusthub.data.network.purchase.model.PurchaseInfoDto
+import pl.cuyer.rusthub.data.network.purchase.model.PurchaseStateDto
 import pl.cuyer.rusthub.data.network.purchase.model.SubscriptionStateDto
 import pl.cuyer.rusthub.domain.model.ActiveSubscription
 import pl.cuyer.rusthub.domain.model.SubscriptionState
 import pl.cuyer.rusthub.presentation.model.SubscriptionPlan
 
 fun PurchaseInfoDto.toDomain(): ActiveSubscription? {
-    val item = subscriptionInfo?.lineItems?.firstOrNull()
-    val id = item?.offerDetails?.basePlanId ?: item?.productId ?: productInfo?.productId
-    val plan = SubscriptionPlan.entries.firstOrNull { it.basePlanId == id || it.productId == id }
-    val expiry = item?.expiryTime ?: expiryTime
+    val subItem = subscriptionInfo?.lineItems?.firstOrNull()
+    val prodItem = productInfo?.productLineItems?.firstOrNull()
+    val id =
+        subItem?.offerDetails?.basePlanId ?: subItem?.productId ?: prodItem?.productId
+            ?: productInfo?.productId
+    val plan =
+        SubscriptionPlan.entries.firstOrNull { it.basePlanId == id || it.productId == id }
+    val expiry = subItem?.expiryTime ?: expiryTime
     val expiration = expiry?.let { runCatching { Instant.parse(it) }.getOrNull() }
-    val state = subscriptionInfo?.subscriptionState?.toDomain() ?: subscriptionState?.toDomain() ?: SubscriptionState.UNSPECIFIED
+    val state =
+        subscriptionInfo?.subscriptionState?.toDomain() ?: subscriptionState?.toDomain()
+            ?: productInfo?.purchaseStateContext?.purchaseState?.toDomain()
+            ?: SubscriptionState.UNSPECIFIED
     return plan?.let { ActiveSubscription(it, expiration, state) }
 }
 
@@ -26,4 +34,11 @@ fun SubscriptionStateDto.toDomain(): SubscriptionState = when (this) {
     SubscriptionStateDto.EXPIRED -> SubscriptionState.EXPIRED
     SubscriptionStateDto.PENDING -> SubscriptionState.PENDING
     SubscriptionStateDto.UNSPECIFIED -> SubscriptionState.UNSPECIFIED
+}
+
+fun PurchaseStateDto.toDomain(): SubscriptionState = when (this) {
+    PurchaseStateDto.PURCHASED -> SubscriptionState.ACTIVE
+    PurchaseStateDto.PENDING -> SubscriptionState.PENDING
+    PurchaseStateDto.CANCELED -> SubscriptionState.CANCELED
+    PurchaseStateDto.UNSPECIFIED -> SubscriptionState.UNSPECIFIED
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/purchase/model/PurchaseInfoDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/purchase/model/PurchaseInfoDto.kt
@@ -2,6 +2,7 @@ package pl.cuyer.rusthub.data.network.purchase.model
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonNames
 
 @Serializable
@@ -46,43 +47,75 @@ enum class AcknowledgementStateDto {
 }
 
 @Serializable
-data class LineItemDto(
-    val productId: String,
-    val expiryTime: String? = null,
-    val cancellationTime: String? = null,
-    @SerialName("offerDetails")
-    val offerDetails: OfferDetails? = null
+enum class PurchaseStateDto {
+    @SerialName("PURCHASE_STATE_UNSPECIFIED")
+    @JsonNames("UNSPECIFIED")
+    UNSPECIFIED,
+    @SerialName("PURCHASED")
+    PURCHASED,
+    @SerialName("PENDING")
+    PENDING,
+    @SerialName("CANCELED")
+    CANCELED
+}
+
+@Serializable
+data class PurchaseStateContextDto(
+    val purchaseState: PurchaseStateDto? = null
 )
 
 @Serializable
-data class OfferDetails(
-    @SerialName("basePlanId")
-    val basePlanId: String? = null,
-    @SerialName("offerId")
-    val offerId: String? = null
+data class SubscriptionLineItemDto(
+    @SerialName("productId") val productId: String,
+    @SerialName("expiryTime") val expiryTime: String? = null,
+    @SerialName("cancellationTime") val cancellationTime: String? = null,
+    @SerialName("offerDetails") val offerDetails: OfferDetailsDto? = null
+)
+
+@Serializable
+data class ProductLineItemDto(
+    @SerialName("productId") val productId: String? = null
+)
+
+@Serializable
+data class OfferDetailsDto(
+    @SerialName("basePlanId") val basePlanId: String? = null,
+    @SerialName("offerId") val offerId: String? = null
+)
+
+@Serializable
+data class TestPurchaseContextDto(
+    @SerialName("fopType") val fopType: String? = null
 )
 
 @Serializable
 data class ExternalAccountIdentifiersDto(
-    val obfuscatedAccountId: String? = null
+    @SerialName("obfuscatedExternalAccountId") val obfuscatedAccountId: String? = null
 )
 
 @Serializable
-data class SubscriptionInfoDto(
+data class SubscriptionPurchaseInfoDto(
     val subscriptionState: SubscriptionStateDto? = null,
     val acknowledgementState: AcknowledgementStateDto? = null,
     val linkedPurchaseToken: String? = null,
-    val lineItems: List<LineItemDto> = emptyList(),
+    val lineItems: List<SubscriptionLineItemDto> = emptyList(),
     val externalAccountIdentifiers: ExternalAccountIdentifiersDto? = null
 )
 
 @Serializable
-data class ProductInfoDto(
-    val productId: String,
-    val acknowledgementState: Int? = null,
-    val purchaseState: Int? = null,
-    val obfuscatedAccountId: String? = null
-)
+data class ProductPurchaseInfoDto(
+    val acknowledgementState: AcknowledgementStateDto? = null,
+    @SerialName("obfuscatedExternalAccountId") val obfuscatedAccountId: String? = null,
+    @SerialName("productLineItem") val productLineItems: List<ProductLineItemDto> = emptyList(),
+    val purchaseStateContext: PurchaseStateContextDto? = null,
+    val testPurchaseContext: TestPurchaseContextDto? = null
+) {
+    @Transient
+    val productId: String? = productLineItems.firstOrNull()?.productId
+
+    @Transient
+    val purchaseState: PurchaseStateDto? = purchaseStateContext?.purchaseState
+}
 
 @Serializable
 data class PurchaseInfoDto(
@@ -91,7 +124,7 @@ data class PurchaseInfoDto(
     val subscriptionState: SubscriptionStateDto? = null,
     val acknowledgementState: AcknowledgementStateDto? = null,
     val expiryTime: String? = null,
-    val subscriptionInfo: SubscriptionInfoDto? = null,
-    val productInfo: ProductInfoDto? = null,
+    val subscriptionInfo: SubscriptionPurchaseInfoDto? = null,
+    val productInfo: ProductPurchaseInfoDto? = null,
     val createdAt: String? = null
 )


### PR DESCRIPTION
## Summary
- split purchase DTOs into dedicated subscription and product variants, adding test purchase context and transient helpers
- update mapper to use product line items and purchase state context when deriving subscription details

## Testing
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_688df868e1f88321a7e07403888e205a