### PR TITLE
Add monuments destination with ads and scheduling

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -27,6 +27,7 @@ android {
         versionName = project.property("VERSION_NAME") as String
         buildConfigField("String", "SERVERS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/4096035325\"")
         buildConfigField("String", "ITEMS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/1469871989\"")
+        buildConfigField("String", "MONUMENTS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/1234567890\"")
     }
 
     androidResources {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -63,6 +63,8 @@ import pl.cuyer.rusthub.android.feature.auth.ResetPasswordScreen
 import pl.cuyer.rusthub.android.feature.auth.UpgradeAccountScreen
 import pl.cuyer.rusthub.android.feature.item.ItemDetailsScreen
 import pl.cuyer.rusthub.android.feature.item.ItemScreen
+import pl.cuyer.rusthub.android.feature.monument.MonumentDetailsScreen
+import pl.cuyer.rusthub.android.feature.monument.MonumentScreen
 import pl.cuyer.rusthub.android.feature.onboarding.OnboardingScreen
 import pl.cuyer.rusthub.android.feature.server.ServerDetailsScreen
 import pl.cuyer.rusthub.android.feature.server.ServerScreen
@@ -88,6 +90,8 @@ import pl.cuyer.rusthub.presentation.features.auth.password.ResetPasswordViewMod
 import pl.cuyer.rusthub.presentation.features.auth.upgrade.UpgradeViewModel
 import pl.cuyer.rusthub.presentation.features.item.ItemState
 import pl.cuyer.rusthub.presentation.features.item.ItemViewModel
+import pl.cuyer.rusthub.presentation.features.monument.MonumentViewModel
+import pl.cuyer.rusthub.presentation.features.monument.MonumentDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.onboarding.OnboardingViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerDetailsViewModel
 import pl.cuyer.rusthub.presentation.features.server.ServerViewModel
@@ -100,6 +104,8 @@ import pl.cuyer.rusthub.presentation.navigation.Credentials
 import pl.cuyer.rusthub.presentation.navigation.DeleteAccount
 import pl.cuyer.rusthub.presentation.navigation.ItemDetails
 import pl.cuyer.rusthub.presentation.navigation.ItemList
+import pl.cuyer.rusthub.presentation.navigation.MonumentDetails
+import pl.cuyer.rusthub.presentation.navigation.MonumentList
 import pl.cuyer.rusthub.presentation.navigation.Onboarding
 import pl.cuyer.rusthub.presentation.navigation.PrivacyPolicy
 import pl.cuyer.rusthub.presentation.navigation.ResetPassword
@@ -333,6 +339,38 @@ private fun AppScaffold(
                             state = state,
                             onNavigateUp = {
                                 while (backStack.lastOrNull() is ItemDetails) {
+                                    backStack.removeLastOrNull()
+                                }
+                            },
+                        )
+                    }
+                    entry<MonumentList>(metadata = ListDetailSceneStrategy.listPane()) {
+                        val viewModel = koinViewModel<MonumentViewModel>()
+                        val adViewModel = koinViewModel<NativeAdViewModel>()
+                        val state = viewModel.state.collectAsStateWithLifecycle()
+                        val paging = viewModel.paging.collectAsLazyPagingItems()
+                        val showAds by viewModel.showAds.collectAsStateWithLifecycle()
+                        val adState = adViewModel.state.collectAsStateWithLifecycle()
+                        MonumentScreen(
+                            state = state,
+                            onAction = viewModel::onAction,
+                            pagedList = paging,
+                            uiEvent = viewModel.uiEvent,
+                            onNavigate = { dest -> backStack.add(dest) },
+                            showAds = showAds,
+                            adState = adState,
+                            onAdAction = adViewModel::onAction
+                        )
+                    }
+                    entry<MonumentDetails>(metadata = ListDetailSceneStrategy.detailPane()) { key ->
+                        val viewModel: MonumentDetailsViewModel = koinViewModel(
+                            key = key.slug
+                        ) { parametersOf(key.slug) }
+                        val state = viewModel.state.collectAsStateWithLifecycle()
+                        MonumentDetailsScreen(
+                            state = state,
+                            onNavigateUp = {
+                                while (backStack.lastOrNull() is MonumentDetails) {
                                     backStack.removeLastOrNull()
                                 }
                             },

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItem.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItem.kt
@@ -1,0 +1,47 @@
+package pl.cuyer.rusthub.android.designsystem
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.domain.model.Monument
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun MonumentListItem(
+    modifier: Modifier = Modifier,
+    monument: Monument,
+    onClick: (String) -> Unit,
+) {
+    ElevatedCard(
+        onClick = { monument.slug?.let(onClick) },
+        shape = MaterialTheme.shapes.extraSmall,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(spacing.xmedium)) {
+            Text(
+                text = monument.name.orEmpty(),
+                style = MaterialTheme.typography.titleLargeEmphasized,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MonumentListItemPreview() {
+    RustHubTheme {
+        MonumentListItem(
+            monument = Monument(name = "Airfield", slug = "airfield"),
+            onClick = {},
+        )
+    }
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentDetailsScreen.kt
@@ -1,0 +1,96 @@
+package pl.cuyer.rusthub.android.feature.monument
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.android.util.composeUtil.stringResource
+import pl.cuyer.rusthub.presentation.features.monument.MonumentDetailsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MonumentDetailsScreen(
+    state: State<MonumentDetailsState>,
+    onNavigateUp: () -> Unit,
+) {
+    val pages = state.value.monumentPages
+    val pagerState = rememberPagerState { pages.size }
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = state.value.monument?.name.orEmpty(),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(SharedRes.strings.back),
+                        )
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+        ) {
+            if (pages.isNotEmpty()) {
+                PrimaryScrollableTabRow(selectedTabIndex = pagerState.currentPage) {
+                    pages.forEachIndexed { index, page ->
+                        Tab(
+                            selected = pagerState.currentPage == index,
+                            onClick = { scope.launch { pagerState.animateScrollToPage(index) } },
+                            text = { Text(stringResource(page.title)) }
+                        )
+                    }
+                }
+                HorizontalPager(
+                    modifier = Modifier.fillMaxSize(),
+                    state = pagerState
+                ) { _ ->
+                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text(text = stringResource(SharedRes.strings.coming_soon))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val MonumentDetailsState.monumentPages: List<MonumentPage>
+    get() = buildList {
+        monument?.attributes?.let { add(MonumentPage.Attributes) }
+        monument?.spawns?.let { add(MonumentPage.Spawns) }
+        monument?.usableEntities?.let { add(MonumentPage.UsableEntities) }
+        monument?.mining?.let { add(MonumentPage.Mining) }
+        monument?.puzzles?.let { add(MonumentPage.Puzzles) }
+    }
+
+private sealed interface MonumentPage {
+    val title: dev.icerock.moko.resources.StringResource
+    data object Attributes : MonumentPage { override val title = SharedRes.strings.attributes }
+    data object Spawns : MonumentPage { override val title = SharedRes.strings.spawns }
+    data object UsableEntities : MonumentPage { override val title = SharedRes.strings.usable_entities }
+    data object Mining : MonumentPage { override val title = SharedRes.strings.mining }
+    data object Puzzles : MonumentPage { override val title = SharedRes.strings.puzzles }
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
@@ -1,0 +1,162 @@
+package pl.cuyer.rusthub.android.feature.monument
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation3.runtime.NavKey
+import androidx.paging.compose.LazyPagingItems
+import kotlinx.coroutines.flow.Flow
+import org.koin.compose.koinInject
+import pl.cuyer.rusthub.android.BuildConfig
+import pl.cuyer.rusthub.android.ads.NativeAdListItem
+import pl.cuyer.rusthub.android.designsystem.MonumentListItem
+import pl.cuyer.rusthub.android.designsystem.RustSearchBarTopAppBar
+import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.util.composeUtil.stringResource
+import pl.cuyer.rusthub.presentation.features.ads.AdAction
+import pl.cuyer.rusthub.presentation.features.ads.NativeAdState
+import pl.cuyer.rusthub.presentation.features.monument.MonumentAction
+import pl.cuyer.rusthub.presentation.features.monument.MonumentState
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.domain.model.Monument
+import pl.cuyer.rusthub.domain.model.MonumentType
+import pl.cuyer.rusthub.domain.model.displayName
+import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.util.StringProvider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MonumentScreen(
+    state: State<MonumentState>,
+    onAction: (MonumentAction) -> Unit,
+    pagedList: LazyPagingItems<Monument>,
+    uiEvent: Flow<UiEvent>,
+    onNavigate: (NavKey) -> Unit,
+    showAds: Boolean,
+    adState: State<NativeAdState>,
+    onAdAction: (AdAction) -> Unit,
+) {
+    val searchBarState = rememberSearchBarState()
+    val textFieldState = rememberTextFieldState(state.value.searchText)
+    val lazyListState = rememberLazyListState()
+    val ads = adState
+
+    ObserveAsEvents(uiEvent) { event ->
+        if (event is UiEvent.Navigate) onNavigate(event.destination)
+    }
+
+    LaunchedEffect(showAds) {
+        if (showAds) {
+            onAdAction(AdAction.LoadAd(BuildConfig.MONUMENTS_ADMOB_NATIVE_AD_ID))
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            RustSearchBarTopAppBar(
+                searchBarState = searchBarState,
+                textFieldState = textFieldState,
+                onSearchTriggered = {
+                    onAction(MonumentAction.OnSearch(textFieldState.text.toString()))
+                },
+                onOpenFilters = {},
+                searchQueryUi = { emptyList() },
+                onDelete = {},
+                onClearSearchQuery = {},
+                isLoadingSearchHistory = { false },
+                placeholderRes = SharedRes.strings.search_monuments,
+                showFiltersIcon = false,
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .consumeWindowInsets(inner)
+                .fillMaxSize()
+        ) {
+            MonumentTypeChips(
+                selected = state.value.selectedType,
+                onSelectedChange = { onAction(MonumentAction.OnTypeChange(it)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(spacing.medium)
+            )
+            val adIndex = remember(pagedList.itemCount) {
+                if (pagedList.itemCount > 0) {
+                    if (pagedList.itemCount >= 5) 4 else pagedList.itemCount - 1
+                } else -1
+            }
+            LazyColumn(
+                contentPadding = PaddingValues(
+                    bottom = WindowInsets.safeDrawing
+                        .asPaddingValues().calculateBottomPadding()
+                ),
+                state = lazyListState,
+                verticalArrangement = Arrangement.spacedBy(spacing.medium),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                itemsIndexed(pagedList.itemSnapshotList.items) { index, monument ->
+                    if (showAds && index == adIndex) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        ) {
+                            NativeAdListItem(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = spacing.xmedium),
+                                ad = ads.value.ads[BuildConfig.MONUMENTS_ADMOB_NATIVE_AD_ID]
+                            )
+                            Spacer(modifier = Modifier.height(spacing.medium))
+                        }
+                    }
+                    MonumentListItem(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = spacing.xmedium),
+                        monument = monument,
+                        onClick = { slug -> onAction(MonumentAction.OnMonumentClick(slug)) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MonumentTypeChips(
+    selected: MonumentType?,
+    onSelectedChange: (MonumentType?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sp = koinInject<StringProvider>()
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing.small)
+    ) {
+        item {
+            FilterChip(
+                selected = selected == null,
+                onClick = { onSelectedChange(null) },
+                label = { Text(stringResource(SharedRes.strings.all)) }
+            )
+        }
+        items(MonumentType.entries.size) { index ->
+            val type = MonumentType.entries[index]
+            val text by rememberUpdatedState(type.displayName(sp))
+            FilterChip(
+                selected = selected == type,
+                onClick = { onSelectedChange(type) },
+                label = { Text(text) }
+            )
+        }
+    }
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/navigation/BottomNavItem.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/navigation/BottomNavItem.kt
@@ -4,11 +4,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Inventory
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.vector.ImageVector
 import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.presentation.navigation.ItemDetails
 import pl.cuyer.rusthub.presentation.navigation.ItemList
+import pl.cuyer.rusthub.presentation.navigation.MonumentDetails
+import pl.cuyer.rusthub.presentation.navigation.MonumentList
 import pl.cuyer.rusthub.presentation.navigation.ServerDetails
 import pl.cuyer.rusthub.presentation.navigation.ServerList
 import pl.cuyer.rusthub.presentation.navigation.Settings as SettingsNav
@@ -39,6 +42,16 @@ internal sealed interface BottomNavKey {
     }
 
     @Immutable
+    data object Monuments : BottomNavKey {
+        override val root = MonumentList
+        override val icon = Icons.Filled.AccountBalance
+        override val label = SharedRes.strings.monuments
+        override val isInHierarchy: (NavKey?) -> Boolean = {
+            it is MonumentList || it is MonumentDetails
+        }
+    }
+
+    @Immutable
     data object Settings : BottomNavKey {
         override val root = SettingsNav
         override val icon = Icons.Filled.Settings
@@ -50,5 +63,6 @@ internal sealed interface BottomNavKey {
 internal val bottomNavItems: List<BottomNavKey> = listOf(
     BottomNavKey.Servers,
     BottomNavKey.Items,
+    BottomNavKey.Monuments,
     BottomNavKey.Settings
 )

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -65,6 +65,8 @@ import pl.cuyer.rusthub.util.RemoteConfig
 import pl.cuyer.rusthub.util.MonumentsScheduler
 import pl.cuyer.rusthub.data.local.monument.MonumentSyncDataSourceImpl
 import pl.cuyer.rusthub.domain.repository.monument.local.MonumentSyncDataSource
+import pl.cuyer.rusthub.presentation.features.monument.MonumentViewModel
+import pl.cuyer.rusthub.presentation.features.monument.MonumentDetailsViewModel
 
 actual fun platformModule(passphrase: String): Module = module {
     single<RustHubDatabase>(createdAtStart = true) {
@@ -118,6 +120,9 @@ actual fun platformModule(passphrase: String): Module = module {
             itemsScheduler = get(),
             itemDataSource = get(),
             itemSyncDataSource = get(),
+            monumentsScheduler = get(),
+            monumentDataSource = get(),
+            monumentSyncDataSource = get(),
             purchaseSyncDataSource = get(),
             purchaseSyncScheduler = get()
         )
@@ -187,10 +192,27 @@ actual fun platformModule(passphrase: String): Module = module {
             adsConsentManager = get(),
         )
     }
+    viewModel {
+        MonumentViewModel(
+            getPagedMonumentsUseCase = get(),
+            monumentSyncDataSource = get(),
+            monumentsScheduler = get(),
+            snackbarController = get(),
+            stringProvider = get(),
+            getUserUseCase = get(),
+            adsConsentManager = get(),
+        )
+    }
     viewModel { (itemId: Long) ->
         ItemDetailsViewModel(
             getItemDetailsUseCase = get(),
             itemId = itemId,
+        )
+    }
+    viewModel { (slug: String) ->
+        MonumentDetailsViewModel(
+            getMonumentDetailsUseCase = get(),
+            slug = slug,
         )
     }
     viewModel {
@@ -208,6 +230,8 @@ actual fun platformModule(passphrase: String): Module = module {
             systemDarkThemeObserver = get(),
             itemsScheduler = get(),
             itemSyncDataSource = get(),
+            monumentsScheduler = get(),
+            monumentSyncDataSource = get(),
             userEventController = get(),
             getActiveSubscriptionUseCase = get(),
             setSubscribedUseCase = get(),

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -14,6 +14,7 @@ import database.ServerEntity
 import database.UserEntity
 import database.ItemEntity
 import database.ItemSearchQueryEntity
+import database.MonumentEntity
 import pl.cuyer.rusthub.data.local.model.DifficultyEntity
 import pl.cuyer.rusthub.data.local.model.FlagEntity
 import pl.cuyer.rusthub.data.local.model.MapsEntity
@@ -51,6 +52,12 @@ import pl.cuyer.rusthub.domain.model.TableRecipe
 import pl.cuyer.rusthub.domain.model.Recycling
 import pl.cuyer.rusthub.domain.model.Raiding
 import pl.cuyer.rusthub.domain.model.ItemAttribute
+import pl.cuyer.rusthub.domain.model.Monument
+import pl.cuyer.rusthub.domain.model.MonumentAttributes
+import pl.cuyer.rusthub.domain.model.MonumentSpawns
+import pl.cuyer.rusthub.domain.model.MonumentPuzzle
+import pl.cuyer.rusthub.domain.model.UsableEntity
+import pl.cuyer.rusthub.domain.model.Mining
 import kotlin.time.Instant
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -230,6 +237,23 @@ fun ItemEntity.toRustItem(json: Json): RustItem {
             json.decodeFromString(ListSerializer(Raiding.serializer()), it)
         },
         id = id
+    )
+}
+
+fun MonumentEntity.toMonument(json: Json): Monument {
+    return Monument(
+        name = name,
+        slug = slug,
+        attributes = attributes?.let { json.decodeFromString(MonumentAttributes.serializer(), it) },
+        spawns = spawns?.let { json.decodeFromString(MonumentSpawns.serializer(), it) },
+        usableEntities = usable_entities?.let {
+            json.decodeFromString(ListSerializer(UsableEntity.serializer()), it)
+        },
+        mining = mining?.let { json.decodeFromString(Mining.serializer(), it) },
+        puzzles = puzzles?.let {
+            json.decodeFromString(ListSerializer(MonumentPuzzle.serializer()), it)
+        },
+        language = language,
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/monument/MonumentDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/monument/MonumentDataSourceImpl.kt
@@ -1,18 +1,29 @@
 package pl.cuyer.rusthub.data.local.monument
 
+import androidx.paging.PagingSource
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToOneOrNull
+import app.cash.sqldelight.paging3.QueryPagingSource
+import database.MonumentEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import pl.cuyer.rusthub.data.local.Queries
+import pl.cuyer.rusthub.data.local.mapper.toMonument
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.domain.model.Language
 import pl.cuyer.rusthub.domain.model.Monument
 import pl.cuyer.rusthub.domain.model.MonumentPuzzle
+import pl.cuyer.rusthub.domain.model.MonumentType
 import pl.cuyer.rusthub.domain.model.UsableEntity
 import pl.cuyer.rusthub.domain.repository.monument.local.MonumentDataSource
+import pl.cuyer.rusthub.util.CrashReporter
 
 class MonumentDataSourceImpl(
     db: RustHubDatabase,
@@ -49,5 +60,51 @@ class MonumentDataSourceImpl(
                 queries.countMonuments(language = language.name).executeAsOne() == 0L
             }
         }
+    }
+
+    override fun getMonumentsPagingSource(
+        name: String?,
+        type: MonumentType?,
+        language: Language,
+    ): PagingSource<Int, MonumentEntity> {
+        return QueryPagingSource(
+            countQuery = queries.countPagedMonumentsFiltered(
+                name = name ?: "",
+                type = type?.toDbValue(),
+                language = language.name
+            ),
+            transacter = queries,
+            context = Dispatchers.IO,
+            queryProvider = { limit, offset ->
+                queries.findMonumentsPagedFiltered(
+                    name = name ?: "",
+                    type = type?.toDbValue(),
+                    language = language.name,
+                    limit = limit,
+                    offset = offset
+                )
+            }
+        )
+    }
+
+    override fun getMonumentBySlug(slug: String, language: Language): Flow<Monument?> {
+        return queries.getMonumentBySlug(slug = slug, language = language.name)
+            .asFlow()
+            .mapToOneOrNull(Dispatchers.IO)
+            .map { it?.toMonument(json) }
+            .catch { e ->
+                CrashReporter.recordException(e)
+                throw e
+            }
+    }
+
+    private fun MonumentType.toDbValue(): String = when (this) {
+        MonumentType.SMALL -> "Small"
+        MonumentType.SAFE_ZONES -> "Safe Zones"
+        MonumentType.OCEANSIDE -> "Oceanside"
+        MonumentType.MEDIUM -> "Medium"
+        MonumentType.ROADSIDE -> "Roadside"
+        MonumentType.OFFSHORE -> "Offshore"
+        MonumentType.LARGE -> "Large"
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/MonumentTypeExt.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/MonumentTypeExt.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.domain.model
+
+import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.util.StringProvider
+
+fun MonumentType.displayName(stringProvider: StringProvider): String = when (this) {
+    MonumentType.SMALL -> stringProvider.get(SharedRes.strings.monument_small)
+    MonumentType.SAFE_ZONES -> stringProvider.get(SharedRes.strings.monument_safe_zones)
+    MonumentType.OCEANSIDE -> stringProvider.get(SharedRes.strings.monument_oceanside)
+    MonumentType.MEDIUM -> stringProvider.get(SharedRes.strings.monument_medium)
+    MonumentType.ROADSIDE -> stringProvider.get(SharedRes.strings.monument_roadside)
+    MonumentType.OFFSHORE -> stringProvider.get(SharedRes.strings.monument_offshore)
+    MonumentType.LARGE -> stringProvider.get(SharedRes.strings.monument_large)
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/monument/local/MonumentDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/monument/local/MonumentDataSource.kt
@@ -1,9 +1,19 @@
 package pl.cuyer.rusthub.domain.repository.monument.local
 
+import androidx.paging.PagingSource
+import database.MonumentEntity
+import kotlinx.coroutines.flow.Flow
 import pl.cuyer.rusthub.domain.model.Monument
 import pl.cuyer.rusthub.domain.model.Language
+import pl.cuyer.rusthub.domain.model.MonumentType
 
 interface MonumentDataSource {
     suspend fun upsertMonuments(monuments: List<Monument>)
     suspend fun isEmpty(language: Language): Boolean
+    fun getMonumentsPagingSource(
+        name: String?,
+        type: MonumentType?,
+        language: Language,
+    ): PagingSource<Int, MonumentEntity>
+    fun getMonumentBySlug(slug: String, language: Language): Flow<Monument?>
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetMonumentDetailsUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetMonumentDetailsUseCase.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.domain.model.Language
+import pl.cuyer.rusthub.domain.model.Monument
+import pl.cuyer.rusthub.domain.repository.monument.local.MonumentDataSource
+
+class GetMonumentDetailsUseCase(
+    private val dataSource: MonumentDataSource,
+) {
+    operator fun invoke(slug: String, language: Language): Flow<Monument?> {
+        return dataSource.getMonumentBySlug(slug, language)
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetPagedMonumentsUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetPagedMonumentsUseCase.kt
@@ -1,0 +1,37 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import pl.cuyer.rusthub.data.local.mapper.toMonument
+import pl.cuyer.rusthub.domain.model.Language
+import pl.cuyer.rusthub.domain.model.Monument
+import pl.cuyer.rusthub.domain.model.MonumentType
+import pl.cuyer.rusthub.domain.repository.monument.local.MonumentDataSource
+
+class GetPagedMonumentsUseCase(
+    private val dataSource: MonumentDataSource,
+    private val json: Json,
+) {
+    operator fun invoke(
+        query: String?,
+        type: MonumentType?,
+        language: Language,
+    ): Flow<PagingData<Monument>> {
+        return Pager(
+            config = PagingConfig(
+                pageSize = 30,
+                enablePlaceholders = true,
+            ),
+            pagingSourceFactory = {
+                dataSource.getMonumentsPagingSource(query, type, language)
+            },
+        ).flow.map { pagingData ->
+            pagingData.map { it.toMonument(json) }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -67,10 +67,12 @@ import pl.cuyer.rusthub.domain.usecase.GetFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.GetGoogleClientIdUseCase
 import pl.cuyer.rusthub.domain.usecase.GetPagedServersUseCase
 import pl.cuyer.rusthub.domain.usecase.GetPagedItemsUseCase
+import pl.cuyer.rusthub.domain.usecase.GetPagedMonumentsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetItemSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetItemDetailsUseCase
+import pl.cuyer.rusthub.domain.usecase.GetMonumentDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.domain.usecase.GetUserPreferencesUseCase
 import pl.cuyer.rusthub.domain.usecase.LoginUserUseCase
@@ -151,6 +153,7 @@ val appModule = module {
     single { UsernameValidator(get()) }
     single { GetPagedServersUseCase(get(), get(), get(), get()) }
     single { GetPagedItemsUseCase(get(), get()) }
+    single { GetPagedMonumentsUseCase(get(), get()) }
     single { GetFiltersUseCase(get()) }
     single { SaveFiltersUseCase(get()) }
     single { SaveSearchQueryUseCase(get()) }
@@ -165,6 +168,7 @@ val appModule = module {
     single { DeleteItemSearchQueriesUseCase(get()) }
     single { GetServerDetailsUseCase(get()) }
     single { GetItemDetailsUseCase(get()) }
+    single { GetMonumentDetailsUseCase(get()) }
     single { RegisterUserUseCase(get(), get(), get(), get()) }
     single { LoginUserUseCase(get(), get(), get(), get()) }
     single { LoginWithGoogleUseCase(get(), get(), get(), get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentAction.kt
@@ -1,0 +1,11 @@
+package pl.cuyer.rusthub.presentation.features.monument
+
+import pl.cuyer.rusthub.domain.model.MonumentType
+
+sealed interface MonumentAction {
+    data class OnMonumentClick(val slug: String) : MonumentAction
+    data class OnSearch(val query: String) : MonumentAction
+    data class OnTypeChange(val type: MonumentType?) : MonumentAction
+    data class OnError(val exception: Throwable) : MonumentAction
+    data object OnRefresh : MonumentAction
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentDetailsState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentDetailsState.kt
@@ -1,0 +1,11 @@
+package pl.cuyer.rusthub.presentation.features.monument
+
+import androidx.compose.runtime.Immutable
+import pl.cuyer.rusthub.domain.model.Monument
+
+@Immutable
+data class MonumentDetailsState(
+    val monument: Monument? = null,
+    val isLoading: Boolean = true,
+    val slug: String? = null,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentDetailsViewModel.kt
@@ -1,0 +1,46 @@
+package pl.cuyer.rusthub.presentation.features.monument
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.domain.usecase.GetMonumentDetailsUseCase
+import pl.cuyer.rusthub.util.getCurrentAppLanguage
+
+class MonumentDetailsViewModel(
+    private val getMonumentDetailsUseCase: GetMonumentDetailsUseCase,
+    private val slug: String?,
+) : BaseViewModel() {
+
+    private val _state = MutableStateFlow(MonumentDetailsState())
+    val state = _state
+        .onStart { slug?.let { observeMonument(it) } }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = MonumentDetailsState(),
+        )
+
+    private fun observeMonument(slug: String) {
+        getMonumentDetailsUseCase(slug, getCurrentAppLanguage())
+            .onStart { updateLoading(true) }
+            .catch { e ->
+                if (e is CancellationException) throw e
+                updateLoading(false)
+            }
+            .onEach { monument ->
+                _state.update { it.copy(monument = monument, isLoading = false, slug = slug) }
+            }
+            .launchIn(coroutineScope)
+    }
+
+    private fun updateLoading(loading: Boolean) {
+        _state.update { it.copy(isLoading = loading) }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentState.kt
@@ -1,0 +1,13 @@
+package pl.cuyer.rusthub.presentation.features.monument
+
+import androidx.compose.runtime.Immutable
+import pl.cuyer.rusthub.domain.model.MonumentType
+import pl.cuyer.rusthub.domain.model.MonumentSyncState
+
+@Immutable
+data class MonumentState(
+    val isRefreshing: Boolean = true,
+    val searchText: String = "",
+    val selectedType: MonumentType? = null,
+    val syncState: MonumentSyncState = MonumentSyncState.DONE,
+)

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentViewModel.kt
@@ -1,0 +1,121 @@
+package pl.cuyer.rusthub.presentation.features.monument
+
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import pl.cuyer.rusthub.common.BaseViewModel
+import pl.cuyer.rusthub.domain.model.Monument
+import pl.cuyer.rusthub.domain.model.MonumentSyncState
+import pl.cuyer.rusthub.domain.model.MonumentType
+import pl.cuyer.rusthub.domain.usecase.GetPagedMonumentsUseCase
+import pl.cuyer.rusthub.domain.repository.monument.local.MonumentSyncDataSource
+import pl.cuyer.rusthub.presentation.navigation.MonumentDetails
+import pl.cuyer.rusthub.presentation.navigation.UiEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.util.MonumentsScheduler
+import pl.cuyer.rusthub.util.StringProvider
+import pl.cuyer.rusthub.util.getCurrentAppLanguage
+import pl.cuyer.rusthub.util.toUserMessage
+import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
+import pl.cuyer.rusthub.util.AdsConsentManager
+
+class MonumentViewModel(
+    private val getPagedMonumentsUseCase: GetPagedMonumentsUseCase,
+    private val monumentSyncDataSource: MonumentSyncDataSource,
+    private val monumentsScheduler: MonumentsScheduler,
+    private val snackbarController: SnackbarController,
+    private val stringProvider: StringProvider,
+    private val getUserUseCase: GetUserUseCase,
+    private val adsConsentManager: AdsConsentManager,
+) : BaseViewModel() {
+
+    private val _uiEvent = Channel<UiEvent>(UNLIMITED)
+    val uiEvent = _uiEvent.receiveAsFlow()
+
+    private val queryFlow = MutableStateFlow("")
+    private val typeFlow = MutableStateFlow<MonumentType?>(null)
+
+    private val _state = MutableStateFlow(MonumentState())
+    val state = _state.stateIn(
+        scope = coroutineScope,
+        started = SharingStarted.WhileSubscribed(5_000L),
+        initialValue = MonumentState(),
+    )
+
+    val showAds = getUserUseCase()
+        .map { user -> !(user?.subscribed ?: false) && adsConsentManager.canRequestAds }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = true,
+        )
+
+    init {
+        observeSyncState()
+    }
+
+    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    val paging: Flow<PagingData<Monument>> =
+        combine(queryFlow, typeFlow) { query, type ->
+            Pair(query, type)
+        }.flatMapLatest { (query, type) ->
+            getPagedMonumentsUseCase(query, type, getCurrentAppLanguage())
+        }.cachedIn(coroutineScope)
+
+    fun onAction(action: MonumentAction) {
+        when (action) {
+            is MonumentAction.OnMonumentClick -> navigateToMonument(action.slug)
+            is MonumentAction.OnSearch -> {
+                queryFlow.value = action.query
+                _state.update { it.copy(searchText = action.query) }
+            }
+            is MonumentAction.OnTypeChange -> {
+                typeFlow.value = action.type
+                _state.update { it.copy(selectedType = action.type) }
+            }
+            MonumentAction.OnRefresh -> refreshMonuments()
+            is MonumentAction.OnError -> {
+                val message = action.exception.toUserMessage(stringProvider)
+                coroutineScope.launch {
+                    snackbarController.sendEvent(SnackbarEvent(message = message))
+                }
+            }
+        }
+    }
+
+    private fun navigateToMonument(slug: String) {
+        coroutineScope.launch {
+            _uiEvent.send(UiEvent.Navigate(MonumentDetails(slug)))
+        }
+    }
+
+    private fun observeSyncState() {
+        coroutineScope.launch {
+            monumentSyncDataSource.observeState().collect { stateValue ->
+                stateValue ?: return@collect
+                _state.update { current ->
+                    current.copy(syncState = stateValue)
+                }
+            }
+        }
+    }
+
+    private fun refreshMonuments() {
+        coroutineScope.launch {
+            monumentSyncDataSource.setState(MonumentSyncState.PENDING)
+            monumentsScheduler.startNow()
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/settings/SettingsViewModel.kt
@@ -68,6 +68,9 @@ import pl.cuyer.rusthub.domain.model.ItemSyncState
 import pl.cuyer.rusthub.domain.model.displayName
 import pl.cuyer.rusthub.util.updateAppLanguage
 import pl.cuyer.rusthub.domain.model.SubscriptionState
+import pl.cuyer.rusthub.domain.model.MonumentSyncState
+import pl.cuyer.rusthub.util.MonumentsScheduler
+import pl.cuyer.rusthub.domain.repository.monument.local.MonumentSyncDataSource
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
@@ -84,8 +87,10 @@ class SettingsViewModel(
     private val stringProvider: StringProvider,
     private val systemDarkThemeObserver: SystemDarkThemeObserver,
     private val itemsScheduler: ItemsScheduler,
+    private val monumentsScheduler: MonumentsScheduler,
     private val getActiveSubscriptionUseCase: GetActiveSubscriptionUseCase,
     private val itemSyncDataSource: ItemSyncDataSource,
+    private val monumentSyncDataSource: MonumentSyncDataSource,
     private val userEventController: UserEventController,
     private val setSubscribedUseCase: SetSubscribedUseCase,
     private val remoteConfig: RemoteConfig,
@@ -360,6 +365,9 @@ class SettingsViewModel(
             itemSyncDataSource.setState(ItemSyncState.PENDING)
             itemsScheduler.startNow()
             itemsScheduler.schedule()
+            monumentSyncDataSource.setState(MonumentSyncState.PENDING)
+            monumentsScheduler.startNow()
+            monumentsScheduler.schedule()
         }
     }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/startup/StartupViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/startup/StartupViewModel.kt
@@ -38,6 +38,10 @@ import pl.cuyer.rusthub.domain.model.ItemSyncState
 import pl.cuyer.rusthub.domain.repository.purchase.PurchaseSyncDataSource
 import pl.cuyer.rusthub.util.InAppUpdateManager
 import pl.cuyer.rusthub.util.PurchaseSyncScheduler
+import pl.cuyer.rusthub.util.MonumentsScheduler
+import pl.cuyer.rusthub.domain.repository.monument.local.MonumentDataSource
+import pl.cuyer.rusthub.domain.repository.monument.local.MonumentSyncDataSource
+import pl.cuyer.rusthub.domain.model.MonumentSyncState
 
 class StartupViewModel(
     private val snackbarController: SnackbarController,
@@ -50,6 +54,9 @@ class StartupViewModel(
     private val itemsScheduler: ItemsScheduler,
     private val itemDataSource: ItemDataSource,
     private val itemSyncDataSource: ItemSyncDataSource,
+    private val monumentsScheduler: MonumentsScheduler,
+    private val monumentDataSource: MonumentDataSource,
+    private val monumentSyncDataSource: MonumentSyncDataSource,
     private val purchaseSyncDataSource: PurchaseSyncDataSource,
     private val purchaseSyncScheduler: PurchaseSyncScheduler
 ) : BaseViewModel() {
@@ -79,6 +86,12 @@ class StartupViewModel(
                 itemsScheduler.startNow()
             } else {
                 itemsScheduler.schedule()
+            }
+            if (monumentDataSource.isEmpty(getCurrentAppLanguage())) {
+                monumentSyncDataSource.setState(MonumentSyncState.PENDING)
+                monumentsScheduler.startNow()
+            } else {
+                monumentsScheduler.schedule()
             }
             if (purchaseSyncDataSource.getPendingOperations().isNotEmpty()) {
                 purchaseSyncScheduler.schedule()

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/navigation/Destination.kt
@@ -53,6 +53,15 @@ data class ItemDetails(
 ) : NavKey
 
 @Serializable
+data object MonumentList : NavKey
+
+@Serializable
+@Immutable
+data class MonumentDetails(
+    val slug: String,
+) : NavKey
+
+@Serializable
 data object PrivacyPolicy : NavKey
 
 @Serializable

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -138,6 +138,13 @@
     <string name="modded">Modded</string>
     <string name="monthly">Monthly</string>
     <string name="monuments">Monuments</string>
+    <string name="monument_small">Small</string>
+    <string name="monument_safe_zones">Safe Zones</string>
+    <string name="monument_oceanside">Oceanside</string>
+    <string name="monument_medium">Medium</string>
+    <string name="monument_roadside">Roadside</string>
+    <string name="monument_offshore">Offshore</string>
+    <string name="monument_large">Large</string>
     <string name="narrow_your_search_using_advanced_filtering_options">Narrow your search using advanced filtering options.</string>
     <string name="navigate_up">Navigate up</string>
     <string name="need_to_compare">Need to compare?</string>
@@ -219,6 +226,13 @@
     <string name="search_and_explore_rust_servers_by_name_type_last_wipe_or_more">Search and explore Rust servers by name, type, last wipe or more.</string>
     <string name="search_servers">Search servers...</string>
     <string name="search_items">Search items...</string>
+    <string name="search_monuments">Search monuments...</string>
+    <string name="attributes">Attributes</string>
+    <string name="spawns">Spawns</string>
+    <string name="usable_entities">Usable Entities</string>
+    <string name="mining">Mining</string>
+    <string name="puzzles">Puzzles</string>
+    <string name="coming_soon">Coming soon</string>
     <string name="search_items_check_details_how_to_craft_drop_and_raid_costs">Search items and check their details, crafting, drops and raid costs.</string>
     <string name="see_server_info_like_time_of_last_wipe_map_ranking_and_more">See server info like time of last wipe, map, ranking and more.</string>
     <string name="seed" translatable="false">Seed</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -137,6 +137,13 @@
     <string name="modded">Gemoddet</string>
     <string name="monthly">Monatlich</string>
     <string name="monuments">Monumente</string>
+    <string name="monument_small">Small</string>
+    <string name="monument_safe_zones">Safe Zones</string>
+    <string name="monument_oceanside">Oceanside</string>
+    <string name="monument_medium">Medium</string>
+    <string name="monument_roadside">Roadside</string>
+    <string name="monument_offshore">Offshore</string>
+    <string name="monument_large">Large</string>
     <string name="narrow_your_search_using_advanced_filtering_options">Verfeinere die Suche mit Filtern.</string>
     <string name="navigate_up">Nach oben</string>
     <string name="need_to_compare">Möchtest du vergleichen?</string>
@@ -218,6 +225,13 @@
     <string name="search_and_explore_rust_servers_by_name_type_last_wipe_or_more">Durchsuche und entdecke Rust-Server nach Name, Typ, letztem Wipe und mehr.</string>
     <string name="search_servers">Server suchen...</string>
     <string name="search_items">Gegenst\u00e4nde suchen...</string>
+    <string name="search_monuments">Search monuments...</string>
+    <string name="attributes">Attributes</string>
+    <string name="spawns">Spawns</string>
+    <string name="usable_entities">Usable Entities</string>
+    <string name="mining">Mining</string>
+    <string name="puzzles">Puzzles</string>
+    <string name="coming_soon">Coming soon</string>
     <string name="search_items_check_details_how_to_craft_drop_and_raid_costs">Suche nach Gegenständen und prüfe Details, Herstellung, Drops und Raid-Kosten.</string>
     <string name="see_server_info_like_time_of_last_wipe_map_ranking_and_more">Sieh Serverinfos wie Zeit des letzten Wipes, Karte, Ranking und mehr.</string>
     <string name="seed" translatable="false">Seed</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -137,6 +137,13 @@
     <string name="modded">Moddé</string>
     <string name="monthly">Mensuel</string>
     <string name="monuments">Monuments</string>
+    <string name="monument_small">Small</string>
+    <string name="monument_safe_zones">Safe Zones</string>
+    <string name="monument_oceanside">Oceanside</string>
+    <string name="monument_medium">Medium</string>
+    <string name="monument_roadside">Roadside</string>
+    <string name="monument_offshore">Offshore</string>
+    <string name="monument_large">Large</string>
     <string name="narrow_your_search_using_advanced_filtering_options">Affinez votre recherche grâce aux filtres avancés.</string>
     <string name="navigate_up">Remonter</string>
     <string name="need_to_compare">Besoin de comparer?</string>
@@ -218,6 +225,13 @@
     <string name="search_and_explore_rust_servers_by_name_type_last_wipe_or_more">Recherchez et explorez les serveurs Rust par nom, type, dernier wipe et plus encore.</string>
     <string name="search_servers">Rechercher des serveurs...</string>
     <string name="search_items">Rechercher des objets...</string>
+    <string name="search_monuments">Search monuments...</string>
+    <string name="attributes">Attributes</string>
+    <string name="spawns">Spawns</string>
+    <string name="usable_entities">Usable Entities</string>
+    <string name="mining">Mining</string>
+    <string name="puzzles">Puzzles</string>
+    <string name="coming_soon">Coming soon</string>
     <string name="search_items_check_details_how_to_craft_drop_and_raid_costs">Recherchez des objets et consultez leurs détails, fabrication, loot et coûts de raid.</string>
     <string name="see_server_info_like_time_of_last_wipe_map_ranking_and_more">Consultez les infos du serveur : date du dernier wipe, carte, classement, etc.</string>
     <string name="seed" translatable="false">Seed</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -137,6 +137,13 @@
     <string name="modded">Zmodowany</string>
     <string name="monthly">Miesięczny</string>
     <string name="monuments">Monumenty</string>
+    <string name="monument_small">Small</string>
+    <string name="monument_safe_zones">Safe Zones</string>
+    <string name="monument_oceanside">Oceanside</string>
+    <string name="monument_medium">Medium</string>
+    <string name="monument_roadside">Roadside</string>
+    <string name="monument_offshore">Offshore</string>
+    <string name="monument_large">Large</string>
     <string name="narrow_your_search_using_advanced_filtering_options">Zawęź wyniki za pomocą filtrów.</string>
     <string name="navigate_up">Do góry</string>
     <string name="need_to_compare">Chcesz porównać?</string>
@@ -218,6 +225,13 @@
     <string name="search_and_explore_rust_servers_by_name_type_last_wipe_or_more">Wyszukuj i odkrywaj serwery Rust po nazwie, typie, wipe’ie i nie tylko.</string>
     <string name="search_servers">Szukaj serwerów...</string>
     <string name="search_items">Szukaj przedmiot\u00f3w...</string>
+    <string name="search_monuments">Search monuments...</string>
+    <string name="attributes">Attributes</string>
+    <string name="spawns">Spawns</string>
+    <string name="usable_entities">Usable Entities</string>
+    <string name="mining">Mining</string>
+    <string name="puzzles">Puzzles</string>
+    <string name="coming_soon">Coming soon</string>
     <string name="search_items_check_details_how_to_craft_drop_and_raid_costs">Wyszukuj przedmioty i sprawdzaj ich szczegóły, crafting, dropy i koszty rajdów.</string>
     <string name="see_server_info_like_time_of_last_wipe_map_ranking_and_more">Sprawdź informacje o serwerze — czas ostatniego wipe’a, mapa, ranking itd.</string>
     <string name="seed" translatable="false">Seed</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -137,6 +137,13 @@
     <string name="modded">Модифицированный</string>
     <string name="monthly">Ежемесячно</string>
     <string name="monuments">Монументы</string>
+    <string name="monument_small">Small</string>
+    <string name="monument_safe_zones">Safe Zones</string>
+    <string name="monument_oceanside">Oceanside</string>
+    <string name="monument_medium">Medium</string>
+    <string name="monument_roadside">Roadside</string>
+    <string name="monument_offshore">Offshore</string>
+    <string name="monument_large">Large</string>
     <string name="narrow_your_search_using_advanced_filtering_options">Сужайте поиск с помощью фильтров.</string>
     <string name="navigate_up">Наверх</string>
     <string name="need_to_compare">Хотите сравнить?</string>
@@ -218,6 +225,13 @@
     <string name="search_and_explore_rust_servers_by_name_type_last_wipe_or_more">Ищите и изучайте серверы Rust по имени, типу, последнему вайпу и др.</string>
     <string name="search_servers">Поиск серверов...</string>
     <string name="search_items">Поиск предметов...</string>
+    <string name="search_monuments">Search monuments...</string>
+    <string name="attributes">Attributes</string>
+    <string name="spawns">Spawns</string>
+    <string name="usable_entities">Usable Entities</string>
+    <string name="mining">Mining</string>
+    <string name="puzzles">Puzzles</string>
+    <string name="coming_soon">Coming soon</string>
     <string name="search_items_check_details_how_to_craft_drop_and_raid_costs">Ищите предметы и смотрите их характеристики, крафт, выпадение и стоимость рейда.</string>
     <string name="see_server_info_like_time_of_last_wipe_map_ranking_and_more">Смотрите инфо о сервере: время последнего вайпа, карта, рейтинг и т.д.</string>
     <string name="seed" translatable="false">Seed</string>

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -808,6 +808,25 @@ SELECT COUNT(*) FROM monumentEntity WHERE language = :language;
 deleteMonuments:
 DELETE FROM monumentEntity;
 
+findMonumentsPagedFiltered:
+SELECT *
+FROM monumentEntity
+WHERE (name LIKE '%' || :name || '%' COLLATE NOCASE)
+  AND (:type IS NULL OR attributes LIKE '%' || :type || '%')
+  AND language = :language
+ORDER BY name
+LIMIT :limit OFFSET :offset;
+
+countPagedMonumentsFiltered:
+SELECT COUNT(*)
+FROM monumentEntity
+WHERE (name LIKE '%' || :name || '%' COLLATE NOCASE)
+  AND (:type IS NULL OR attributes LIKE '%' || :type || '%')
+  AND language = :language;
+
+getMonumentBySlug:
+SELECT * FROM monumentEntity WHERE slug = :slug AND language = :language;
+
 CREATE TABLE monumentSyncEntity (
     id TEXT NOT NULL PRIMARY KEY,
     sync_state TEXT NOT NULL

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -59,6 +59,8 @@ import pl.cuyer.rusthub.domain.repository.ads.NativeAdRepository
 import pl.cuyer.rusthub.domain.usecase.ads.GetNativeAdUseCase
 import pl.cuyer.rusthub.domain.usecase.ads.ClearNativeAdsUseCase
 import pl.cuyer.rusthub.presentation.features.ads.NativeAdViewModel
+import pl.cuyer.rusthub.presentation.features.monument.MonumentViewModel
+import pl.cuyer.rusthub.presentation.features.monument.MonumentDetailsViewModel
 
 @Suppress("UNUSED_PARAMETER")
 actual fun platformModule(passphrase: String): Module = module {
@@ -105,6 +107,9 @@ actual fun platformModule(passphrase: String): Module = module {
             itemsScheduler = get(),
             itemDataSource = get(),
             itemSyncDataSource = get(),
+            monumentsScheduler = get(),
+            monumentDataSource = get(),
+            monumentSyncDataSource = get(),
             purchaseSyncDataSource = get(),
             purchaseSyncScheduler = get()
         )
@@ -118,10 +123,25 @@ actual fun platformModule(passphrase: String): Module = module {
             adsConsentManager = get()
         )
     }
+    factory {
+        MonumentViewModel(
+            getPagedMonumentsUseCase = get(),
+            monumentSyncDataSource = get(),
+            monumentsScheduler = get(),
+            getUserUseCase = get(),
+            adsConsentManager = get(),
+        )
+    }
     factory { (itemId: Long) ->
         ItemDetailsViewModel(
             getItemDetailsUseCase = get(),
             itemId = itemId,
+        )
+    }
+    factory { (slug: String) ->
+        MonumentDetailsViewModel(
+            getMonumentDetailsUseCase = get(),
+            slug = slug,
         )
     }
     factory {
@@ -181,6 +201,8 @@ actual fun platformModule(passphrase: String): Module = module {
             systemDarkThemeObserver = get(),
             itemsScheduler = get(),
             itemSyncDataSource = get(),
+            monumentsScheduler = get(),
+            monumentSyncDataSource = get(),
             userEventController = get(),
             setSubscribedUseCase = get(),
             remoteConfig = get(),


### PR DESCRIPTION
## Summary
- add Gradle config and bottom navigation entry for Monuments
- implement Monuments list with search, filters, ads and details placeholders
- schedule monument sync alongside items and handle language changes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6893753ea3948321bf759265d401d74a