### PR TITLE
Fix next wipe calculations for server queries

### DIFF
--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -74,13 +74,10 @@ WHERE
   AND (fe.filter != 'FAVOURITES' OR se.favourite = 1)
   AND (fe.filter != 'SUBSCRIBED' OR se.subscribed = 1)
   AND (
-    fe.sort_order != 'NEXT_WIPE' OR (
-        CASE
-            WHEN se.rust_next_map_wipe > CURRENT_TIMESTAMP
-                 AND (se.rust_next_wipe IS NULL OR se.rust_next_map_wipe <= se.rust_next_wipe)
-                THEN se.rust_next_map_wipe
-            WHEN se.rust_next_wipe > CURRENT_TIMESTAMP THEN se.rust_next_wipe
-        END
+    fe.sort_order != 'NEXT_WIPE' OR
+    MIN(
+        CASE WHEN se.rust_next_map_wipe > CURRENT_TIMESTAMP THEN se.rust_next_map_wipe END,
+        CASE WHEN se.rust_next_wipe > CURRENT_TIMESTAMP THEN se.rust_next_wipe END
     ) IS NOT NULL
   )
   AND (se.name LIKE '%' || :name || '%' COLLATE NOCASE)
@@ -89,12 +86,10 @@ ORDER BY
     CASE WHEN fe.sort_order = 'PLAYER_COUNT' THEN se.player_count END DESC,
     CASE WHEN fe.sort_order = 'RANK' THEN se.ranking END ASC,
     CASE WHEN fe.sort_order = 'NEXT_WIPE' THEN
-        CASE
-            WHEN se.rust_next_map_wipe > CURRENT_TIMESTAMP
-                 AND (se.rust_next_wipe IS NULL OR se.rust_next_map_wipe <= se.rust_next_wipe)
-                THEN se.rust_next_map_wipe
-            WHEN se.rust_next_wipe > CURRENT_TIMESTAMP THEN se.rust_next_wipe
-        END
+        MIN(
+            CASE WHEN se.rust_next_map_wipe > CURRENT_TIMESTAMP THEN se.rust_next_map_wipe END,
+            CASE WHEN se.rust_next_wipe > CURRENT_TIMESTAMP THEN se.rust_next_wipe END
+        )
     END ASC
 LIMIT :limit OFFSET :offset;
 
@@ -117,13 +112,10 @@ WHERE
   AND (fe.filter != 'FAVOURITES' OR se.favourite = 1)
   AND (fe.filter != 'SUBSCRIBED' OR se.subscribed = 1)
   AND (
-    fe.sort_order != 'NEXT_WIPE' OR (
-        CASE
-            WHEN se.rust_next_map_wipe > CURRENT_TIMESTAMP
-                 AND (se.rust_next_wipe IS NULL OR se.rust_next_map_wipe <= se.rust_next_wipe)
-                THEN se.rust_next_map_wipe
-            WHEN se.rust_next_wipe > CURRENT_TIMESTAMP THEN se.rust_next_wipe
-        END
+    fe.sort_order != 'NEXT_WIPE' OR
+    MIN(
+        CASE WHEN se.rust_next_map_wipe > CURRENT_TIMESTAMP THEN se.rust_next_map_wipe END,
+        CASE WHEN se.rust_next_wipe > CURRENT_TIMESTAMP THEN se.rust_next_wipe END
     ) IS NOT NULL
   )
   AND (se.name LIKE '%' || :name || '%' COLLATE NOCASE);


### PR DESCRIPTION
## Summary
- compute earliest upcoming wipe across `rust_next_map_wipe` and `rust_next_wipe`
- order and filter by the computed minimum when sorting by next wipe

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_688e4a227dfc83218d98e3c65ec9105e