### PR TITLE
Fix: hide manage subscription for lifetime and localize app version

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -415,21 +415,23 @@ private fun AccountSection(
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
-                AppTextButton(
-                    onClick = {
-                        storeNavigator.openSubscriptionManagement(SubscriptionPlan.SUBSCRIPTION_ID)
-                    }
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                if (plan != SubscriptionPlan.LIFETIME) {
+                    AppTextButton(
+                        onClick = {
+                            storeNavigator.openSubscriptionManagement(SubscriptionPlan.SUBSCRIPTION_ID)
+                        }
                     ) {
-                        Text(stringResource(SharedRes.strings.manage_subscription))
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Default.ArrowRight,
-                            contentDescription = stringResource(SharedRes.strings.manage_subscription)
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(stringResource(SharedRes.strings.manage_subscription))
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                                contentDescription = stringResource(SharedRes.strings.manage_subscription)
+                            )
+                        }
                     }
                 }
             }

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -186,7 +186,7 @@
     <string name="report_bug_button">Report bug button</string>
     <string name="suggest_feature">Suggest a feature</string>
     <string name="suggest_feature_button">Suggest feature button</string>
-    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="app_version_build">App-Version: %1$s (%2$d)</string>
     <string name="facepunch" translatable="false">Facepunch</string>
     <string name="disclaimer_facepunch">RustHub steht in keiner Verbindung zu %1$s und wird nicht von ihnen unterstützt.</string>
     <string name="licenses">Licenses</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -186,7 +186,7 @@
     <string name="report_bug_button">Report bug button</string>
     <string name="suggest_feature">Suggest a feature</string>
     <string name="suggest_feature_button">Suggest feature button</string>
-    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="app_version_build">Version de l’application : %1$s (%2$d)</string>
     <string name="facepunch" translatable="false">Facepunch</string>
     <string name="disclaimer_facepunch">RustHub n'est ni affilié ni approuvé par %1$s.</string>
     <string name="licenses">Licenses</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -186,7 +186,7 @@
     <string name="report_bug_button">Report bug button</string>
     <string name="suggest_feature">Suggest a feature</string>
     <string name="suggest_feature_button">Suggest feature button</string>
-    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="app_version_build">Wersja aplikacji: %1$s (%2$d)</string>
     <string name="facepunch" translatable="false">Facepunch</string>
     <string name="disclaimer_facepunch">RustHub nie jest powiązany ani wspierany przez %1$s.</string>
     <string name="licenses">Licenses</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -186,7 +186,7 @@
     <string name="report_bug_button">Report bug button</string>
     <string name="suggest_feature">Suggest a feature</string>
     <string name="suggest_feature_button">Suggest feature button</string>
-    <string name="app_version_build">App version: %1$s (%2$d)</string>
+    <string name="app_version_build">Версия приложения: %1$s (%2$d)</string>
     <string name="facepunch" translatable="false">Facepunch</string>
     <string name="disclaimer_facepunch">RustHub не связан и не одобрен компанией %1$s.</string>
     <string name="licenses">Licenses</string>


### PR DESCRIPTION
## Summary
- hide manage subscription option when user owns lifetime plan
- translate app version label on About screen

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_688e7fd7f5bc832186a9203a88adfcc5