### PR TITLE
Fix: arrange subscription plans vertically

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/PlanSelectorShimmer.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/PlanSelectorShimmer.kt
@@ -2,17 +2,14 @@ package pl.cuyer.rusthub.android.designsystem
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import pl.cuyer.rusthub.android.theme.spacing
@@ -20,17 +17,15 @@ import pl.cuyer.rusthub.android.theme.spacing
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun PlanSelectorShimmer(modifier: Modifier = Modifier) {
-    androidx.compose.foundation.layout.Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(64.dp),
-        horizontalArrangement = Arrangement.spacedBy(spacing.small)
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(spacing.small)
     ) {
         repeat(3) {
             Box(
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .height(64.dp)
                     .clip(MaterialTheme.shapes.extraSmall)
                     .shimmer()
                     .clearAndSetSemantics {}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/subscription/SubscriptionScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -484,14 +483,10 @@ private fun PlanSelector(
     products: Map<SubscriptionPlan, BillingProduct>,
     currentPlan: SubscriptionPlan?
 ) {
-    Row(
-        modifier = Modifier
-            .height(IntrinsicSize.Max)
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(
-            spacing.small,
-            Alignment.CenterHorizontally
-        )
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(spacing.small),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         val lifetimeOwned = currentPlan == SubscriptionPlan.LIFETIME
         SubscriptionPlan.entries.forEach { plan ->
@@ -516,18 +511,17 @@ private fun PlanSelector(
                     }
                     .then(
                         if (isSelected) Modifier
-                            .fillMaxHeight()
+                            .fillMaxWidth()
                             .border(
                                 width = 1.dp,
                                 color = MaterialTheme.colorScheme.primary,
                                 shape = CardDefaults.elevatedShape
-                            ) else Modifier.fillMaxHeight()
+                            ) else Modifier.fillMaxWidth()
                     )
             ) {
                 Column(
                     modifier = Modifier
                         .padding(spacing.medium)
-                        .widthIn(min = 60.dp, max = 80.dp)
                         .fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -539,7 +533,7 @@ private fun PlanSelector(
                     Text(stringResource(plan.label), style = MaterialTheme.typography.titleMedium)
                     Text(
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxWidth(),
                         text = products[plan]?.price ?: stringResource(plan.billed),
                         style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Thin)
                     )


### PR DESCRIPTION
## Summary
- stack plan cards vertically on subscription screen
- update plan selector shimmer to match vertical layout

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68930197f7c083219650f3092673232d