### PR TITLE
feat: persist table recipe in items

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/item/ItemDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/item/ItemDataSourceImpl.kt
@@ -63,6 +63,7 @@ class ItemDataSourceImpl(
                                     json.encodeToString(ListSerializer(WhereToFind.serializer()), it)
                                 },
                                 crafting = item.crafting?.let { json.encodeToString(it) },
+                                tableRecipe = item.tableRecipe?.let { json.encodeToString(it) },
                                 recycling = item.recycling?.let { json.encodeToString(it) },
                                 raiding = item.raiding?.let {
                                     json.encodeToString(ListSerializer(Raiding.serializer()), it)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -47,6 +47,7 @@ import pl.cuyer.rusthub.domain.model.Looting
 import pl.cuyer.rusthub.domain.model.LootContent
 import pl.cuyer.rusthub.domain.model.WhereToFind
 import pl.cuyer.rusthub.domain.model.Crafting
+import pl.cuyer.rusthub.domain.model.TableRecipe
 import pl.cuyer.rusthub.domain.model.Recycling
 import pl.cuyer.rusthub.domain.model.Raiding
 import kotlin.time.Instant
@@ -219,6 +220,7 @@ fun ItemEntity.toRustItem(json: Json): RustItem {
             json.decodeFromString(ListSerializer(WhereToFind.serializer()), it)
         },
         crafting = crafting?.let { json.decodeFromString(Crafting.serializer(), it) },
+        tableRecipe = table_recipe?.let { json.decodeFromString(TableRecipe.serializer(), it) },
         recycling = recycling?.let { json.decodeFromString(Recycling.serializer(), it) },
         raiding = raiding?.let {
             json.decodeFromString(ListSerializer(Raiding.serializer()), it)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/item/mapper/RustItemNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/item/mapper/RustItemNetworkMapper.kt
@@ -19,6 +19,8 @@ import pl.cuyer.rusthub.data.network.item.model.RaidItemDto
 import pl.cuyer.rusthub.data.network.item.model.RaidResourceDto
 import pl.cuyer.rusthub.data.network.item.model.LootContentDto
 import pl.cuyer.rusthub.data.network.item.model.WhereToFindDto
+import pl.cuyer.rusthub.data.network.item.model.TableRecipeDto
+import pl.cuyer.rusthub.data.network.item.model.TableRecipeIngredientDto
 import pl.cuyer.rusthub.domain.model.ItemCategory
 import pl.cuyer.rusthub.domain.model.Language
 import pl.cuyer.rusthub.domain.model.RustItem
@@ -38,6 +40,8 @@ import pl.cuyer.rusthub.domain.model.RaidItem
 import pl.cuyer.rusthub.domain.model.RaidResource
 import pl.cuyer.rusthub.domain.model.LootContent
 import pl.cuyer.rusthub.domain.model.WhereToFind
+import pl.cuyer.rusthub.domain.model.TableRecipe
+import pl.cuyer.rusthub.domain.model.TableRecipeIngredient
 
 fun RustItemDto.toDomain(): RustItem {
     return RustItem(
@@ -53,6 +57,7 @@ fun RustItemDto.toDomain(): RustItem {
         lootContents = lootContents?.map { it.toDomain() },
         whereToFind = whereToFind?.map { it.toDomain() },
         crafting = crafting?.toDomain(),
+        tableRecipe = tableRecipe?.toDomain(),
         recycling = recycling?.toDomain(),
         raiding = raiding?.map { it.toDomain() },
         shortName = shortName,
@@ -149,6 +154,26 @@ fun TechTreeCostDto.toDomain(): TechTreeCost {
         scrapName = scrapName,
         scrapAmount = scrapAmount,
         outputName = outputName
+    )
+}
+
+fun TableRecipeDto.toDomain(): TableRecipe {
+    return TableRecipe(
+        tableImage = tableImage,
+        tableName = tableName,
+        ingredients = ingredients?.map { it.toDomain() },
+        outputImage = outputImage,
+        outputName = outputName,
+        outputAmount = outputAmount,
+        totalCost = totalCost?.map { it.toDomain() }
+    )
+}
+
+fun TableRecipeIngredientDto.toDomain(): TableRecipeIngredient {
+    return TableRecipeIngredient(
+        image = image,
+        name = name,
+        amount = amount,
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/item/model/RustItemDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/item/model/RustItemDto.kt
@@ -10,6 +10,7 @@ import pl.cuyer.rusthub.data.network.item.model.RecyclingDto
 import pl.cuyer.rusthub.data.network.item.model.RaidingDto
 import pl.cuyer.rusthub.data.network.item.model.LootContentDto
 import pl.cuyer.rusthub.data.network.item.model.WhereToFindDto
+import pl.cuyer.rusthub.data.network.item.model.TableRecipeDto
 
 @Serializable
 data class RustItemDto(
@@ -25,6 +26,7 @@ data class RustItemDto(
     @SerialName("loot_contents") val lootContents: List<LootContentDto>? = null,
     @SerialName("where_to_find") val whereToFind: List<WhereToFindDto>? = null,
     val crafting: CraftingDto? = null,
+    @SerialName("table_recipe") val tableRecipe: TableRecipeDto? = null,
     val recycling: RecyclingDto? = null,
     val raiding: List<RaidingDto>? = null,
     @SerialName("short_name") val shortName: String? = null,

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/item/model/TableRecipeDto.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/item/model/TableRecipeDto.kt
@@ -1,0 +1,22 @@
+package pl.cuyer.rusthub.data.network.item.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TableRecipeDto(
+    @SerialName("table_image") val tableImage: String? = null,
+    @SerialName("table_name") val tableName: String? = null,
+    val ingredients: List<TableRecipeIngredientDto>? = null,
+    @SerialName("output_image") val outputImage: String? = null,
+    @SerialName("output_name") val outputName: String? = null,
+    @SerialName("output_amount") val outputAmount: Int? = null,
+    @SerialName("total_cost") val totalCost: List<TableRecipeIngredientDto>? = null,
+)
+
+@Serializable
+data class TableRecipeIngredientDto(
+    val image: String? = null,
+    val name: String? = null,
+    val amount: Int? = null,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/RustItem.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/RustItem.kt
@@ -27,6 +27,7 @@ data class RustItem(
     val lootContents: List<LootContent>? = null,
     val whereToFind: List<WhereToFind>? = null,
     val crafting: Crafting? = null,
+    val tableRecipe: TableRecipe? = null,
     val recycling: Recycling? = null,
     val raiding: List<Raiding>? = null,
     val shortName: String? = null,

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/RustItemDetails.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/RustItemDetails.kt
@@ -87,6 +87,26 @@ data class Crafting(
 
 @Serializable
 @Immutable
+data class TableRecipeIngredient(
+    val image: String? = null,
+    val name: String? = null,
+    val amount: Int? = null,
+)
+
+@Serializable
+@Immutable
+data class TableRecipe(
+    val tableImage: String? = null,
+    val tableName: String? = null,
+    val ingredients: List<TableRecipeIngredient>? = null,
+    val outputImage: String? = null,
+    val outputName: String? = null,
+    val outputAmount: Int? = null,
+    val totalCost: List<TableRecipeIngredient>? = null,
+)
+
+@Serializable
+@Immutable
 data class RecyclerOutput(
     val image: String? = null,
     val name: String? = null,

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -643,6 +643,7 @@ CREATE TABLE itemEntity (
     loot_contents TEXT,
     where_to_find TEXT,
     crafting TEXT,
+    table_recipe TEXT,
     recycling TEXT,
     raiding TEXT,
     PRIMARY KEY(id, language)
@@ -666,6 +667,7 @@ INSERT INTO itemEntity (
     loot_contents,
     where_to_find,
     crafting,
+    table_recipe,
     recycling,
     raiding
 ) VALUES (
@@ -685,6 +687,7 @@ INSERT INTO itemEntity (
     :lootContents,
     :whereToFind,
     :crafting,
+    :tableRecipe,
     :recycling,
     :raiding
 ) ON CONFLICT(id, language) DO UPDATE SET
@@ -703,6 +706,7 @@ INSERT INTO itemEntity (
     loot_contents = excluded.loot_contents,
     where_to_find = excluded.where_to_find,
     crafting = excluded.crafting,
+    table_recipe = excluded.table_recipe,
     recycling = excluded.recycling,
     raiding = excluded.raiding;
 

--- a/shared/src/commonMain/sqldelight/database/migrations/2.sq
+++ b/shared/src/commonMain/sqldelight/database/migrations/2.sq
@@ -1,0 +1,2 @@
+ALTER TABLE itemEntity ADD COLUMN table_recipe TEXT;
+


### PR DESCRIPTION
## Summary
- extend item DTOs, domain models, and network mapper to handle table recipes
- store table recipes in the local database and expose them on `RustItem`
- add database column with migration for table recipe persistence

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68934467b3c88321b30ffeb096503c04