### PR TITLE
Refactor async passphrase loading for DB

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -1,7 +1,6 @@
 package pl.cuyer.rusthub.presentation.di
 
 import dev.icerock.moko.permissions.PermissionsController
-import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
@@ -9,7 +8,6 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 import pl.cuyer.rusthub.BuildConfig
 import pl.cuyer.rusthub.data.local.DatabaseDriverFactory
-import pl.cuyer.rusthub.data.local.DatabasePassphraseProvider
 import pl.cuyer.rusthub.data.local.item.ItemSyncDataSourceImpl
 import pl.cuyer.rusthub.data.network.HttpClientFactory
 import pl.cuyer.rusthub.database.RustHubDatabase
@@ -64,11 +62,9 @@ import org.koin.android.ext.koin.androidApplication
 import pl.cuyer.rusthub.util.EmailSender
 import pl.cuyer.rusthub.util.UrlOpener
 
-actual val platformModule: Module = module {
-    single { DatabasePassphraseProvider(androidContext()) }
-    single<RustHubDatabase> {
+actual fun platformModule(passphrase: String): Module = module {
+    single<RustHubDatabase>(createdAtStart = true) {
         if (BuildConfig.USE_ENCRYPTED_DB) {
-            val passphrase = runBlocking { get<DatabasePassphraseProvider>().getPassphrase() }
             DatabaseDriverFactory(androidContext(), passphrase).create()
         } else {
             DatabaseDriverFactory(androidContext()).create()

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -186,13 +186,13 @@ val appModule = module {
     single { GetNativeAdUseCase(get()) }
 }
 
-expect val platformModule: Module
+expect fun platformModule(passphrase: String): Module
 expect val userPreferencesModule: Module
 
-fun initKoin(appDeclaration: KoinAppDeclaration = {}) = startKoin {
+fun initKoin(passphrase: String = "", appDeclaration: KoinAppDeclaration = {}) = startKoin {
     if (BuildType.isDebug) {
         Napier.base(DebugAntilog())
     }
     appDeclaration()
-    modules(appModule, userPreferencesModule, platformModule)
+    modules(appModule, userPreferencesModule, platformModule(passphrase))
 }

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -56,7 +56,8 @@ import pl.cuyer.rusthub.domain.usecase.ads.GetNativeAdUseCase
 import pl.cuyer.rusthub.domain.usecase.ads.ClearNativeAdsUseCase
 import pl.cuyer.rusthub.presentation.features.ads.NativeAdViewModel
 
-actual val platformModule: Module = module {
+@Suppress("UNUSED_PARAMETER")
+actual fun platformModule(passphrase: String): Module = module {
     single<RustHubDatabase> { DatabaseDriverFactory().create() }
     single { AppCheckTokenProvider() }
     single { HttpClientFactory(get(), get(), get(), get(), get()).create() }


### PR DESCRIPTION
## Summary
- cache SQL passphrase and expose async loader
- inject pre-loaded passphrase into Koin without runBlocking
- start Koin after passphrase load in RustHubApplication

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6891ae18aea883219d8a919187c0de4f