### PR TITLE
feat: add localized min core temperature attribute

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ItemAttribute.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ItemAttribute.kt
@@ -21,6 +21,7 @@ enum class ItemAttributeType(val key: String) {
     DURATION("duration"),
     HARVESTING_YIELD("harvestingYield"),
     TEMPERATURE("temperature"),
+    MIN_CORE_TEMPERATURE("minCoreTemperature"),
     MAX_CORE_TEMPERATURE("maxCoreTemperature"),
     CALORIES("calories"),
     HEALTH("health"),
@@ -50,6 +51,7 @@ fun ItemAttributeType.toNameRes(stringProvider: StringProvider): String {
         ItemAttributeType.DURATION -> stringProvider.get(SharedRes.strings.duration)
         ItemAttributeType.HARVESTING_YIELD -> stringProvider.get(SharedRes.strings.harvesting_yield)
         ItemAttributeType.TEMPERATURE -> stringProvider.get(SharedRes.strings.temperature)
+        ItemAttributeType.MIN_CORE_TEMPERATURE -> stringProvider.get(SharedRes.strings.min_core_temperature)
         ItemAttributeType.MAX_CORE_TEMPERATURE -> stringProvider.get(SharedRes.strings.max_core_temperature)
         ItemAttributeType.CALORIES -> stringProvider.get(SharedRes.strings.calories)
         ItemAttributeType.HEALTH -> stringProvider.get(SharedRes.strings.health)

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -473,7 +473,8 @@
     <string name="duration">Duration</string>
     <string name="harvesting_yield">Harvesting Yield</string>
     <string name="temperature">Temperature</string>
-    <string name="max_core_temperature">Max. Core Temperature</string>
+    <string name="min_core_temperature">Min. Body Temperature</string>
+    <string name="max_core_temperature">Max. Body Temperature</string>
     <string name="calories">Calories</string>
     <string name="health">Health</string>
     <string name="hunter_vision">Hunter Vision</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -471,7 +471,8 @@
     <string name="duration">Dauer</string>
     <string name="harvesting_yield">Ernteertrag</string>
     <string name="temperature">Temperatur</string>
-    <string name="max_core_temperature">Max. Kerntemperatur</string>
+    <string name="min_core_temperature">Min. Körpertemperatur</string>
+    <string name="max_core_temperature">Max. Körpertemperatur</string>
     <string name="calories">Kalorien</string>
     <string name="health">Gesundheit</string>
     <string name="hunter_vision">Jägersicht</string>

--- a/shared/src/commonMain/moko-resources/es/strings.xml
+++ b/shared/src/commonMain/moko-resources/es/strings.xml
@@ -472,7 +472,8 @@
     <string name="duration">Duración</string>
     <string name="harvesting_yield">Cosecha de rendimiento</string>
     <string name="temperature">Temperatura</string>
-    <string name="max_core_temperature">Max. Temperatura central</string>
+    <string name="min_core_temperature">Min. temperatura corporal</string>
+    <string name="max_core_temperature">Max. temperatura corporal</string>
     <string name="calories">Calorías</string>
     <string name="health">Salud</string>
     <string name="hunter_vision">Visión de cazador</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -470,7 +470,8 @@
     <string name="duration">Durée</string>
     <string name="harvesting_yield">Rendement de récolte</string>
     <string name="temperature">Température</string>
-    <string name="max_core_temperature">Température centrale max.</string>
+    <string name="min_core_temperature">Température corporelle min.</string>
+    <string name="max_core_temperature">Température corporelle max.</string>
     <string name="calories">Calories</string>
     <string name="health">Santé</string>
     <string name="hunter_vision">Vision de chasseur</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -471,7 +471,8 @@
     <string name="duration">Czas trwania</string>
     <string name="harvesting_yield">Wydajność zbiorów</string>
     <string name="temperature">Temperatura</string>
-    <string name="max_core_temperature">Maks. temperatura rdzenia</string>
+    <string name="min_core_temperature">Min. temperatura ciała</string>
+    <string name="max_core_temperature">Maks. temperatura ciała</string>
     <string name="calories">Kalorie</string>
     <string name="health">Zdrowie</string>
     <string name="hunter_vision">Wzrok łowcy</string>

--- a/shared/src/commonMain/moko-resources/pt/strings.xml
+++ b/shared/src/commonMain/moko-resources/pt/strings.xml
@@ -471,7 +471,8 @@
     <string name="duration">Duração</string>
     <string name="harvesting_yield">Colheita de rendimento</string>
     <string name="temperature">Temperatura</string>
-    <string name="max_core_temperature">Máx. Temperatura central</string>
+    <string name="min_core_temperature">Mín. temperatura corporal</string>
+    <string name="max_core_temperature">Máx. temperatura corporal</string>
     <string name="calories">Calorias</string>
     <string name="health">Saúde</string>
     <string name="hunter_vision">Visão de Hunter</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -471,7 +471,8 @@
     <string name="duration">Длительность</string>
     <string name="harvesting_yield">Урожайность</string>
     <string name="temperature">Температура</string>
-    <string name="max_core_temperature">Макс. температура ядра</string>
+    <string name="min_core_temperature">Мин. температура тела</string>
+    <string name="max_core_temperature">Макс. температура тела</string>
     <string name="calories">Калории</string>
     <string name="health">Здоровье</string>
     <string name="hunter_vision">Зрение охотника</string>

--- a/shared/src/commonMain/moko-resources/uk/strings.xml
+++ b/shared/src/commonMain/moko-resources/uk/strings.xml
@@ -472,7 +472,8 @@
     <string name="duration">Тривалість</string>
     <string name="harvesting_yield">Врожайність урожаю</string>
     <string name="temperature">Температура</string>
-    <string name="max_core_temperature">Макс. Температура ядра</string>
+    <string name="min_core_temperature">Мін. температура тіла</string>
+    <string name="max_core_temperature">Макс. температура тіла</string>
     <string name="calories">Калорій</string>
     <string name="health">Здоров'я</string>
     <string name="hunter_vision">Мисливець</string>


### PR DESCRIPTION
## Summary
- add min core temperature item attribute
- localize min core temperature string in resources
- fix min and max body temperature translations across locales

## Testing
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_6895c271137c83219a05a9ddaf10ac45