### PR TITLE
Refactor: align MonumentScreen with ItemScreen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItemShimmer.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItemShimmer.kt
@@ -1,0 +1,43 @@
+package pl.cuyer.rusthub.android.designsystem
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import pl.cuyer.rusthub.android.theme.RustHubTheme
+import pl.cuyer.rusthub.android.theme.spacing
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun MonumentListItemShimmer(modifier: Modifier = Modifier) {
+    ElevatedCard(
+        shape = MaterialTheme.shapes.extraSmall,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Box(
+            modifier = Modifier
+                .padding(spacing.xmedium)
+                .fillMaxWidth()
+                .height(20.dp)
+                .clip(MaterialTheme.shapes.extraSmall)
+                .shimmer()
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MonumentListItemShimmerPreview() {
+    RustHubTheme {
+        MonumentListItemShimmer()
+    }
+}
+

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
@@ -1,37 +1,91 @@
 package pl.cuyer.rusthub.android.feature.monument
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.material3.rememberSearchBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation3.runtime.NavKey
 import androidx.paging.compose.LazyPagingItems
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.android.BuildConfig
 import pl.cuyer.rusthub.android.ads.NativeAdListItem
 import pl.cuyer.rusthub.android.designsystem.MonumentListItem
+import pl.cuyer.rusthub.android.designsystem.MonumentListItemShimmer
 import pl.cuyer.rusthub.android.designsystem.RustSearchBarTopAppBar
 import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.util.HandlePagingItems
 import pl.cuyer.rusthub.android.util.composeUtil.stringResource
+import pl.cuyer.rusthub.domain.model.Monument
+import pl.cuyer.rusthub.domain.model.MonumentSyncState
+import pl.cuyer.rusthub.domain.model.MonumentType
+import pl.cuyer.rusthub.domain.model.displayName
 import pl.cuyer.rusthub.presentation.features.ads.AdAction
 import pl.cuyer.rusthub.presentation.features.ads.NativeAdState
 import pl.cuyer.rusthub.presentation.features.monument.MonumentAction
 import pl.cuyer.rusthub.presentation.features.monument.MonumentState
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
-import pl.cuyer.rusthub.domain.model.Monument
-import pl.cuyer.rusthub.domain.model.MonumentType
-import pl.cuyer.rusthub.domain.model.displayName
-import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.util.StringProvider
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(
+    ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class
+)
 @Composable
 fun MonumentScreen(
     state: State<MonumentState>,
@@ -45,7 +99,16 @@ fun MonumentScreen(
 ) {
     val searchBarState = rememberSearchBarState()
     val textFieldState = rememberTextFieldState(state.value.searchText)
+    val scrollBehavior = SearchBarDefaults.enterAlwaysSearchBarScrollBehavior()
     val lazyListState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    val pullToRefreshState = rememberPullToRefreshState()
+    val isAtTop by remember {
+        derivedStateOf {
+            lazyListState.firstVisibleItemIndex == 0 &&
+                    lazyListState.firstVisibleItemScrollOffset == 0
+        }
+    }
     val ads = adState
 
     ObserveAsEvents(uiEvent) { event ->
@@ -59,71 +122,216 @@ fun MonumentScreen(
     }
 
     Scaffold(
+        containerColor = Color.Transparent,
+        contentColor = MaterialTheme.colorScheme.onBackground,
         topBar = {
-            RustSearchBarTopAppBar(
-                searchBarState = searchBarState,
-                textFieldState = textFieldState,
-                onSearchTriggered = {
-                    onAction(MonumentAction.OnSearch(textFieldState.text.toString()))
-                },
-                onOpenFilters = {},
-                searchQueryUi = { emptyList() },
-                onDelete = {},
-                onClearSearchQuery = {},
-                isLoadingSearchHistory = { false },
-                placeholderRes = SharedRes.strings.search_monuments,
-                showFiltersIcon = false,
-            )
-        }
-    ) { inner ->
-        Column(
+            LookaheadScope {
+                Column(
+                    modifier = with(scrollBehavior) { Modifier.searchBarScrollBehavior() }
+                        .animateBounds(this)
+                ) {
+                    RustSearchBarTopAppBar(
+                        searchBarState = searchBarState,
+                        textFieldState = textFieldState,
+                        onSearchTriggered = {
+                            onAction(MonumentAction.OnSearch(textFieldState.text.toString()))
+                        },
+                        onOpenFilters = {},
+                        searchQueryUi = { emptyList() },
+                        onDelete = {},
+                        onClearSearchQuery = {},
+                        isLoadingSearchHistory = { false },
+                        placeholderRes = SharedRes.strings.search_monuments,
+                        showFiltersIcon = false,
+                    )
+                    MonumentTypeChips(
+                        selected = state.value.selectedType,
+                        onSelectedChange = { onAction(MonumentAction.OnTypeChange(it)) },
+                        modifier = Modifier
+                            .padding(horizontal = spacing.xmedium)
+                    )
+                }
+            }
+        },
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
+    ) { innerPadding ->
+        PullToRefreshBox(
+            isRefreshing = false,
+            onRefresh = {
+                onAction(MonumentAction.OnRefresh)
+                pagedList.refresh()
+            },
+            state = pullToRefreshState,
             modifier = Modifier
-                .padding(inner)
-                .consumeWindowInsets(inner)
+                .padding(innerPadding)
+                .consumeWindowInsets(innerPadding)
                 .fillMaxSize()
         ) {
-            MonumentTypeChips(
-                selected = state.value.selectedType,
-                onSelectedChange = { onAction(MonumentAction.OnTypeChange(it)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(spacing.medium)
-            )
-            val adIndex = remember(pagedList.itemCount) {
-                if (pagedList.itemCount > 0) {
-                    if (pagedList.itemCount >= 5) 4 else pagedList.itemCount - 1
-                } else -1
-            }
-            LazyColumn(
-                contentPadding = PaddingValues(
-                    bottom = WindowInsets.safeDrawing
-                        .asPaddingValues().calculateBottomPadding()
-                ),
-                state = lazyListState,
-                verticalArrangement = Arrangement.spacedBy(spacing.medium),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                itemsIndexed(pagedList.itemSnapshotList.items) { index, monument ->
-                    if (showAds && index == adIndex) {
-                        Column(
+            if (state.value.syncState == MonumentSyncState.PENDING) {
+                LazyColumn(
+                    contentPadding = PaddingValues(
+                        top = 0.dp,
+                        bottom = WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding(),
+                        start = 0.dp,
+                        end = 0.dp
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(spacing.medium),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    items(
+                        count = 8,
+                        key = { it },
+                        contentType = { "shimmer" }
+                    ) {
+                        MonumentListItemShimmer(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .animateItem()
+                                .padding(horizontal = spacing.xmedium)
+                        )
+                    }
+                }
+            } else {
+                HandlePagingItems(
+                    items = { pagedList },
+                    onError = {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
                         ) {
-                            NativeAdListItem(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = spacing.xmedium),
-                                ad = ads.value.ads[BuildConfig.MONUMENTS_ADMOB_NATIVE_AD_ID]
-                            )
-                            Spacer(modifier = Modifier.height(spacing.medium))
+                            item(key = "error", contentType = "error") {
+                                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center
+                                    ) {
+                                        Text(
+                                            text = "(×_×)",
+                                            style = MaterialTheme.typography.headlineLarge,
+                                            fontSize = 96.sp,
+                                        )
+                                        Text(
+                                            text = stringResource(SharedRes.strings.error_oops),
+                                            style = MaterialTheme.typography.bodyLarge
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    onEmpty = {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            item(key = "empty", contentType = "empty") {
+                                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center
+                                    ) {
+                                        Text(
+                                            text = "( •_•)?",
+                                            style = MaterialTheme.typography.headlineLarge,
+                                            fontSize = 96.sp,
+                                        )
+                                        Text(
+                                            text = stringResource(SharedRes.strings.no_monuments_available),
+                                            style = MaterialTheme.typography.bodyLarge
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
-                    MonumentListItem(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = spacing.xmedium),
-                        monument = monument,
-                        onClick = { slug -> onAction(MonumentAction.OnMonumentClick(slug)) }
+                ) {
+                    val adIndex = remember(pagedList.itemCount) {
+                        if (pagedList.itemCount > 0) {
+                            if (pagedList.itemCount >= 5) 4 else pagedList.itemCount - 1
+                        } else -1
+                    }
+                    LazyColumn(
+                        contentPadding = PaddingValues(
+                            top = 0.dp,
+                            bottom = WindowInsets.safeDrawing.asPaddingValues().calculateBottomPadding(),
+                            start = 0.dp,
+                            end = 0.dp
+                        ),
+                        state = lazyListState,
+                        verticalArrangement = Arrangement.spacedBy(spacing.medium),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        onPagingItemsIndexed(
+                            key = { index, item ->
+                                if (showAds && index == adIndex) "ad" else item.slug ?: index
+                            },
+                            contentType = { index, _ -> if (showAds && index == adIndex) "ad" else "monument" }
+                        ) { index, monument ->
+                            if (showAds && index == adIndex) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .animateItem()
+                                ) {
+                                    NativeAdListItem(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(horizontal = spacing.xmedium),
+                                        ad = ads.value.ads[BuildConfig.MONUMENTS_ADMOB_NATIVE_AD_ID]
+                                    )
+                                    Spacer(modifier = Modifier.height(spacing.medium))
+                                }
+                            }
+                            MonumentListItem(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .animateItem()
+                                    .padding(horizontal = spacing.xmedium),
+                                monument = monument,
+                                onClick = { slug -> onAction(MonumentAction.OnMonumentClick(slug)) }
+                            )
+                        }
+                    }
+                }
+            }
+            AnimatedVisibility(
+                visible = !isAtTop,
+                enter = slideInVertically(
+                    initialOffsetY = { it },
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessVeryLow
+                    )
+                ) + scaleIn(
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessLow
+                    )
+                ),
+                exit = slideOutVertically(
+                    targetOffsetY = { it },
+                    animationSpec = tween(durationMillis = 150)
+                ),
+                modifier = Modifier
+                    .padding(spacing.medium)
+                    .align(Alignment.BottomEnd)
+            ) {
+                FloatingActionButton(
+                    onClick = {
+                        coroutineScope.launch {
+                            lazyListState.animateScrollToItem(0)
+                            scrollBehavior.scrollOffset = 1f
+                        }
+                    }
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowUpward,
+                        contentDescription = stringResource(SharedRes.strings.scroll_to_top),
+                        tint = contentColorFor(FloatingActionButtonDefaults.containerColor)
                     )
                 }
             }
@@ -160,3 +368,4 @@ private fun MonumentTypeChips(
         }
     }
 }
+

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -385,6 +385,7 @@
     <string name="no_servers_available_offline">No servers available offline.</string>
     <string name="no_servers_available">No servers available.</string>
     <string name="no_items_available">No items available.</string>
+    <string name="no_monuments_available">No monuments available.</string>
     <string name="error_timeout">Request timed out. Please try again.</string>
     <string name="error_service_unavailable">Service temporarily unavailable. Try again later.</string>
     <string name="error_bad_request">Bad request.</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -383,6 +383,7 @@
     <string name="no_servers_available_offline">Offline sind keine Server verfügbar.</string>
     <string name="no_servers_available">Keine Server verfügbar.</string>
     <string name="no_items_available">Keine Gegenstände verfügbar.</string>
+    <string name="no_monuments_available">Keine Monumente verfügbar.</string>
     <string name="error_timeout">Zeitüberschreitung. Bitte versuche es erneut.</string>
     <string name="error_service_unavailable">Dienst vorübergehend nicht verfügbar. Bitte versuche es später erneut.</string>
     <string name="error_bad_request">Fehlerhafte Anfrage.</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -383,6 +383,7 @@
     <string name="no_servers_available_offline">Aucun serveur disponible hors ligne.</string>
     <string name="no_servers_available">Aucun serveur disponible.</string>
     <string name="no_items_available">Aucun objet disponible.</string>
+    <string name="no_monuments_available">Aucun monument disponible.</string>
     <string name="error_timeout">Temps d'attente écoulé. Veuillez réessayer.</string>
     <string name="error_service_unavailable">Service temporairement indisponible. Veuillez réessayer plus tard.</string>
     <string name="error_bad_request">Requête incorrecte.</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -383,6 +383,7 @@
     <string name="no_servers_available_offline">Brak dostępnych serwerów offline.</string>
     <string name="no_servers_available">Brak dostępnych serwerów.</string>
     <string name="no_items_available">Brak dostępnych przedmiotów.</string>
+    <string name="no_monuments_available">Brak dostępnych monumentów.</string>
     <string name="error_timeout">Przekroczono czas oczekiwania. Spróbuj ponownie.</string>
     <string name="error_service_unavailable">Serwis chwilowo niedostępny. Spróbuj później.</string>
     <string name="error_bad_request">Błędne żądanie.</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -383,6 +383,7 @@
     <string name="no_servers_available_offline">Нет серверов в автономном режиме.</string>
     <string name="no_servers_available">Нет доступных серверов.</string>
     <string name="no_items_available">Нет доступных предметов.</string>
+    <string name="no_monuments_available">Нет доступных монументов.</string>
     <string name="error_timeout">Превышено время ожидания. Попробуйте ещё раз.</string>
     <string name="error_service_unavailable">Сервис временно недоступен. Попробуйте позже.</string>
     <string name="error_bad_request">Неверный запрос.</string>


### PR DESCRIPTION
## Summary
- align MonumentScreen behaviour with ItemScreen: pull-to-refresh, unified paging, ads, and scroll-to-top
- add skeleton MonumentListItemShimmer for loading state
- add localized `no_monuments_available` string

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68937cf607348321b3029521a803661f