### PR TITLE
Add gzip handling to Ktor client

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -12,6 +12,8 @@ import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.compression.gzip
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -75,6 +77,9 @@ actual class HttpClientFactory actual constructor(
             }
             install(ContentNegotiation) {
                 json(json)
+            }
+            install(ContentEncoding) {
+                gzip()
             }
             install(Auth) {
                 bearer {

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
@@ -9,6 +9,8 @@ import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.compression.gzip
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.logging.DEFAULT
 import io.ktor.client.plugins.logging.LogLevel
@@ -68,6 +70,9 @@ actual class HttpClientFactory actual constructor(
         return HttpClient(Darwin) {
             install(ContentNegotiation) {
                 json(json)
+            }
+            install(ContentEncoding) {
+                gzip()
             }
             install(Auth) {
                 bearer {


### PR DESCRIPTION
## Summary
- enable gzip decompression for Android HttpClient
- enable gzip decompression for iOS HttpClient

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_688e5147f9d88321ba026ea83f491581