### PR TITLE
Feat: add privacy options management

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/settings/SettingsScreen.kt
@@ -147,6 +147,7 @@ fun SettingsScreen(
                     planExpiration = state.value.subscriptionExpiration,
                     status = state.value.subscriptionStatus,
                     loading = state.value.isLoading,
+                    isPrivacyOptionsRequired = state.value.isPrivacyOptionsRequired,
                     onAction = onAction,
                     onThemeClick = { showThemeSheet = true },
                     onLanguageClick = { showLanguageSheet = true }
@@ -165,6 +166,7 @@ fun SettingsScreen(
                     planExpiration = state.value.subscriptionExpiration,
                     status = state.value.subscriptionStatus,
                     loading = state.value.isLoading,
+                    isPrivacyOptionsRequired = state.value.isPrivacyOptionsRequired,
                     onAction = onAction,
                     onThemeClick = { showThemeSheet = true },
                     onLanguageClick = { showLanguageSheet = true }
@@ -220,6 +222,7 @@ private fun SettingsScreenCompact(
     planExpiration: String?,
     status: String?,
     loading: Boolean,
+    isPrivacyOptionsRequired: Boolean,
     onAction: (SettingsAction) -> Unit,
     onThemeClick: () -> Unit,
     onLanguageClick: () -> Unit
@@ -242,7 +245,7 @@ private fun SettingsScreenCompact(
             onAction = onAction
         )
         HorizontalDivider(modifier = Modifier.padding(vertical = spacing.medium))
-        OtherSection(onAction)
+        OtherSection(onAction, isPrivacyOptionsRequired)
     }
 }
 
@@ -257,6 +260,7 @@ private fun SettingsScreenExpanded(
     planExpiration: String?,
     status: String?,
     loading: Boolean,
+    isPrivacyOptionsRequired: Boolean,
     onAction: (SettingsAction) -> Unit,
     onThemeClick: () -> Unit,
     onLanguageClick: () -> Unit
@@ -291,7 +295,7 @@ private fun SettingsScreenExpanded(
                 .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(spacing.medium)
         ) {
-            OtherSection(onAction)
+            OtherSection(onAction, isPrivacyOptionsRequired)
         }
     }
 }
@@ -504,14 +508,37 @@ private fun AccountSection(
 }
 
 @Composable
-
-private fun OtherSection(onAction: (SettingsAction) -> Unit) {
+private fun OtherSection(
+    onAction: (SettingsAction) -> Unit,
+    isPrivacyOptionsRequired: Boolean
+) {
     val storeNavigator = koinInject<StoreNavigator>()
     Text(
         text = stringResource(SharedRes.strings.other),
         style = MaterialTheme.typography.titleLarge,
         modifier = Modifier.padding(bottom = spacing.small)
     )
+
+    if (isPrivacyOptionsRequired) {
+        val activity = LocalContext.current as Activity
+        AppTextButton(onClick = {
+            onAction(SettingsAction.OnManagePrivacy(activity))
+        }) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(stringResource(SharedRes.strings.manage_privacy))
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowRight,
+                    contentDescription = stringResource(
+                        SharedRes.strings.manage_privacy_button
+                    )
+                )
+            }
+        }
+    }
 
     AppTextButton(
         onClick = { onAction(SettingsAction.OnPrivacyPolicy) }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -208,6 +208,7 @@ actual fun platformModule(passphrase: String): Module = module {
             setSubscribedUseCase = get(),
             remoteConfig = get(),
             connectivityObserver = get(),
+            adsConsentManager = get(),
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsAction.kt
@@ -23,6 +23,8 @@ sealed interface SettingsAction {
     @Immutable
     data object OnTerms : SettingsAction
     @Immutable
+    data class OnManagePrivacy(val activity: Any) : SettingsAction
+    @Immutable
     data object OnDeleteAccount : SettingsAction
     @Immutable
     data object OnUpgradeAccount : SettingsAction

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsState.kt
@@ -20,6 +20,7 @@ data class SettingsState(
     val anonymousExpiration: String? = null,
     val isLoading: Boolean = false,
     val isLoggingOut: Boolean = false,
+    val isPrivacyOptionsRequired: Boolean = false,
     val theme: Theme = Theme.SYSTEM,
     val dynamicColors: Boolean = false,
     val useSystemColors: Boolean = true,

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -166,6 +166,8 @@
     <string name="players">Players</string>
     <string name="preferences">Preferences</string>
     <string name="premium" translatable="false" >Premium</string>
+    <string name="manage_privacy">Manage privacy</string>
+    <string name="manage_privacy_button">Manage privacy button</string>
     <string name="privacy_policy">Privacy policy</string>
     <string name="privacy_policy_button">Privacy policy button</string>
     <string name="onboarding_disclaimer">By creating an account you confirm that you have read and accept our privacy policy and terms &amp; conditions.</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -165,6 +165,8 @@
     <string name="players">Spieler</string>
     <string name="preferences">Einstellungen</string>
     <string name="premium" translatable="false">Premium</string>
+    <string name="manage_privacy">Datenschutz verwalten</string>
+    <string name="manage_privacy_button">Schaltfläche Datenschutz verwalten</string>
     <string name="privacy_policy">Datenschutzerklärung</string>
     <string name="privacy_policy_button">Datenschutz-Button</string>
     <string name="onboarding_disclaimer">Durch das Erstellen eines Kontos bestätigst du, dass du unsere Datenschutzrichtlinie und unsere AGB gelesen hast und akzeptierst.</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -165,6 +165,8 @@
     <string name="players">Joueurs</string>
     <string name="preferences">Préférences</string>
     <string name="premium" translatable="false">Premium</string>
+    <string name="manage_privacy">Gérer la confidentialité</string>
+    <string name="manage_privacy_button">Bouton gérer la confidentialité</string>
     <string name="privacy_policy">Politique de confidentialité</string>
     <string name="privacy_policy_button">Bouton politique de confidentialité</string>
     <string name="onboarding_disclaimer">En créant un compte, vous confirmez avoir lu et accepter notre politique de confidentialité et nos conditions générales.</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -165,6 +165,8 @@
     <string name="players">Gracze</string>
     <string name="preferences">Preferencje</string>
     <string name="premium" translatable="false" >Premium</string>
+    <string name="manage_privacy">Zarządzaj prywatnością</string>
+    <string name="manage_privacy_button">Przycisk zarządzania prywatnością</string>
     <string name="privacy_policy">Polityka prywatności</string>
     <string name="privacy_policy_button">Przycisk polityki prywatności</string>
     <string name="onboarding_disclaimer">Tworząc konto potwierdzasz, że zapoznałeś się z naszą polityką prywatności oraz regulaminem i akceptujesz je.</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -165,6 +165,8 @@
     <string name="players">Игроки</string>
     <string name="preferences">Настройки</string>
     <string name="premium" translatable="false">Premium</string>
+    <string name="manage_privacy">Управление конфиденциальностью</string>
+    <string name="manage_privacy_button">Кнопка управления конфиденциальностью</string>
     <string name="privacy_policy">Политика конфиденциальности</string>
     <string name="privacy_policy_button">Кнопка политики конфиденциальности</string>
     <string name="onboarding_disclaimer">Создавая аккаунт, вы подтверждаете, что ознакомились и принимаете нашу политику конфиденциальности и условия использования.</string>

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -179,7 +179,8 @@ actual fun platformModule(passphrase: String): Module = module {
             userEventController = get(),
             setSubscribedUseCase = get(),
             remoteConfig = get(),
-            connectivityObserver = get()
+            connectivityObserver = get(),
+            adsConsentManager = get()
         )
     }
     factory {


### PR DESCRIPTION
## Summary
- show Ads privacy form from settings when required
- track consent requirement state
- add multilingual strings for "Manage privacy" button

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68926741565483219226f0f946b09376