### PR TITLE
chore: bump app version to 0.0.49

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,7 +23,7 @@ android {
         applicationId = "pl.cuyer.rusthub.android"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 48
+        versionCode = 49
         versionName = project.property("VERSION_NAME") as String
         buildConfigField("String", "SERVERS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/4096035325\"")
         buildConfigField("String", "ITEMS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/1469871989\"")

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ kotlin.incremental.multiplatform=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 # App version
-VERSION_NAME=0.0.48
+VERSION_NAME=0.0.49

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-        <string>0.0.4</string>
-	<key>CFBundleVersion</key>
-        <string>4</string>
+        <string>0.0.49</string>
+        <key>CFBundleVersion</key>
+        <string>49</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>


### PR DESCRIPTION
## Summary
- bump version name to 0.0.49
- increment android version code to 49
- sync iOS Info.plist version to 0.0.49 (49)

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_68908d7937c483218f55b707e0fd299c