### PR TITLE
Add mining page to monument details

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentDetailsScreen.kt
@@ -114,7 +114,12 @@ fun MonumentDetailsScreen(
                             modifier = Modifier.fillMaxSize()
                         )
 
-                        else -> Box(
+                        is PageData.Mining -> MonumentMiningPage(
+                            mining = data.mining,
+                            modifier = Modifier.fillMaxSize()
+                        )
+
+                        is PageData.Puzzles -> Box(
                             modifier = Modifier.fillMaxSize(),
                             contentAlignment = Alignment.Center
                         ) {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentMiningPage.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentMiningPage.kt
@@ -1,0 +1,111 @@
+package pl.cuyer.rusthub.android.feature.monument
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.android.designsystem.ItemTooltipImage
+import pl.cuyer.rusthub.android.theme.spacing
+import pl.cuyer.rusthub.android.util.composeUtil.stringResource
+import pl.cuyer.rusthub.domain.model.Mining
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun MonumentMiningPage(
+    mining: Mining,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = WindowInsets.safeDrawing.asPaddingValues(),
+        verticalArrangement = Arrangement.spacedBy(spacing.medium)
+    ) {
+        item(key = "mining", contentType = "mining") {
+            ElevatedCard(
+                shape = MaterialTheme.shapes.extraSmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .animateItem()
+                    .padding(horizontal = spacing.xmedium)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = spacing.xmedium, vertical = spacing.medium),
+                    verticalArrangement = Arrangement.spacedBy(spacing.medium)
+                ) {
+                    mining.item?.let { item ->
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            ItemTooltipImage(
+                                imageUrl = item.image ?: "",
+                                text = item.amount?.let { amount ->
+                                    stringResource(SharedRes.strings.multiplier_format, amount)
+                                },
+                                tooltipText = item.name
+                            )
+                            Column(verticalArrangement = Arrangement.spacedBy(spacing.xxsmall)) {
+                                Text(
+                                    text = item.name.orEmpty(),
+                                    style = MaterialTheme.typography.titleLargeEmphasized
+                                )
+                                mining.timePerFuelSeconds?.let { secs ->
+                                    Text(
+                                        text = stringResource(
+                                            SharedRes.strings.time_per_fuel,
+                                            secs
+                                        ),
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    mining.productionItems?.takeIf { it.isNotEmpty() }?.let { outputs ->
+                        Text(
+                            text = stringResource(SharedRes.strings.output),
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+                            verticalArrangement = Arrangement.spacedBy(spacing.small),
+                            itemVerticalAlignment = Alignment.CenterVertically
+                        ) {
+                            outputs.forEach { output ->
+                                ItemTooltipImage(
+                                    imageUrl = output.image ?: "",
+                                    text = output.amount?.let { amount ->
+                                        stringResource(
+                                            SharedRes.strings.multiplier_format,
+                                            amount
+                                        )
+                                    },
+                                    tooltipText = output.name
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -449,6 +449,7 @@
     <string name="extra_chance_output">Extra Chance Output</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
+    <string name="time_per_fuel">Time per fuel: %1$d s</string>
     <string name="raw_material_cost">Raw Material Cost</string>
     <string name="using_mixing_table">Using mixing table x%1$d</string>
     <string name="time_to_raid">Time to Raid: %1$s</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -447,6 +447,7 @@
     <string name="extra_chance_output">Zusätzliche Chance Ausgabe</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
+    <string name="time_per_fuel">Time per fuel: %1$d s</string>
     <string name="raw_material_cost">Rohmaterialkosten</string>
     <string name="using_mixing_table">Mit Mischtisch x%1$d</string>
     <string name="time_to_raid">Raidzeit: %1$s</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -446,6 +446,7 @@
     <string name="extra_chance_output">Sortie avec chance supplémentaire</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
+    <string name="time_per_fuel">Time per fuel: %1$d s</string>
     <string name="raw_material_cost">Coût des matières premières</string>
     <string name="using_mixing_table">Utilisation du table de mixage x%1$d</string>
     <string name="time_to_raid">Temps de raid : %1$s</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -447,6 +447,7 @@
     <string name="extra_chance_output">Rezultat z dodatkową szansą</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
+    <string name="time_per_fuel">Time per fuel: %1$d s</string>
     <string name="raw_material_cost">Koszt surowców</string>
     <string name="using_mixing_table">Używając stołu mieszającego x%1$d</string>
     <string name="time_to_raid">Czas rajdu: %1$s</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -447,6 +447,7 @@
     <string name="extra_chance_output">Дополнительный шанс на результат</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
+    <string name="time_per_fuel">Time per fuel: %1$d s</string>
     <string name="raw_material_cost">Стоимость сырья</string>
     <string name="using_mixing_table">Используя смесительный стол x%1$d</string>
     <string name="time_to_raid">Время рейда: %1$s</string>


### PR DESCRIPTION
## Summary
- add composable mining page showing fuel input, time per fuel and outputs
- wire mining page into monument details screen
- add string resource for time per fuel

## Testing
- No tests run due to repo instructions

------
https://chatgpt.com/codex/tasks/task_e_6893bc0d9fd083219901978641e71c2e