### PR TITLE
Fix filter dropdown menus hiding last item

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppExposedDropdownMenu.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppExposedDropdownMenu.kt
@@ -92,12 +92,18 @@ fun AppExposedDropdownMenu(
             modifier = Modifier
                 .width(with(LocalResources.current.displayMetrics) { textFieldWidth / density }.dp)
         ) {
-            val visibleItems = options.size.coerceAtMost(maxVisibleItems)
+            val totalItems = options.size + if (allowEmptySelection) 1 else 0
+            val visibleItems = totalItems.coerceAtMost(maxVisibleItems)
             val dropdownHeight = visibleItems * 48.dp
-            LazyColumn(
-                modifier = Modifier
+            val listModifier = if (totalItems > maxVisibleItems) {
+                Modifier
                     .width(with(LocalResources.current.displayMetrics) { textFieldWidth / density }.dp)
                     .height(dropdownHeight)
+            } else {
+                Modifier.width(with(LocalResources.current.displayMetrics) { textFieldWidth / density }.dp)
+            }
+            LazyColumn(
+                modifier = listModifier
             ) {
                 if (allowEmptySelection) {
                     item(key = "empty") {


### PR DESCRIPTION
## Summary
- ensure dropdown menus account for optional empty item when sizing
- avoid unnecessary height restriction so last option is visible

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6895dbaeecb88321a5dad748999db1e2