### PR TITLE
Fix list not resetting to top after filter changes

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
@@ -135,6 +135,11 @@ fun ItemScreen(
     }
     val ads = adState
 
+    LaunchedEffect(state.value.selectedCategory) {
+        lazyListState.scrollToItem(0)
+        scrollBehavior.scrollOffset = 1f
+    }
+
     ObserveAsEvents(uiEvent) { event ->
         if (event is UiEvent.Navigate) onNavigate(event.destination)
     }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerScreen.kt
@@ -146,10 +146,16 @@ fun ServerScreen(
     val ads = adState
     val activity = LocalActivity.current as Activity
 
+    LaunchedEffect(state.value.filter) {
+        lazyListState.scrollToItem(0)
+        scrollBehavior.scrollOffset = 1f
+    }
+
     LaunchedEffect(Unit) {
-        onAction(ServerAction.GatherConsent(activity) {
-            onAdAction(AdAction.LoadAd(BuildConfig.SERVERS_ADMOB_NATIVE_AD_ID))
-        }
+        onAction(
+            ServerAction.GatherConsent(activity) {
+                onAdAction(AdAction.LoadAd(BuildConfig.SERVERS_ADMOB_NATIVE_AD_ID))
+            }
         )
     }
 


### PR DESCRIPTION
## Summary
- ensure server list resets to top when selected filter changes
- reset item list to top when category filter changes

## Testing
- No tests were run due to project instructions


------
https://chatgpt.com/codex/tasks/task_e_6890dcb516b48321b1c28a41f393e8c3