### PR TITLE
Refactor: parallelize item fetching

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/ItemsWorker.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/work/ItemsWorker.kt
@@ -3,7 +3,6 @@ package pl.cuyer.rusthub.work
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import kotlinx.coroutines.flow.collectLatest
 import pl.cuyer.rusthub.domain.repository.item.ItemRepository
 import pl.cuyer.rusthub.domain.repository.item.local.ItemDataSource
 import pl.cuyer.rusthub.domain.repository.item.local.ItemSyncDataSource
@@ -19,24 +18,14 @@ class ItemsWorker(
 ) : CoroutineWorker(appContext, params) {
 
     override suspend fun doWork(): Result {
-        var hadError = false
-        repository.getItems().collect { result ->
-            when (result) {
-                is DomainResult.Success -> {
-                    dataSource.upsertItems(result.data)
-                    syncDataSource.setState(ItemSyncState.PENDING)
-                }
-                is DomainResult.Error -> {
-                    hadError = true
-                }
+        syncDataSource.setState(ItemSyncState.PENDING)
+        return when (val result = repository.getItems()) {
+            is DomainResult.Success -> {
+                dataSource.upsertItems(result.data)
+                syncDataSource.setState(ItemSyncState.DONE)
+                Result.success()
             }
-        }
-
-        return if (!hadError) {
-            syncDataSource.setState(ItemSyncState.DONE)
-            Result.success()
-        } else {
-            Result.retry()
+            is DomainResult.Error -> Result.retry()
         }
     }
 }

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/item/ItemRepository.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/repository/item/ItemRepository.kt
@@ -1,9 +1,8 @@
 package pl.cuyer.rusthub.domain.repository.item
 
-import kotlinx.coroutines.flow.Flow
 import pl.cuyer.rusthub.common.Result
 import pl.cuyer.rusthub.domain.model.RustItem
 
 interface ItemRepository {
-    fun getItems(): Flow<Result<List<RustItem>>>
+    suspend fun getItems(): Result<List<RustItem>>
 }


### PR DESCRIPTION
## Summary
- fetch item pages concurrently once total page count is known
- fetch and store all items in one go
- remove unnecessary coroutine scope around async page requests

## Testing
- `./gradlew -q help`


------
https://chatgpt.com/codex/tasks/task_e_6896f834c000832199fe3cab1d01cb0a