### PR TITLE
Refactor scroll-to-top behavior after paging refresh

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -72,11 +73,14 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation3.runtime.NavKey
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -140,10 +144,11 @@ fun ItemScreen(
     }
 
     LaunchedEffect(state.value.selectedCategory) {
-        coroutineScope.launch {
-            lazyListState.scrollToItem(0)
-            scrollBehavior.scrollOffset = 1f
-        }
+        snapshotFlow { pagedList.loadState.refresh }
+            .filter { it is LoadState.NotLoading && pagedList.itemCount > 0 }
+            .first()
+        lazyListState.scrollToItem(0)
+        scrollBehavior.scrollOffset = 1f
     }
 
     LaunchedEffect(showAds) {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -73,11 +74,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation3.runtime.NavKey
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -139,10 +143,11 @@ fun ServerScreen(
     val lazyListState = rememberLazyListState()
 
     LaunchedEffect(state.value.filter) {
-        coroutineScope.launch {
-            lazyListState.scrollToItem(0)
-            scrollBehavior.scrollOffset = 1f
-        }
+        snapshotFlow { pagedList.loadState.refresh }
+            .filter { it is LoadState.NotLoading && pagedList.itemCount > 0 }
+            .first()
+        lazyListState.scrollToItem(0)
+        scrollBehavior.scrollOffset = 1f
     }
 
     val pullToRefreshState = rememberPullToRefreshState()


### PR DESCRIPTION
## Summary
- wait for paging refresh to finish before scrolling item list to top
- wait for paging refresh to finish before scrolling server list to top

## Testing
- No tests were run


------
https://chatgpt.com/codex/tasks/task_e_6891096556f88321b88ba733dfde1a49