### PR TITLE
Fix: clear database file on passphrase reset

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/local/DatabasePassphraseProvider.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/local/DatabasePassphraseProvider.android.kt
@@ -94,6 +94,7 @@ actual class DatabasePassphraseProvider(private val context: Context) {
             }
         } catch (_: Exception) {
         }
+        context.getDatabasePath("RustHubDatabase.db").delete()
         passphraseFile.delete()
     }
 


### PR DESCRIPTION
## Summary
- ensure SQLCipher database file removed before regenerating passphrase

## Testing
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_688e5174aab0832186a2146f3a1537d1