### PR TITLE
Fix Android HttpClient gzip configuration

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -21,7 +21,8 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders.ContentEncoding
+import io.ktor.client.plugins.compression.ContentEncoding
+import io.ktor.client.plugins.compression.gzip
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json


### PR DESCRIPTION
## Summary
- use Ktor `ContentEncoding` plugin and `gzip()` for Android client

## Testing
- No tests run (per repository instructions)


------
https://chatgpt.com/codex/tasks/task_e_688e55d5045c8321ab3a8f727e3e82be