### PR TITLE
Fix: make logout overlay cover screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -133,10 +133,12 @@ fun SettingsScreen(
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding)
                 .fillMaxSize()
-                .padding(spacing.medium)
         ) {
             if (isTabletMode) {
                 SettingsScreenExpanded(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(spacing.medium),
                     username = state.value.username,
                     provider = state.value.provider,
                     subscribed = state.value.subscribed,
@@ -152,7 +154,9 @@ fun SettingsScreen(
             } else {
                 SettingsScreenCompact(
                     modifier = Modifier
-                        .verticalScroll(rememberScrollState()),
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(spacing.medium),
                     username = state.value.username,
                     provider = state.value.provider,
                     subscribed = state.value.subscribed,


### PR DESCRIPTION
## Summary
- ensure the logout overlay covers the whole screen by moving padding to individual layouts

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_688fd86363d083218d2e4811c3d1afc1