### PR TITLE
Fix: localize time per fuel string

### DIFF
--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -450,7 +450,7 @@
     <string name="extra_chance_output">Zusätzliche Chance Ausgabe</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
-    <string name="time_per_fuel">Time per fuel: %1$d s</string>
+    <string name="time_per_fuel">Zeit pro Brennstoffeinheit: %1$d s</string>
     <string name="raw_material_cost">Rohmaterialkosten</string>
     <string name="using_mixing_table">Mit Mischtisch x%1$d</string>
     <string name="time_to_raid">Raidzeit: %1$s</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -449,7 +449,7 @@
     <string name="extra_chance_output">Sortie avec chance supplémentaire</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
-    <string name="time_per_fuel">Time per fuel: %1$d s</string>
+    <string name="time_per_fuel">Temps par carburant : %1$d s</string>
     <string name="raw_material_cost">Coût des matières premières</string>
     <string name="using_mixing_table">Utilisation du table de mixage x%1$d</string>
     <string name="time_to_raid">Temps de raid : %1$s</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -450,7 +450,7 @@
     <string name="extra_chance_output">Rezultat z dodatkową szansą</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
-    <string name="time_per_fuel">Time per fuel: %1$d s</string>
+    <string name="time_per_fuel">Czas na jednostkę paliwa: %1$d s</string>
     <string name="raw_material_cost">Koszt surowców</string>
     <string name="using_mixing_table">Używając stołu mieszającego x%1$d</string>
     <string name="time_to_raid">Czas rajdu: %1$s</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -450,7 +450,7 @@
     <string name="extra_chance_output">Дополнительный шанс на результат</string>
     <string name="multiplier_format">x%1$d</string>
     <string name="percentage_format">%1$d%%</string>
-    <string name="time_per_fuel">Time per fuel: %1$d s</string>
+    <string name="time_per_fuel">Время на единицу топлива: %1$d с</string>
     <string name="raw_material_cost">Стоимость сырья</string>
     <string name="using_mixing_table">Используя смесительный стол x%1$d</string>
     <string name="time_to_raid">Время рейда: %1$s</string>


### PR DESCRIPTION
## Summary
- localize "time per fuel" string in French, Russian, German and Polish resource files

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_6893da3690d8832189dd03dcc72b2a04