### PR TITLE
Add localized healthOverTime item attribute

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ItemAttribute.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/model/ItemAttribute.kt
@@ -25,6 +25,7 @@ enum class ItemAttributeType(val key: String) {
     MAX_CORE_TEMPERATURE("maxCoreTemperature"),
     CALORIES("calories"),
     HEALTH("health"),
+    HEALTH_OVER_TIME("healthOverTime"),
     HUNTER_VISION("hunterVision"),
     VISION_CARE("visionCare"),
     MAX_HP("maxHp"),
@@ -55,6 +56,7 @@ fun ItemAttributeType.toNameRes(stringProvider: StringProvider): String {
         ItemAttributeType.MAX_CORE_TEMPERATURE -> stringProvider.get(SharedRes.strings.max_core_temperature)
         ItemAttributeType.CALORIES -> stringProvider.get(SharedRes.strings.calories)
         ItemAttributeType.HEALTH -> stringProvider.get(SharedRes.strings.health)
+        ItemAttributeType.HEALTH_OVER_TIME -> stringProvider.get(SharedRes.strings.health_over_time)
         ItemAttributeType.HUNTER_VISION -> stringProvider.get(SharedRes.strings.hunter_vision)
         ItemAttributeType.VISION_CARE -> stringProvider.get(SharedRes.strings.vision_care)
         ItemAttributeType.MAX_HP -> stringProvider.get(SharedRes.strings.max_hp)

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -477,6 +477,7 @@
     <string name="max_core_temperature">Max. Body Temperature</string>
     <string name="calories">Calories</string>
     <string name="health">Health</string>
+    <string name="health_over_time">Health Over Time</string>
     <string name="hunter_vision">Hunter Vision</string>
     <string name="vision_care">Vision Care</string>
     <string name="max_hp">Max HP</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -475,6 +475,7 @@
     <string name="max_core_temperature">Max. Körpertemperatur</string>
     <string name="calories">Kalorien</string>
     <string name="health">Gesundheit</string>
+    <string name="health_over_time">Gesundheit über Zeit</string>
     <string name="hunter_vision">Jägersicht</string>
     <string name="vision_care">Augenpflege</string>
     <string name="max_hp">Max. HP</string>

--- a/shared/src/commonMain/moko-resources/es/strings.xml
+++ b/shared/src/commonMain/moko-resources/es/strings.xml
@@ -476,6 +476,7 @@
     <string name="max_core_temperature">Max. temperatura corporal</string>
     <string name="calories">Calorías</string>
     <string name="health">Salud</string>
+    <string name="health_over_time">Salud con el tiempo</string>
     <string name="hunter_vision">Visión de cazador</string>
     <string name="vision_care">Cuidado de la visión</string>
     <string name="max_hp">Max HP</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -474,6 +474,7 @@
     <string name="max_core_temperature">Température corporelle max.</string>
     <string name="calories">Calories</string>
     <string name="health">Santé</string>
+    <string name="health_over_time">Santé au fil du temps</string>
     <string name="hunter_vision">Vision de chasseur</string>
     <string name="vision_care">Soin de la vision</string>
     <string name="max_hp">HP max</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -475,6 +475,7 @@
     <string name="max_core_temperature">Maks. temperatura ciała</string>
     <string name="calories">Kalorie</string>
     <string name="health">Zdrowie</string>
+    <string name="health_over_time">Zdrowie w czasie</string>
     <string name="hunter_vision">Wzrok łowcy</string>
     <string name="vision_care">Ochrona wzroku</string>
     <string name="max_hp">Maks. HP</string>

--- a/shared/src/commonMain/moko-resources/pt/strings.xml
+++ b/shared/src/commonMain/moko-resources/pt/strings.xml
@@ -475,6 +475,7 @@
     <string name="max_core_temperature">Máx. temperatura corporal</string>
     <string name="calories">Calorias</string>
     <string name="health">Saúde</string>
+    <string name="health_over_time">Saúde ao longo do tempo</string>
     <string name="hunter_vision">Visão de Hunter</string>
     <string name="vision_care">Cuidado com visão</string>
     <string name="max_hp">Max HP</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -475,6 +475,7 @@
     <string name="max_core_temperature">Макс. температура тела</string>
     <string name="calories">Калории</string>
     <string name="health">Здоровье</string>
+    <string name="health_over_time">Здоровье со временем</string>
     <string name="hunter_vision">Зрение охотника</string>
     <string name="vision_care">Забота о зрении</string>
     <string name="max_hp">Макс. HP</string>

--- a/shared/src/commonMain/moko-resources/uk/strings.xml
+++ b/shared/src/commonMain/moko-resources/uk/strings.xml
@@ -476,6 +476,7 @@
     <string name="max_core_temperature">Макс. температура тіла</string>
     <string name="calories">Калорій</string>
     <string name="health">Здоров'я</string>
+    <string name="health_over_time">Здоров'я з часом</string>
     <string name="hunter_vision">Мисливець</string>
     <string name="vision_care">Догляд за зором</string>
     <string name="max_hp">Макс HP</string>


### PR DESCRIPTION
## Summary
- add `HEALTH_OVER_TIME` to `ItemAttributeType`
- localize `health_over_time` string in all languages

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6895ca52ba608321a6038bec0eab5e10