### PR TITLE
Refactor: align MonumentViewModel with ItemViewModel

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
@@ -98,7 +98,7 @@ fun MonumentScreen(
     onAdAction: (AdAction) -> Unit,
 ) {
     val searchBarState = rememberSearchBarState()
-    val textFieldState = rememberTextFieldState(state.value.searchText)
+    val textFieldState = rememberTextFieldState("")
     val scrollBehavior = SearchBarDefaults.enterAlwaysSearchBarScrollBehavior()
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
@@ -137,10 +137,13 @@ fun MonumentScreen(
                             onAction(MonumentAction.OnSearch(textFieldState.text.toString()))
                         },
                         onOpenFilters = {},
-                        searchQueryUi = { emptyList() },
-                        onDelete = {},
-                        onClearSearchQuery = {},
-                        isLoadingSearchHistory = { false },
+                        searchQueryUi = { state.value.searchQuery },
+                        onDelete = {
+                            if (it.isBlank()) onAction(MonumentAction.DeleteSearchQueries)
+                            else onAction(MonumentAction.DeleteSearchQueryByQuery(it))
+                        },
+                        onClearSearchQuery = { onAction(MonumentAction.OnClearSearchQuery) },
+                        isLoadingSearchHistory = { state.value.isLoadingSearchHistory },
                         placeholderRes = SharedRes.strings.search_monuments,
                         showFiltersIcon = false,
                     )
@@ -194,7 +197,7 @@ fun MonumentScreen(
             } else {
                 HandlePagingItems(
                     items = { pagedList },
-                    onError = {
+                    onError = { error ->
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),
                             horizontalAlignment = Alignment.CenterHorizontally,
@@ -220,6 +223,7 @@ fun MonumentScreen(
                                 }
                             }
                         }
+                        onAction(MonumentAction.OnError(error))
                     },
                     onEmpty = {
                         LazyColumn(

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -199,6 +199,9 @@ actual fun platformModule(passphrase: String): Module = module {
             monumentsScheduler = get(),
             snackbarController = get(),
             stringProvider = get(),
+            saveSearchQueryUseCase = get(),
+            getSearchQueriesUseCase = get(),
+            deleteSearchQueriesUseCase = get(),
             getUserUseCase = get(),
             adsConsentManager = get(),
         )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/auth/AuthDataSourceImpl.kt
@@ -21,6 +21,7 @@ import pl.cuyer.rusthub.domain.repository.filtersOptions.FiltersOptionsDataSourc
 import pl.cuyer.rusthub.domain.repository.item.local.ItemSyncDataSource
 import pl.cuyer.rusthub.domain.repository.search.ItemSearchQueryDataSource
 import pl.cuyer.rusthub.domain.repository.search.SearchQueryDataSource
+import pl.cuyer.rusthub.domain.repository.search.MonumentSearchQueryDataSource
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
 import pl.cuyer.rusthub.util.CrashReporter
@@ -34,6 +35,7 @@ class AuthDataSourceImpl(
     private val filtersOptionsDataSource: FiltersOptionsDataSource,
     private val searchQueryDataSource: SearchQueryDataSource,
     private val itemSearchQueryDataSource: ItemSearchQueryDataSource,
+    private val monumentSearchQueryDataSource: MonumentSearchQueryDataSource,
     private val favouriteSyncDataSource: FavouriteSyncDataSource,
     private val subscriptionSyncDataSource: SubscriptionSyncDataSource,
     private val itemSyncDataSource: ItemSyncDataSource,
@@ -75,6 +77,7 @@ class AuthDataSourceImpl(
             filtersOptionsDataSource.clearFiltersOptions()
             searchQueryDataSource.clearQueries()
             itemSearchQueryDataSource.clearQueries()
+            monumentSearchQueryDataSource.clearQueries()
             favouriteSyncDataSource.clearOperations()
             subscriptionSyncDataSource.clearOperations()
             itemSyncDataSource.clearState()

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -14,6 +14,7 @@ import database.ServerEntity
 import database.UserEntity
 import database.ItemEntity
 import database.ItemSearchQueryEntity
+import database.MonumentSearchQueryEntity
 import database.MonumentEntity
 import pl.cuyer.rusthub.data.local.model.DifficultyEntity
 import pl.cuyer.rusthub.data.local.model.FlagEntity
@@ -92,6 +93,14 @@ fun WipeTypeEntity?.toDomain(): WipeType? = this?.let { WipeType.valueOf(it.name
 fun WipeType?.toEntity(): WipeTypeEntity? = this?.let { WipeTypeEntity.valueOf(it.name) }
 
 fun ItemSearchQueryEntity.toDomain(): SearchQuery {
+    return SearchQuery(
+        id = id,
+        query = query,
+        timestamp = Instant.parse(timestamp)
+    )
+}
+
+fun MonumentSearchQueryEntity.toDomain(): SearchQuery {
     return SearchQuery(
         id = id,
         query = query,

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/search/MonumentSearchQueryDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/search/MonumentSearchQueryDataSourceImpl.kt
@@ -1,0 +1,54 @@
+package pl.cuyer.rusthub.data.local.search
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import pl.cuyer.rusthub.data.local.Queries
+import pl.cuyer.rusthub.data.local.mapper.toDomain
+import pl.cuyer.rusthub.database.RustHubDatabase
+import pl.cuyer.rusthub.domain.model.SearchQuery
+import pl.cuyer.rusthub.domain.repository.search.MonumentSearchQueryDataSource
+import pl.cuyer.rusthub.util.CrashReporter
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+class MonumentSearchQueryDataSourceImpl(
+    db: RustHubDatabase
+) : MonumentSearchQueryDataSource, Queries(db) {
+
+    override fun getQueries(): Flow<List<SearchQuery>> {
+        return queries.getMonumentSearchQueries()
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { list -> list.map { it.toDomain() } }
+            .catch { e ->
+                CrashReporter.recordException(e)
+                throw e
+            }
+    }
+
+    override suspend fun upsertQuery(query: SearchQuery) {
+        withContext(Dispatchers.IO) {
+            safeExecute {
+                queries.upsertMonumentSearchQuery(
+                    query = query.query,
+                    timestamp = query.timestamp.toString()
+                )
+            }
+        }
+    }
+
+    override suspend fun clearQueries() {
+        withContext(Dispatchers.IO) { safeExecute { queries.clearMonumentSearchQueries() } }
+    }
+
+    override suspend fun deleteByQuery(query: String) {
+        withContext(Dispatchers.IO) { safeExecute { queries.deleteMonumentSearchQueryByQuery(query) } }
+    }
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/search/MonumentSearchQueryDataSource.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/search/MonumentSearchQueryDataSource.kt
@@ -1,0 +1,12 @@
+package pl.cuyer.rusthub.domain.repository.search
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.domain.model.SearchQuery
+
+interface MonumentSearchQueryDataSource {
+    fun getQueries(): Flow<List<SearchQuery>>
+    suspend fun upsertQuery(query: SearchQuery)
+    suspend fun clearQueries()
+    suspend fun deleteByQuery(query: String)
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/DeleteMonumentSearchQueriesUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/DeleteMonumentSearchQueriesUseCase.kt
@@ -1,0 +1,16 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import pl.cuyer.rusthub.domain.repository.search.MonumentSearchQueryDataSource
+
+class DeleteMonumentSearchQueriesUseCase(
+    private val dataSource: MonumentSearchQueryDataSource
+) {
+    suspend operator fun invoke() {
+        dataSource.clearQueries()
+    }
+
+    suspend operator fun invoke(query: String) {
+        dataSource.deleteByQuery(query)
+    }
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetMonumentSearchQueriesUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetMonumentSearchQueriesUseCase.kt
@@ -1,0 +1,14 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import pl.cuyer.rusthub.domain.model.SearchQuery
+import pl.cuyer.rusthub.domain.repository.search.MonumentSearchQueryDataSource
+
+class GetMonumentSearchQueriesUseCase(
+    private val dataSource: MonumentSearchQueryDataSource
+) {
+    operator fun invoke(): Flow<List<SearchQuery>> {
+        return dataSource.getQueries()
+    }
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/SaveMonumentSearchQueryUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/SaveMonumentSearchQueryUseCase.kt
@@ -1,0 +1,13 @@
+package pl.cuyer.rusthub.domain.usecase
+
+import pl.cuyer.rusthub.domain.model.SearchQuery
+import pl.cuyer.rusthub.domain.repository.search.MonumentSearchQueryDataSource
+
+class SaveMonumentSearchQueryUseCase(
+    private val dataSource: MonumentSearchQueryDataSource
+) {
+    suspend operator fun invoke(query: SearchQuery) {
+        dataSource.upsertQuery(query)
+    }
+}
+

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.kt
@@ -16,6 +16,7 @@ import pl.cuyer.rusthub.data.local.filter.FiltersDataSourceImpl
 import pl.cuyer.rusthub.data.local.filtersOptions.FiltersOptionsDataSourceImpl
 import pl.cuyer.rusthub.data.local.search.SearchQueryDataSourceImpl
 import pl.cuyer.rusthub.data.local.search.ItemSearchQueryDataSourceImpl
+import pl.cuyer.rusthub.data.local.search.MonumentSearchQueryDataSourceImpl
 import pl.cuyer.rusthub.data.local.server.ServerDataSourceImpl
 import pl.cuyer.rusthub.data.local.item.ItemDataSourceImpl
 import pl.cuyer.rusthub.data.local.item.ItemSyncDataSourceImpl
@@ -49,6 +50,7 @@ import pl.cuyer.rusthub.domain.repository.monument.local.MonumentSyncDataSource
 import pl.cuyer.rusthub.domain.repository.notification.MessagingTokenRepository
 import pl.cuyer.rusthub.domain.repository.search.SearchQueryDataSource
 import pl.cuyer.rusthub.domain.repository.search.ItemSearchQueryDataSource
+import pl.cuyer.rusthub.domain.repository.search.MonumentSearchQueryDataSource
 import pl.cuyer.rusthub.domain.repository.server.ServerDataSource
 import pl.cuyer.rusthub.domain.repository.server.ServerRepository
 import pl.cuyer.rusthub.domain.repository.subscription.SubscriptionSyncDataSource
@@ -62,6 +64,7 @@ import pl.cuyer.rusthub.domain.usecase.ClearFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteAccountUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.DeleteItemSearchQueriesUseCase
+import pl.cuyer.rusthub.domain.usecase.DeleteMonumentSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetFiltersOptionsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.GetGoogleClientIdUseCase
@@ -70,6 +73,7 @@ import pl.cuyer.rusthub.domain.usecase.GetPagedItemsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetPagedMonumentsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetItemSearchQueriesUseCase
+import pl.cuyer.rusthub.domain.usecase.GetMonumentSearchQueriesUseCase
 import pl.cuyer.rusthub.domain.usecase.GetServerDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetItemDetailsUseCase
 import pl.cuyer.rusthub.domain.usecase.GetMonumentDetailsUseCase
@@ -86,6 +90,7 @@ import pl.cuyer.rusthub.domain.usecase.SetSubscribedUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveFiltersUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveSearchQueryUseCase
 import pl.cuyer.rusthub.domain.usecase.SaveItemSearchQueryUseCase
+import pl.cuyer.rusthub.domain.usecase.SaveMonumentSearchQueryUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleFavouriteUseCase
 import pl.cuyer.rusthub.domain.usecase.ToggleSubscriptionUseCase
 import pl.cuyer.rusthub.domain.usecase.ConfirmPurchaseUseCase
@@ -140,6 +145,7 @@ val appModule = module {
     singleOf(::FiltersDataSourceImpl) bind FiltersDataSource::class
     singleOf(::SearchQueryDataSourceImpl) bind SearchQueryDataSource::class
     singleOf(::ItemSearchQueryDataSourceImpl) bind ItemSearchQueryDataSource::class
+    singleOf(::MonumentSearchQueryDataSourceImpl) bind MonumentSearchQueryDataSource::class
     singleOf(::MessagingTokenClientImpl) bind MessagingTokenRepository::class
     single { MessagingTokenManager(get(), get()) }
     singleOf(::FiltersOptionsClientImpl) bind FiltersOptionsRepository::class
@@ -158,14 +164,17 @@ val appModule = module {
     single { SaveFiltersUseCase(get()) }
     single { SaveSearchQueryUseCase(get()) }
     single { SaveItemSearchQueryUseCase(get()) }
+    single { SaveMonumentSearchQueryUseCase(get()) }
     single { ClearFiltersUseCase(get()) }
     singleOf(::ServerCacheDataSourceImpl) bind ServerCacheDataSource::class
     single { ClearServerCacheUseCase(get()) }
     single { GetFiltersOptionsUseCase(get(), get()) }
     single { GetSearchQueriesUseCase(get()) }
     single { GetItemSearchQueriesUseCase(get()) }
+    single { GetMonumentSearchQueriesUseCase(get()) }
     single { DeleteSearchQueriesUseCase(get()) }
     single { DeleteItemSearchQueriesUseCase(get()) }
+    single { DeleteMonumentSearchQueriesUseCase(get()) }
     single { GetServerDetailsUseCase(get()) }
     single { GetItemDetailsUseCase(get()) }
     single { GetMonumentDetailsUseCase(get()) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentAction.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentAction.kt
@@ -7,4 +7,8 @@ sealed interface MonumentAction {
     data class OnSearch(val query: String) : MonumentAction
     data class OnTypeChange(val type: MonumentType?) : MonumentAction
     data object OnRefresh : MonumentAction
+    data class OnError(val exception: Throwable) : MonumentAction
+    data object OnClearSearchQuery : MonumentAction
+    data object DeleteSearchQueries : MonumentAction
+    data class DeleteSearchQueryByQuery(val query: String) : MonumentAction
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentState.kt
@@ -3,11 +3,13 @@ package pl.cuyer.rusthub.presentation.features.monument
 import androidx.compose.runtime.Immutable
 import pl.cuyer.rusthub.domain.model.MonumentType
 import pl.cuyer.rusthub.domain.model.MonumentSyncState
+import pl.cuyer.rusthub.presentation.model.SearchQueryUi
 
 @Immutable
 data class MonumentState(
     val isRefreshing: Boolean = true,
-    val searchText: String = "",
+    val searchQuery: List<SearchQueryUi> = emptyList(),
+    val isLoadingSearchHistory: Boolean = true,
     val selectedType: MonumentType? = null,
     val syncState: MonumentSyncState = MonumentSyncState.DONE,
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/monument/MonumentViewModel.kt
@@ -2,6 +2,7 @@ package pl.cuyer.rusthub.presentation.features.monument
 
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.flow.Flow
@@ -9,34 +10,55 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.common.BaseViewModel
 import pl.cuyer.rusthub.domain.model.Monument
 import pl.cuyer.rusthub.domain.model.MonumentSyncState
 import pl.cuyer.rusthub.domain.model.MonumentType
+import pl.cuyer.rusthub.domain.model.SearchQuery
 import pl.cuyer.rusthub.domain.usecase.GetPagedMonumentsUseCase
 import pl.cuyer.rusthub.domain.repository.monument.local.MonumentSyncDataSource
+import pl.cuyer.rusthub.domain.usecase.SaveMonumentSearchQueryUseCase
+import pl.cuyer.rusthub.domain.usecase.GetMonumentSearchQueriesUseCase
+import pl.cuyer.rusthub.domain.usecase.DeleteMonumentSearchQueriesUseCase
 import pl.cuyer.rusthub.presentation.navigation.MonumentDetails
 import pl.cuyer.rusthub.presentation.navigation.UiEvent
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarController
 import pl.cuyer.rusthub.presentation.snackbar.SnackbarEvent
+import pl.cuyer.rusthub.presentation.snackbar.SnackbarAction
+import pl.cuyer.rusthub.presentation.snackbar.Duration
 import pl.cuyer.rusthub.util.MonumentsScheduler
 import pl.cuyer.rusthub.util.StringProvider
 import pl.cuyer.rusthub.util.getCurrentAppLanguage
 import pl.cuyer.rusthub.util.toUserMessage
+import pl.cuyer.rusthub.util.catchAndLog
 import pl.cuyer.rusthub.domain.usecase.GetUserUseCase
 import pl.cuyer.rusthub.util.AdsConsentManager
+import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.presentation.model.SearchQueryUi
+import pl.cuyer.rusthub.presentation.model.toUi
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
+@OptIn(ExperimentalTime::class)
 class MonumentViewModel(
     private val getPagedMonumentsUseCase: GetPagedMonumentsUseCase,
     private val monumentSyncDataSource: MonumentSyncDataSource,
     private val monumentsScheduler: MonumentsScheduler,
     private val snackbarController: SnackbarController,
     private val stringProvider: StringProvider,
+    private val saveSearchQueryUseCase: SaveMonumentSearchQueryUseCase,
+    private val getSearchQueriesUseCase: GetMonumentSearchQueriesUseCase,
+    private val deleteSearchQueriesUseCase: DeleteMonumentSearchQueriesUseCase,
     private val getUserUseCase: GetUserUseCase,
     private val adsConsentManager: AdsConsentManager,
 ) : BaseViewModel() {
@@ -64,29 +86,102 @@ class MonumentViewModel(
 
     init {
         observeSyncState()
+        observeSearchQueries()
     }
 
-    @kotlinx.coroutines.ExperimentalCoroutinesApi
+    @OptIn(ExperimentalCoroutinesApi::class)
     val paging: Flow<PagingData<Monument>> =
         combine(queryFlow, typeFlow) { query, type ->
             Pair(query, type)
-        }.flatMapLatest { (query, type) ->
-            getPagedMonumentsUseCase(query, type, getCurrentAppLanguage())
-        }.cachedIn(coroutineScope)
+        }
+            .flatMapLatest { (query, type) ->
+                getPagedMonumentsUseCase(query, type, getCurrentAppLanguage())
+            }
+            .flowOn(Dispatchers.Default)
+            .cachedIn(coroutineScope)
+            .catchAndLog { }
 
     fun onAction(action: MonumentAction) {
         when (action) {
             is MonumentAction.OnMonumentClick -> navigateToMonument(action.slug)
-            is MonumentAction.OnSearch -> {
-                queryFlow.value = action.query
-                _state.update { it.copy(searchText = action.query) }
-            }
-            is MonumentAction.OnTypeChange -> {
-                typeFlow.value = action.type
-                _state.update { it.copy(selectedType = action.type) }
-            }
+            is MonumentAction.OnSearch -> handleSearch(action.query)
+            is MonumentAction.OnTypeChange -> changeType(action.type)
             MonumentAction.OnRefresh -> refreshMonuments()
+            MonumentAction.OnClearSearchQuery -> clearSearchQuery()
+            MonumentAction.DeleteSearchQueries -> deleteSearchQueries(null)
+            is MonumentAction.DeleteSearchQueryByQuery -> deleteSearchQueries(action.query)
+            is MonumentAction.OnError -> sendSnackbarEvent(
+                action.exception.toUserMessage(stringProvider)
+                    ?: stringProvider.get(SharedRes.strings.error_unknown)
+            )
         }
+    }
+
+    private fun handleSearch(query: String) {
+        if (query.isNotEmpty()) {
+            coroutineScope.launch {
+                runCatching {
+                    saveSearchQueryUseCase(
+                        SearchQuery(query = query, timestamp = Clock.System.now(), id = null)
+                    )
+                }.onFailure {
+                    sendSnackbarEvent(stringProvider.get(SharedRes.strings.error_saving_search))
+                }.onSuccess {
+                    queryFlow.update { query }
+                }
+            }
+        } else {
+            sendSnackbarEvent(stringProvider.get(SharedRes.strings.monument_query_cannot_be_empty))
+        }
+    }
+
+    private fun changeType(type: MonumentType?) {
+        typeFlow.update { type }
+        _state.update { it.copy(selectedType = type) }
+    }
+
+    private fun clearSearchQuery() {
+        queryFlow.update { "" }
+    }
+
+    private fun deleteSearchQueries(query: String?) {
+        coroutineScope.launch {
+            runCatching {
+                if (query != null) deleteSearchQueriesUseCase(query)
+                else deleteSearchQueriesUseCase()
+            }.onFailure {
+                val msg = if (query != null) {
+                    stringProvider.get(SharedRes.strings.error_deleting_query)
+                } else {
+                    stringProvider.get(SharedRes.strings.error_deleting_queries)
+                }
+                sendSnackbarEvent(msg)
+            }
+        }
+    }
+
+    private fun observeSearchQueries() {
+        getSearchQueriesUseCase()
+            .distinctUntilChanged()
+            .map { queries -> queries.map { it.toUi() } }
+            .flowOn(Dispatchers.Default)
+            .onEach { mapped ->
+                updateSearchQuery(mapped)
+                updateIsLoadingSearchHistory(false)
+            }
+            .onStart { updateIsLoadingSearchHistory(true) }
+            .catchAndLog {
+                sendSnackbarEvent(stringProvider.get(SharedRes.strings.error_fetching_search_history))
+            }
+            .launchIn(coroutineScope)
+    }
+
+    private fun updateSearchQuery(mapped: List<SearchQueryUi>) {
+        _state.update { it.copy(searchQuery = mapped) }
+    }
+
+    private fun updateIsLoadingSearchHistory(loading: Boolean) {
+        _state.update { it.copy(isLoadingSearchHistory = loading) }
     }
 
     private fun navigateToMonument(slug: String) {
@@ -110,6 +205,23 @@ class MonumentViewModel(
         coroutineScope.launch {
             monumentSyncDataSource.setState(MonumentSyncState.PENDING)
             monumentsScheduler.startNow()
+        }
+    }
+
+    private fun sendSnackbarEvent(
+        message: String,
+        actionText: String? = null,
+        action: () -> Unit = {},
+        duration: Duration? = null
+    ) {
+        coroutineScope.launch {
+            snackbarController.sendEvent(
+                event = SnackbarEvent(
+                    message = message,
+                    action = actionText?.let { SnackbarAction(name = it, action = action) },
+                    duration = duration ?: Duration.SHORT
+                )
+            )
         }
     }
 }

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -377,6 +377,7 @@
     <string name="error_fetching_server_data">An error occurred while fetching data about the server.</string>
     <string name="server_query_cannot_be_empty">Enter the server name.</string>
     <string name="item_query_cannot_be_empty">Enter the item name.</string>
+    <string name="monument_query_cannot_be_empty">Enter the monument name.</string>
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="offline_cached_servers_info">Network unavailable. Showing cached servers.</string>
     <string name="offline">No internet connection.</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -375,6 +375,7 @@
     <string name="error_fetching_server_data">Beim Laden der Serverdaten ist ein Fehler aufgetreten.</string>
     <string name="server_query_cannot_be_empty">Bitte gib einen Servernamen ein.</string>
     <string name="item_query_cannot_be_empty">Gib den Namen des Gegenstands ein.</string>
+    <string name="monument_query_cannot_be_empty">Gib den Namen des Monuments ein.</string>
     <string name="error_network">Netzwerkfehler. Bitte überprüfe deine Verbindung.</string>
     <string name="offline_cached_servers_info">Netzwerk nicht verfügbar. Zeige zwischengespeicherte Server.</string>
     <string name="offline">Keine Internetverbindung.</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -375,6 +375,7 @@
     <string name="error_fetching_server_data">Błąd pobierania danych o serwerze.</string>
     <string name="server_query_cannot_be_empty">Wpisz nazwę serwera.</string>
     <string name="item_query_cannot_be_empty">Wpisz nazwę przedmiotu.</string>
+    <string name="monument_query_cannot_be_empty">Wpisz nazwę monumentu.</string>
     <string name="error_network">Błąd sieci. Sprawdź swoje połączenie.</string>
     <string name="offline_cached_servers_info">Brak sieci. Wyświetlana jest zapisana lista serwerów.</string>
     <string name="offline">Brak połączenia z internetem.</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -375,6 +375,7 @@
     <string name="error_fetching_server_data">Ошибка при получении данных о сервере.</string>
     <string name="server_query_cannot_be_empty">Введите имя сервера.</string>
     <string name="item_query_cannot_be_empty">Введите название предмета.</string>
+    <string name="monument_query_cannot_be_empty">Введите название монумента.</string>
     <string name="error_network">Ошибка сети. Проверьте подключение.</string>
     <string name="offline_cached_servers_info">Нет сети. Отображаются кэшированные серверы.</string>
     <string name="offline">Нет подключения к интернету.</string>

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -520,6 +520,28 @@ DELETE FROM itemSearchQueryEntity;
 deleteItemSearchQueryByQuery:
 DELETE FROM itemSearchQueryEntity WHERE query = :query;
 
+CREATE TABLE monumentSearchQueryEntity (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL UNIQUE,
+    timestamp TEXT NOT NULL
+);
+
+upsertMonumentSearchQuery:
+INSERT INTO monumentSearchQueryEntity (query, timestamp)
+VALUES (:query, :timestamp)
+ON CONFLICT(query) DO UPDATE SET
+    timestamp = excluded.timestamp;
+
+getMonumentSearchQueries:
+SELECT * FROM monumentSearchQueryEntity
+ORDER BY timestamp DESC;
+
+clearMonumentSearchQueries:
+DELETE FROM monumentSearchQueryEntity;
+
+deleteMonumentSearchQueryByQuery:
+DELETE FROM monumentSearchQueryEntity WHERE query = :query;
+
 CREATE TABLE favouriteSyncEntity (
     server_id INTEGER NOT NULL PRIMARY KEY,
     action INTEGER NOT NULL,

--- a/shared/src/commonMain/sqldelight/database/migrations/5.sqm
+++ b/shared/src/commonMain/sqldelight/database/migrations/5.sqm
@@ -1,0 +1,5 @@
+CREATE TABLE monumentSearchQueryEntity (
+    id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    query TEXT NOT NULL UNIQUE,
+    timestamp TEXT NOT NULL
+);

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -119,6 +119,11 @@ actual fun platformModule(passphrase: String): Module = module {
             getPagedItemsUseCase = get(),
             itemSyncDataSource = get(),
             itemsScheduler = get(),
+            snackbarController = get(),
+            stringProvider = get(),
+            saveSearchQueryUseCase = get(),
+            getSearchQueriesUseCase = get(),
+            deleteSearchQueriesUseCase = get(),
             getUserUseCase = get(),
             adsConsentManager = get()
         )
@@ -128,6 +133,11 @@ actual fun platformModule(passphrase: String): Module = module {
             getPagedMonumentsUseCase = get(),
             monumentSyncDataSource = get(),
             monumentsScheduler = get(),
+            snackbarController = get(),
+            stringProvider = get(),
+            saveSearchQueryUseCase = get(),
+            getSearchQueriesUseCase = get(),
+            deleteSearchQueriesUseCase = get(),
             getUserUseCase = get(),
             adsConsentManager = get(),
         )


### PR DESCRIPTION
## Summary
- implement full MonumentAction set including search history management
- persist monument search queries with new data source, use cases, SQLDelight table, and migration
- observe search query history and wire MonumentScreen to display and delete suggestions

## Testing
- `./gradlew -v`


------
https://chatgpt.com/codex/tasks/task_e_689380afc13483218f273a7ebe5e715c