### PR TITLE
Feat: store languages as enums

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItem.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItem.kt
@@ -1,17 +1,29 @@
 package pl.cuyer.rusthub.android.designsystem
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.common.getImageByFileName
 import pl.cuyer.rusthub.domain.model.Monument
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -26,10 +38,37 @@ fun MonumentListItem(
         shape = MaterialTheme.shapes.extraSmall,
         modifier = modifier.fillMaxWidth(),
     ) {
-        Column(modifier = Modifier.padding(spacing.xmedium)) {
+        Row(
+            modifier = Modifier
+                .padding(horizontal = spacing.xmedium, vertical = spacing.xxmedium),
+            horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SubcomposeAsyncImage(
+                modifier = Modifier.size(48.dp),
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data("https://cdn.rustlabs.com/img/monuments/${monument.slug}.png")
+                    .crossfade(true)
+                    .build(),
+                contentDescription = monument.name,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .shimmer()
+                    )
+                },
+                error = {
+                    Image(
+                        painter = painterResource(getImageByFileName("ic_fallback").drawableResId),
+                        contentDescription = monument.name,
+                        modifier = Modifier.matchParentSize()
+                    )
+                }
+            )
             Text(
                 text = monument.name.orEmpty(),
-                style = MaterialTheme.typography.titleLargeEmphasized,
+                style = MaterialTheme.typography.titleLargeEmphasized
             )
         }
     }

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItemShimmer.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MonumentListItemShimmer.kt
@@ -2,7 +2,6 @@ package pl.cuyer.rusthub.android.designsystem
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -40,24 +39,14 @@ fun MonumentListItemShimmer(modifier: Modifier = Modifier) {
                     .shimmer()
                     .clearAndSetSemantics {}
             )
-            Column(verticalArrangement = Arrangement.spacedBy(spacing.xxsmall)) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(0.6f)
-                        .height(20.dp)
-                        .clip(MaterialTheme.shapes.extraSmall)
-                        .shimmer()
-                        .clearAndSetSemantics {}
-                )
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth(0.8f)
-                        .height(16.dp)
-                        .clip(MaterialTheme.shapes.extraSmall)
-                        .shimmer()
-                        .clearAndSetSemantics {}
-                )
-            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.6f)
+                    .height(20.dp)
+                    .clip(MaterialTheme.shapes.extraSmall)
+                    .shimmer()
+                    .clearAndSetSemantics {}
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/item/ItemDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/item/ItemDataSourceImpl.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import pl.cuyer.rusthub.data.local.Queries
+import pl.cuyer.rusthub.data.local.mapper.toEntity
 import pl.cuyer.rusthub.data.local.mapper.toRustItem
 import pl.cuyer.rusthub.database.RustHubDatabase
 import pl.cuyer.rusthub.domain.model.Crafting
@@ -27,6 +28,7 @@ import pl.cuyer.rusthub.domain.model.Recycling
 import pl.cuyer.rusthub.domain.model.RustItem
 import pl.cuyer.rusthub.domain.model.WhereToFind
 import pl.cuyer.rusthub.domain.model.ItemAttribute
+import pl.cuyer.rusthub.data.local.model.LanguageEntity
 import pl.cuyer.rusthub.domain.repository.item.local.ItemDataSource
 import pl.cuyer.rusthub.util.CrashReporter
 
@@ -56,7 +58,7 @@ class ItemDataSourceImpl(
                                 categories = item.categories?.joinToString(",") { it.name },
                                 shortName = item.shortName,
                                 iconUrl = item.iconUrl,
-                                language = item.language?.name ?: Language.ENGLISH.name,
+                                language = item.language?.toEntity() ?: LanguageEntity.ENGLISH,
                                 looting = item.looting?.let {
                                     json.encodeToString(ListSerializer(Looting.serializer()), it)
                                 },
@@ -99,7 +101,7 @@ class ItemDataSourceImpl(
                 } else {
                     language
                 }
-                queries.countItems(language = updatedLanguage.name).executeAsOne() == 0L
+                queries.countItems(language = updatedLanguage.toEntity()).executeAsOne() == 0L
             }
         }
     }
@@ -113,7 +115,7 @@ class ItemDataSourceImpl(
             countQuery = queries.countPagedItemsFiltered(
                 name = name ?: "",
                 category = category?.name,
-                language = language.name
+                language = language.toEntity()
             ),
             transacter = queries,
             context = Dispatchers.IO,
@@ -121,7 +123,7 @@ class ItemDataSourceImpl(
                 queries.findItemsPagedFiltered(
                     name = name ?: "",
                     category = category?.name,
-                    language = language.name,
+                    language = language.toEntity(),
                     limit = limit,
                     offset = offset
                 )
@@ -130,7 +132,7 @@ class ItemDataSourceImpl(
     }
 
     override fun getItemById(id: Long, language: Language): Flow<RustItem?> {
-        return queries.getItemById(id = id, language = language.name)
+        return queries.getItemById(id = id, language = language.toEntity())
             .asFlow()
             .mapToOneOrNull(Dispatchers.IO)
             .map { it?.toRustItem(json) }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/mapper/EntityMappers.kt
@@ -21,6 +21,7 @@ import pl.cuyer.rusthub.data.local.model.FlagEntity
 import pl.cuyer.rusthub.data.local.model.MapsEntity
 import pl.cuyer.rusthub.data.local.model.OrderEntity
 import pl.cuyer.rusthub.data.local.model.RegionEntity
+import pl.cuyer.rusthub.data.local.model.LanguageEntity
 import pl.cuyer.rusthub.data.local.model.ServerFilterEntity
 import pl.cuyer.rusthub.data.local.model.ServerStatusEntity
 import pl.cuyer.rusthub.data.local.model.WipeScheduleEntity
@@ -91,6 +92,9 @@ fun ServerFilter?.toEntity(): ServerFilterEntity? = this?.let { ServerFilterEnti
 
 fun WipeTypeEntity?.toDomain(): WipeType? = this?.let { WipeType.valueOf(it.name) }
 fun WipeType?.toEntity(): WipeTypeEntity? = this?.let { WipeTypeEntity.valueOf(it.name) }
+
+fun LanguageEntity?.toDomain(): Language? = this?.let { Language.valueOf(it.name) }
+fun Language?.toEntity(): LanguageEntity? = this?.let { LanguageEntity.valueOf(it.name) }
 
 fun ItemSearchQueryEntity.toDomain(): SearchQuery {
     return SearchQuery(
@@ -229,7 +233,7 @@ fun ItemEntity.toRustItem(json: Json): RustItem {
         },
         shortName = short_name,
         iconUrl = icon_url,
-        language = language?.let { Language.valueOf(it) },
+        language = language.toDomain(),
         looting = looting?.let {
             json.decodeFromString(ListSerializer(Looting.serializer()), it)
         },
@@ -262,7 +266,7 @@ fun MonumentEntity.toMonument(json: Json): Monument {
         puzzles = puzzles?.let {
             json.decodeFromString(ListSerializer(MonumentPuzzle.serializer()), it)
         },
-        language = language,
+        language = language.toDomain(),
     )
 }
 

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/model/LanguageEntity.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/model/LanguageEntity.kt
@@ -1,0 +1,3 @@
+package pl.cuyer.rusthub.data.local.model
+
+enum class LanguageEntity { ENGLISH, POLISH, GERMAN, FRENCH, RUSSIAN }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/monument/mapper/MonumentNetworkMapper.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/network/monument/mapper/MonumentNetworkMapper.kt
@@ -12,7 +12,7 @@ fun MonumentDto.toDomain(): Monument {
         usableEntities = usableEntities?.map { it.toDomain() },
         mining = mining?.toDomain(),
         puzzles = puzzles?.map { it.toDomain() },
-        language = language
+        language = language?.toLanguage() ?: Language.ENGLISH
     )
 }
 
@@ -95,4 +95,12 @@ fun MonumentPuzzleDto.toDomain(): MonumentPuzzle {
 
 fun PuzzleRequirementDto.toDomain(): PuzzleRequirement {
     return PuzzleRequirement(name = name, amount = amount, image = image)
+}
+
+private fun String.toLanguage(): Language = when (lowercase()) {
+    "pl" -> Language.POLISH
+    "de" -> Language.GERMAN
+    "fr" -> Language.FRENCH
+    "ru" -> Language.RUSSIAN
+    else -> Language.ENGLISH
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Monument.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/Monument.kt
@@ -14,7 +14,7 @@ data class Monument(
     @SerialName("usableEntities") val usableEntities: List<UsableEntity>? = null,
     val mining: Mining? = null,
     val puzzles: List<MonumentPuzzle>? = null,
-    val language: String? = null
+    val language: Language = Language.ENGLISH
 )
 
 @Serializable

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -7,6 +7,7 @@ import pl.cuyer.rusthub.data.local.model.ServerFilterEntity;
 import pl.cuyer.rusthub.data.local.model.ServerStatusEntity;
 import pl.cuyer.rusthub.data.local.model.WipeScheduleEntity;
 import pl.cuyer.rusthub.data.local.model.WipeTypeEntity;
+import pl.cuyer.rusthub.data.local.model.LanguageEntity;
 
 -- =============================================================================
 -- Table Definition
@@ -661,7 +662,7 @@ CREATE TABLE itemEntity (
     categories TEXT,
     short_name TEXT,
     icon_url TEXT,
-    language TEXT NOT NULL,
+    language TEXT NOT NULL AS LanguageEntity,
     looting TEXT,
     loot_contents TEXT,
     where_to_find TEXT,
@@ -790,7 +791,7 @@ CREATE TABLE monumentEntity (
     usable_entities TEXT,
     mining TEXT,
     puzzles TEXT,
-    language TEXT NOT NULL,
+    language TEXT NOT NULL AS LanguageEntity,
     PRIMARY KEY(slug, language)
 );
 


### PR DESCRIPTION
## Summary
- persist item and monument languages using `LanguageEntity`
- show monument entries with image-based list items

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689391743b308321be055595d204ee49