### PR TITLE
Fix duplicate iconUrl migration for monuments

### DIFF
--- a/shared/src/commonMain/sqldelight/database/migrations/6.sqm
+++ b/shared/src/commonMain/sqldelight/database/migrations/6.sqm
@@ -1,1 +1,2 @@
-ALTER TABLE monumentEntity ADD COLUMN iconUrl TEXT;
+-- Migration 6 removed: iconUrl column already present.
+-- This migration is intentionally left blank to avoid duplicate column errors.


### PR DESCRIPTION
## Summary
- remove redundant monument iconUrl migration to prevent duplicate column errors

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689464e1508c8321b357c5cb6f24173c