### PR TITLE
Fix missing Ktor content encoding dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-view
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }
 ktor-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-serialization = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -88,6 +88,7 @@ kotlin {
             implementation(libs.ktor.serialization.json)
             implementation(libs.ktor.logging)
             implementation(libs.ktor.auth)
+            implementation(libs.ktor.client.encoding)
             implementation(libs.androidx.datastore.preferences)
             implementation(libs.androidx.datastore)
             implementation(libs.kotlin.serialization.protobuf)


### PR DESCRIPTION
## Summary
- include Ktor client encoding library in version catalog
- wire encoding plugin into shared module dependencies

## Testing
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_688e79ae4b688321909dd307bf5601d8