### PR TITLE
Localize recycling output strings

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemDetailsScreen.kt
@@ -701,10 +701,18 @@ private fun RecyclerOutputRow(
         ) {
             outputs.forEach { output ->
                 output.image?.let { image ->
-                    val outputString = if (extraChance) {
-                        "${output.amount?.times(100)}%"
-                    } else {
-                        "x${output.amount?.toInt()}"
+                    val outputString = remember(output.amount, extraChance) {
+                        if (extraChance) {
+                            stringResource(
+                                SharedRes.strings.percentage_format,
+                                output.amount?.times(100)?.roundToInt() ?: 0
+                            )
+                        } else {
+                            stringResource(
+                                SharedRes.strings.multiplier_format,
+                                output.amount?.toInt() ?: 0
+                            )
+                        }
                     }
 
                     ItemTooltipImage(

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -418,6 +418,8 @@
     <string name="radtown_recycler">Radtown Recycler</string>
     <string name="guaranteed_output">Guaranteed Output</string>
     <string name="extra_chance_output">Extra Chance Output</string>
+    <string name="multiplier_format">x%1$d</string>
+    <string name="percentage_format">%1$d%%</string>
     <string name="raw_material_cost">Raw Material Cost</string>
     <string name="using_mixing_table">Using mixing table x%1$d</string>
     <string name="time_to_raid">Time to Raid: %1$s</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -416,6 +416,8 @@
     <string name="safezone_recycler">Safezone-Recycler</string>
     <string name="guaranteed_output">Garantierte Ausgabe</string>
     <string name="extra_chance_output">Zusätzliche Chance Ausgabe</string>
+    <string name="multiplier_format">x%1$d</string>
+    <string name="percentage_format">%1$d%%</string>
     <string name="raw_material_cost">Rohmaterialkosten</string>
     <string name="using_mixing_table">Mit Mischtisch x%1$d</string>
     <string name="time_to_raid">Raidzeit: %1$s</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -414,6 +414,10 @@
     <string name="tech_tree_cost">Coût de l'arbre technologique</string>
     <string name="radtown_recycler">Recycler de Radtown</string>
     <string name="safezone_recycler">Recycler de Safezone</string>
+    <string name="guaranteed_output">Sortie garantie</string>
+    <string name="extra_chance_output">Sortie avec chance supplémentaire</string>
+    <string name="multiplier_format">x%1$d</string>
+    <string name="percentage_format">%1$d%%</string>
     <string name="raw_material_cost">Coût des matières premières</string>
     <string name="using_mixing_table">Utilisation du table de mixage x%1$d</string>
     <string name="time_to_raid">Temps de raid : %1$s</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -412,6 +412,12 @@
     <string name="crafting_recipe">Przepis do craftowania</string>
     <string name="research_table_cost">Koszt odkrycia</string>
     <string name="tech_tree_cost">Koszt drzewa technologicznego</string>
+    <string name="radtown_recycler">Recycler w Radtown</string>
+    <string name="safezone_recycler">Recycler w Safezone</string>
+    <string name="guaranteed_output">Gwarantowany rezultat</string>
+    <string name="extra_chance_output">Rezultat z dodatkową szansą</string>
+    <string name="multiplier_format">x%1$d</string>
+    <string name="percentage_format">%1$d%%</string>
     <string name="raw_material_cost">Koszt surowców</string>
     <string name="using_mixing_table">Używając stołu mieszającego x%1$d</string>
     <string name="time_to_raid">Czas rajdu: %1$s</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -414,6 +414,10 @@
     <string name="tech_tree_cost">Стоимость дерева технологий</string>
     <string name="radtown_recycler">Ресайклер в заброшенном городе</string>
     <string name="safezone_recycler">Ресайклер в безопасной зоне</string>
+    <string name="guaranteed_output">Гарантированный результат</string>
+    <string name="extra_chance_output">Дополнительный шанс на результат</string>
+    <string name="multiplier_format">x%1$d</string>
+    <string name="percentage_format">%1$d%%</string>
     <string name="raw_material_cost">Стоимость сырья</string>
     <string name="using_mixing_table">Используя смесительный стол x%1$d</string>
     <string name="time_to_raid">Время рейда: %1$s</string>


### PR DESCRIPTION
## Summary
- format recycling output values using localized string resources
- add multiplier and percentage formats across translations

## Testing
- `./gradlew lintKotlin` *(fails: Task 'lintKotlin' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890bddb55608321a7cdb8a4d6663f37