### PR TITLE
feat: add firebase remote config

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -96,6 +96,7 @@ firebase-messaging = { module = "com.google.firebase:firebase-messaging" }
 firebase-performance = { module = "com.google.firebase:firebase-perf" }
 firebase-appcheck-playintegrity = { module = "com.google.firebase:firebase-appcheck-playintegrity" }
 firebase-appcheck-debug = { module = "com.google.firebase:firebase-appcheck-debug" }
+firebase-config = { module = "com.google.firebase:firebase-config" }
 
 #KOTLIN
 kotlin-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -67,6 +67,7 @@ kotlin {
             implementation(libs.firebase.crashlytics)
             implementation(libs.firebase.appcheck.playintegrity)
             implementation(libs.firebase.appcheck.debug)
+            implementation(libs.firebase.config)
             implementation(libs.google.auth)
             implementation(libs.androidx.credentials)
             implementation(libs.google.identity)

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -61,6 +61,7 @@ import pl.cuyer.rusthub.presentation.model.SubscriptionPlan
 import org.koin.android.ext.koin.androidApplication
 import pl.cuyer.rusthub.util.EmailSender
 import pl.cuyer.rusthub.util.UrlOpener
+import pl.cuyer.rusthub.util.RemoteConfig
 
 actual fun platformModule(passphrase: String): Module = module {
     single<RustHubDatabase>(createdAtStart = true) {
@@ -97,6 +98,7 @@ actual fun platformModule(passphrase: String): Module = module {
     single { SystemDarkThemeObserver(androidContext()) }
     single { ConnectivityObserver(androidContext()) }
     single { GoogleAuthClient(androidContext()) }
+    single { RemoteConfig() }
     single { StringProvider(androidContext()) }
     single { PermissionsController(androidContext()) }
     viewModel {
@@ -124,7 +126,8 @@ actual fun platformModule(passphrase: String): Module = module {
             googleAuthClient = get(),
             snackbarController = get(),
             emailValidator = get(),
-            stringProvider = get()
+            stringProvider = get(),
+            remoteConfig = get()
         )
     }
     viewModel { (email: String, exists: Boolean, provider: AuthProvider?) ->
@@ -141,8 +144,9 @@ actual fun platformModule(passphrase: String): Module = module {
             usernameValidator = get(),
             loginWithGoogleUseCase = get(),
             getGoogleClientIdUseCase = get(),
-            googleAuthClient = get()
-            , stringProvider = get()
+            googleAuthClient = get(),
+            remoteConfig = get(),
+            stringProvider = get()
         )
     }
     viewModel {
@@ -202,6 +206,7 @@ actual fun platformModule(passphrase: String): Module = module {
             userEventController = get(),
             getActiveSubscriptionUseCase = get(),
             setSubscribedUseCase = get(),
+            remoteConfig = get(),
             connectivityObserver = get(),
         )
     }
@@ -243,7 +248,8 @@ actual fun platformModule(passphrase: String): Module = module {
             usernameValidator = get(),
             passwordValidator = get(),
             emailValidator = get(),
-            stringProvider = get()
+            stringProvider = get(),
+            remoteConfig = get()
         )
     }
     viewModel {

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/RemoteConfig.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/RemoteConfig.android.kt
@@ -1,0 +1,22 @@
+package pl.cuyer.rusthub.util
+
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+
+actual class RemoteConfig actual constructor() {
+    private val remoteConfig = FirebaseRemoteConfig.getInstance().apply {
+        val settings = FirebaseRemoteConfigSettings.Builder()
+            .setMinimumFetchIntervalInSeconds(3600)
+            .build()
+        setConfigSettingsAsync(settings)
+        setDefaultsAsync(
+            mapOf(
+                RemoteConfigKeys.GOOGLE_AUTH_ENABLED to true,
+                RemoteConfigKeys.FEATURE_SUBSCRIPTION_ENABLED to true
+            )
+        )
+        fetchAndActivate()
+    }
+
+    actual fun getBoolean(key: String): Boolean = remoteConfig.getBoolean(key)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/credentials/CredentialsViewModel.kt
@@ -34,6 +34,8 @@ import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
+import pl.cuyer.rusthub.util.RemoteConfig
+import pl.cuyer.rusthub.util.RemoteConfigKeys
 import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.util.StringProvider
 import pl.cuyer.rusthub.util.toUserMessage
@@ -55,6 +57,7 @@ class CredentialsViewModel(
     private val loginWithGoogleUseCase: LoginWithGoogleUseCase,
     private val getGoogleClientIdUseCase: GetGoogleClientIdUseCase,
     private val googleAuthClient: GoogleAuthClient,
+    private val remoteConfig: RemoteConfig,
     private val stringProvider: StringProvider
 ) : BaseViewModel() {
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
@@ -137,6 +140,12 @@ class CredentialsViewModel(
     private fun startGoogleLogin() {
         googleJob?.cancel()
         googleJob = coroutineScope.launch {
+            if (!remoteConfig.getBoolean(RemoteConfigKeys.GOOGLE_AUTH_ENABLED)) {
+                showErrorSnackbar(
+                    stringProvider.get(SharedRes.strings.google_sign_in_disabled)
+                )
+                return@launch
+            }
             getGoogleClientIdUseCase()
                 .onStart { updateGoogleLoading(true) }
                 .onCompletion { updateGoogleLoading(false) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/auth/upgrade/UpgradeViewModel.kt
@@ -22,6 +22,8 @@ import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
+import pl.cuyer.rusthub.util.RemoteConfig
+import pl.cuyer.rusthub.util.RemoteConfigKeys
 import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.util.StringProvider
 import pl.cuyer.rusthub.util.toUserMessage
@@ -39,6 +41,7 @@ class UpgradeViewModel(
     private val passwordValidator: PasswordValidator,
     private val emailValidator: EmailValidator,
     private val stringProvider: StringProvider,
+    private val remoteConfig: RemoteConfig,
 ) : BaseViewModel() {
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
     val uiEvent = _uiEvent.receiveAsFlow()
@@ -128,6 +131,12 @@ class UpgradeViewModel(
     private fun startGoogleLogin() {
         googleJob?.cancel()
         googleJob = coroutineScope.launch {
+            if (!remoteConfig.getBoolean(RemoteConfigKeys.GOOGLE_AUTH_ENABLED)) {
+                showErrorSnackbar(
+                    stringProvider.get(SharedRes.strings.google_sign_in_disabled)
+                )
+                return@launch
+            }
             getGoogleClientIdUseCase()
                 .onStart { updateGoogleLoading(true) }
                 .onCompletion { updateGoogleLoading(false) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/onboarding/OnboardingViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/onboarding/OnboardingViewModel.kt
@@ -29,6 +29,8 @@ import pl.cuyer.rusthub.presentation.navigation.Terms
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
 import pl.cuyer.rusthub.util.GoogleAuthClient
+import pl.cuyer.rusthub.util.RemoteConfig
+import pl.cuyer.rusthub.util.RemoteConfigKeys
 import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.util.StringProvider
 import pl.cuyer.rusthub.util.toUserMessage
@@ -42,7 +44,8 @@ class OnboardingViewModel(
     private val googleAuthClient: GoogleAuthClient,
     private val snackbarController: SnackbarController,
     private val emailValidator: EmailValidator,
-    private val stringProvider: StringProvider
+    private val stringProvider: StringProvider,
+    private val remoteConfig: RemoteConfig
 ) : BaseViewModel() {
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
     val uiEvent = _uiEvent.receiveAsFlow()
@@ -138,6 +141,12 @@ class OnboardingViewModel(
     private fun startGoogleLogin() {
         googleJob?.cancel()
         googleJob = coroutineScope.launch {
+            if (!remoteConfig.getBoolean(RemoteConfigKeys.GOOGLE_AUTH_ENABLED)) {
+                showErrorSnackbar(
+                    stringProvider.get(SharedRes.strings.google_sign_in_disabled)
+                )
+                return@launch
+            }
             getGoogleClientIdUseCase()
                 .onStart { updateGoogleLoading(true) }
                 .onCompletion { updateGoogleLoading(false) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -48,6 +48,8 @@ import pl.cuyer.rusthub.presentation.snackbar.SnackbarAction
 import pl.cuyer.rusthub.common.user.UserEvent
 import pl.cuyer.rusthub.common.user.UserEventController
 import pl.cuyer.rusthub.util.GoogleAuthClient
+import pl.cuyer.rusthub.util.RemoteConfig
+import pl.cuyer.rusthub.util.RemoteConfigKeys
 import pl.cuyer.rusthub.util.StringProvider
 import pl.cuyer.rusthub.util.toUserMessage
 import pl.cuyer.rusthub.util.SystemDarkThemeObserver
@@ -85,6 +87,7 @@ class SettingsViewModel(
     private val itemSyncDataSource: ItemSyncDataSource,
     private val userEventController: UserEventController,
     private val setSubscribedUseCase: SetSubscribedUseCase,
+    private val remoteConfig: RemoteConfig,
     private val connectivityObserver: ConnectivityObserver
 ) : BaseViewModel() {
 
@@ -117,6 +120,8 @@ class SettingsViewModel(
                     showUnconfirmedSnackbar()
                 } else if (!state.value.isConnected) {
                     showErrorSnackbar(stringProvider.get(SharedRes.strings.connect_manage_subscription))
+                } else if (!remoteConfig.getBoolean(RemoteConfigKeys.FEATURE_SUBSCRIPTION_ENABLED)) {
+                    showErrorSnackbar(stringProvider.get(SharedRes.strings.subscription_disabled))
                 } else {
                     navigateSubscription()
                 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/RemoteConfig.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/util/RemoteConfig.kt
@@ -1,0 +1,10 @@
+package pl.cuyer.rusthub.util
+
+expect class RemoteConfig() {
+    fun getBoolean(key: String): Boolean
+}
+
+object RemoteConfigKeys {
+    const val GOOGLE_AUTH_ENABLED = "GOOGLE_AUTH_ENABLED"
+    const val FEATURE_SUBSCRIPTION_ENABLED = "FEATURE_SUBSCRIPTION_ENABLED"
+}

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -327,6 +327,7 @@
     <string name="unable_to_upgrade_account">Unable to upgrade account</string>
     <string name="google_sign_in_failed">Google sign in failed</string>
     <string name="error_google_sign_in">An error occurred during Google sign-in.</string>
+    <string name="google_sign_in_disabled">Signing in with Google is currently disabled</string>
     <string name="unable_to_get_client_id">Unable to get client id</string>
     <string name="error_creating_guest_account">An error occurred while creating guest account.</string>
     <string name="provided_credentials_incorrect">Provided credentials are incorrect.</string>
@@ -363,6 +364,7 @@
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="offline_cached_servers_info">Network unavailable. Showing cached servers.</string>
     <string name="offline">No internet connection.</string>
+    <string name="subscription_disabled">Subscriptions are currently disabled.</string>
     <string name="connect_manage_subscription">Connect to the internet to manage your subscription.</string>
     <string name="no_servers_available_offline">No servers available offline.</string>
     <string name="no_servers_available">No servers available.</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -325,6 +325,7 @@
     <string name="unable_to_upgrade_account">Konto konnte nicht upgegradet werden</string>
     <string name="google_sign_in_failed">Google-Anmeldung fehlgeschlagen</string>
     <string name="error_google_sign_in">Bei der Google-Anmeldung ist ein Fehler aufgetreten.</string>
+    <string name="google_sign_in_disabled">Die Anmeldung mit Google ist derzeit deaktiviert</string>
     <string name="unable_to_get_client_id">Client-ID konnte nicht abgerufen werden</string>
     <string name="error_creating_guest_account">Beim Erstellen des Gastkontos ist ein Fehler aufgetreten.</string>
     <string name="provided_credentials_incorrect">Die angegebenen Zugangsdaten sind falsch.</string>
@@ -361,6 +362,7 @@
     <string name="error_network">Netzwerkfehler. Bitte überprüfe deine Verbindung.</string>
     <string name="offline_cached_servers_info">Netzwerk nicht verfügbar. Zeige zwischengespeicherte Server.</string>
     <string name="offline">Keine Internetverbindung.</string>
+    <string name="subscription_disabled">Abonnements sind derzeit deaktiviert.</string>
     <string name="connect_manage_subscription">Verbinde dich mit dem Internet, um das Abo zu verwalten.</string>
     <string name="no_servers_available_offline">Offline sind keine Server verfügbar.</string>
     <string name="no_servers_available">Keine Server verfügbar.</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -325,6 +325,7 @@
     <string name="unable_to_upgrade_account">Impossible d’améliorer le compte</string>
     <string name="google_sign_in_failed">La connexion Google a échoué</string>
     <string name="error_google_sign_in">Une erreur est survenue lors de la connexion avec Google.</string>
+    <string name="google_sign_in_disabled">La connexion avec Google est actuellement désactivée</string>
     <string name="unable_to_get_client_id">Impossible d’obtenir l’ID client</string>
     <string name="error_creating_guest_account">Erreur lors de la création d’un compte invité.</string>
     <string name="provided_credentials_incorrect">Identifiants incorrects.</string>
@@ -361,6 +362,7 @@
     <string name="error_network">Erreur réseau. Veuillez vérifier votre connexion.</string>
     <string name="offline_cached_servers_info">Réseau indisponible. Affichage des serveurs en cache.</string>
     <string name="offline">Pas de connexion Internet.</string>
+    <string name="subscription_disabled">Les abonnements sont actuellement désactivés.</string>
     <string name="connect_manage_subscription">Connectez-vous à Internet pour gérer votre abonnement.</string>
     <string name="no_servers_available_offline">Aucun serveur disponible hors ligne.</string>
     <string name="no_servers_available">Aucun serveur disponible.</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -325,6 +325,7 @@
     <string name="unable_to_upgrade_account">Nie udało się ulepszyć konta</string>
     <string name="google_sign_in_failed">Logowanie przez Google nie powiodło się</string>
     <string name="error_google_sign_in">Wystąpił błąd podczas logowania Google.</string>
+    <string name="google_sign_in_disabled">Logowanie przez Google jest obecnie wyłączone</string>
     <string name="unable_to_get_client_id">Nie można pobrać ID klienta</string>
     <string name="error_creating_guest_account">Błąd przy tworzeniu konta gościa.</string>
     <string name="provided_credentials_incorrect">Nieprawidłowe dane logowania.</string>
@@ -361,6 +362,7 @@
     <string name="error_network">Błąd sieci. Sprawdź swoje połączenie.</string>
     <string name="offline_cached_servers_info">Brak sieci. Wyświetlana jest zapisana lista serwerów.</string>
     <string name="offline">Brak połączenia z internetem.</string>
+    <string name="subscription_disabled">Subskrypcje są obecnie wyłączone.</string>
     <string name="connect_manage_subscription">Połącz się z internetem, aby zarządzać subskrypcją.</string>
     <string name="no_servers_available_offline">Brak dostępnych serwerów offline.</string>
     <string name="no_servers_available">Brak dostępnych serwerów.</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -325,6 +325,7 @@
     <string name="unable_to_upgrade_account">Не удалось улучшить аккаунт</string>
     <string name="google_sign_in_failed">Ошибка входа через Google</string>
     <string name="error_google_sign_in">Произошла ошибка при входе через Google.</string>
+    <string name="google_sign_in_disabled">Вход через Google временно отключён</string>
     <string name="unable_to_get_client_id">Не удалось получить client id</string>
     <string name="error_creating_guest_account">Ошибка при создании гостевого аккаунта.</string>
     <string name="provided_credentials_incorrect">Введены неверные данные.</string>
@@ -361,6 +362,7 @@
     <string name="error_network">Ошибка сети. Проверьте подключение.</string>
     <string name="offline_cached_servers_info">Нет сети. Отображаются кэшированные серверы.</string>
     <string name="offline">Нет подключения к интернету.</string>
+    <string name="subscription_disabled">Подписки временно отключены.</string>
     <string name="connect_manage_subscription">Подключитесь к интернету, чтобы управлять подпиской.</string>
     <string name="no_servers_available_offline">Нет серверов в автономном режиме.</string>
     <string name="no_servers_available">Нет доступных серверов.</string>

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -42,6 +42,7 @@ import pl.cuyer.rusthub.domain.usecase.ConfirmPurchaseUseCase
 import pl.cuyer.rusthub.domain.usecase.RefreshUserUseCase
 import pl.cuyer.rusthub.presentation.features.subscription.SubscriptionViewModel
 import pl.cuyer.rusthub.presentation.model.SubscriptionPlan
+import pl.cuyer.rusthub.util.RemoteConfig
 import pl.cuyer.rusthub.domain.repository.item.local.ItemDataSource
 import pl.cuyer.rusthub.data.local.item.ItemSyncDataSourceImpl
 import pl.cuyer.rusthub.domain.repository.item.local.ItemSyncDataSource
@@ -80,6 +81,7 @@ actual fun platformModule(passphrase: String): Module = module {
     single { EmailSender() }
     single { SystemDarkThemeObserver() }
     single { GoogleAuthClient() }
+    single { RemoteConfig() }
     single { StringProvider() }
     single { AdsConsentManager() }
     single<NativeAdRepository> { NativeAdRepositoryImpl() }
@@ -136,7 +138,8 @@ actual fun platformModule(passphrase: String): Module = module {
             googleAuthClient = get(),
             snackbarController = get(),
             emailValidator = get(),
-            stringProvider = get()
+            stringProvider = get(),
+            remoteConfig = get()
         )
     }
     factory { (email: String, exists: Boolean, provider: AuthProvider?) ->
@@ -151,6 +154,10 @@ actual fun platformModule(passphrase: String): Module = module {
             snackbarController = get(),
             passwordValidator = get(),
             usernameValidator = get(),
+            loginWithGoogleUseCase = get(),
+            getGoogleClientIdUseCase = get(),
+            googleAuthClient = get(),
+            remoteConfig = get(),
             stringProvider = get()
         )
     }
@@ -171,6 +178,7 @@ actual fun platformModule(passphrase: String): Module = module {
             itemSyncDataSource = get(),
             userEventController = get(),
             setSubscribedUseCase = get(),
+            remoteConfig = get(),
             connectivityObserver = get()
         )
     }
@@ -212,7 +220,8 @@ actual fun platformModule(passphrase: String): Module = module {
             usernameValidator = get(),
             passwordValidator = get(),
             emailValidator = get(),
-            stringProvider = get()
+            stringProvider = get(),
+            remoteConfig = get()
         )
     }
     factory { (plan: SubscriptionPlan?) ->

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/RemoteConfig.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/util/RemoteConfig.ios.kt
@@ -1,0 +1,5 @@
+package pl.cuyer.rusthub.util
+
+actual class RemoteConfig actual constructor() {
+    actual fun getBoolean(key: String): Boolean = true
+}


### PR DESCRIPTION
## Summary
- extend RemoteConfig with FEATURE_SUBSCRIPTION_ENABLED flag
- show snackbar on subscription attempt when feature is disabled
- inject RemoteConfig into SettingsViewModel and add localized message

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68922650b9f48321b91b427db5e497bd