### PR TITLE
feat: add table recipe page

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/RustItemExtensions.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/RustItemExtensions.kt
@@ -35,6 +35,16 @@ fun TechTreeCost.hasContent(): Boolean {
         outputName != null
 }
 
+fun TableRecipe.hasContent(): Boolean {
+    return tableImage != null ||
+        tableName != null ||
+        !ingredients.isNullOrEmpty() ||
+        outputImage != null ||
+        outputName != null ||
+        outputAmount != null ||
+        !totalCost.isNullOrEmpty()
+}
+
 fun Recycler.hasContent(): Boolean {
     return image != null ||
         !guarantedOutput.isNullOrEmpty() ||

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -412,10 +412,15 @@
     <string name="where_to_find">Where to find</string>
     <string name="chance">Chance</string>
     <string name="amount">Amount</string>
+    <string name="table">Table</string>
+    <string name="output">Output</string>
     <string name="crafting">Crafting</string>
+    <string name="table_recipe">Table Recipe</string>
     <string name="recycling">Recycling</string>
     <string name="raiding">Raiding</string>
     <string name="crafting_recipe">Crafting Recipe</string>
+    <string name="recipe">Recipe</string>
+    <string name="total_cost">Total Cost</string>
     <string name="research_table_cost">Research Table Cost</string>
     <string name="tech_tree_cost">Tech Tree Cost</string>
     <string name="safezone_recycler">Safezone Recycler</string>


### PR DESCRIPTION
## Summary
- add table recipe tab with attributes, recipe, and total cost cards
- support table recipe content detection
- translate and expose new strings for table recipe

## Testing
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_6893484783488321a7881bf14d19cffc