### PR TITLE
Add connectivity observer to item list

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -173,6 +174,32 @@ fun ItemScreen(
                         modifier = Modifier
                             .padding(horizontal = spacing.xmedium)
                     )
+                    AnimatedVisibility(
+                        visible = !state.value.isConnected,
+                        enter = slideInVertically(
+                            animationSpec = spring(
+                                stiffness = Spring.StiffnessLow,
+                                dampingRatio = Spring.DampingRatioLowBouncy
+                            )
+                        ),
+                        exit = slideOutVertically(
+                            animationSpec = spring(
+                                stiffness = Spring.StiffnessLow,
+                                dampingRatio = Spring.DampingRatioLowBouncy
+                            )
+                        )
+                    ) {
+                        Text(
+                            textAlign = TextAlign.Center,
+                            text = stringResource(SharedRes.strings.offline_cached_items_info),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSecondary,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = spacing.xsmall)
+                                .background(MaterialTheme.colorScheme.secondary)
+                        )
+                    }
                 }
             }
         },
@@ -264,8 +291,13 @@ fun ItemScreen(
                                         textAlign = TextAlign.Center,
                                         fontSize = 96.sp
                                     )
+                                    val message = if (!state.value.isConnected) {
+                                        stringResource(SharedRes.strings.no_items_available_offline)
+                                    } else {
+                                        stringResource(SharedRes.strings.no_items_available)
+                                    }
                                     Text(
-                                        text = stringResource(SharedRes.strings.no_items_available),
+                                        text = message,
                                         style = MaterialTheme.typography.bodyLarge,
                                         textAlign = TextAlign.Center
                                     )

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -180,6 +180,7 @@ actual fun platformModule(passphrase: String): Module = module {
             deleteSearchQueriesUseCase = get(),
             getUserUseCase = get(),
             adsConsentManager = get(),
+            connectivityObserver = get(),
         )
     }
     viewModel {

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/item/ItemState.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/item/ItemState.kt
@@ -9,4 +9,5 @@ data class ItemState(
     val searchQuery: List<SearchQueryUi> = emptyList(),
     val isLoadingSearchHistory: Boolean = true,
     val selectedCategory: ItemCategory? = null,
+    val isConnected: Boolean = true,
 )

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/item/ItemViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/item/ItemViewModel.kt
@@ -47,6 +47,7 @@ import pl.cuyer.rusthub.presentation.model.SearchQueryUi
 import pl.cuyer.rusthub.presentation.model.toUi
 import kotlin.time.Clock
 import pl.cuyer.rusthub.util.AdsConsentManager
+import pl.cuyer.rusthub.util.ConnectivityObserver
 import kotlin.time.ExperimentalTime
 
 @OptIn(ExperimentalTime::class)
@@ -59,6 +60,7 @@ class ItemViewModel(
     private val deleteSearchQueriesUseCase: DeleteItemSearchQueriesUseCase,
     private val getUserUseCase: GetUserUseCase,
     private val adsConsentManager: AdsConsentManager,
+    private val connectivityObserver: ConnectivityObserver,
 ) : BaseViewModel() {
 
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
@@ -85,6 +87,7 @@ class ItemViewModel(
 
     init {
         observeSearchQueries()
+        observeConnectivity()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -190,6 +193,14 @@ class ItemViewModel(
 
     private fun updateIsLoadingSearchHistory(loading: Boolean) {
         _state.update { it.copy(isLoadingSearchHistory = loading) }
+    }
+
+    private fun observeConnectivity() {
+        connectivityObserver.isConnected
+            .onEach { connected ->
+                _state.update { it.copy(isConnected = connected) }
+            }
+            .launchIn(coroutineScope)
     }
 
     private fun sendSnackbarEvent(

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -391,10 +391,12 @@
     <string name="error_network">Network error. Please check your connection.</string>
     <string name="offline_cached_servers_info">Network unavailable. Showing cached servers.</string>
     <string name="offline">No internet connection.</string>
+    <string name="offline_cached_items_info">Network unavailable. Showing cached items.</string>
     <string name="subscription_disabled">Subscriptions are currently disabled.</string>
     <string name="connect_manage_subscription">Connect to the internet to manage your subscription.</string>
     <string name="no_servers_available_offline">No servers available offline.</string>
     <string name="no_servers_available">No servers available.</string>
+    <string name="no_items_available_offline">No items available offline.</string>
     <string name="no_items_available">No items available.</string>
     <string name="no_monuments_available">No monuments available.</string>
     <string name="error_timeout">Request timed out. Please try again.</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -389,10 +389,12 @@
     <string name="error_network">Netzwerkfehler. Bitte überprüfe deine Verbindung.</string>
     <string name="offline_cached_servers_info">Netzwerk nicht verfügbar. Zeige zwischengespeicherte Server.</string>
     <string name="offline">Keine Internetverbindung.</string>
+    <string name="offline_cached_items_info">Netzwerk nicht verfügbar. Zeige zwischengespeicherte Gegenstände.</string>
     <string name="subscription_disabled">Abonnements sind derzeit deaktiviert.</string>
     <string name="connect_manage_subscription">Verbinde dich mit dem Internet, um das Abo zu verwalten.</string>
     <string name="no_servers_available_offline">Offline sind keine Server verfügbar.</string>
     <string name="no_servers_available">Keine Server verfügbar.</string>
+    <string name="no_items_available_offline">Offline sind keine Gegenstände verfügbar.</string>
     <string name="no_items_available">Keine Gegenstände verfügbar.</string>
     <string name="no_monuments_available">Keine Monumente verfügbar.</string>
     <string name="error_timeout">Zeitüberschreitung. Bitte versuche es erneut.</string>

--- a/shared/src/commonMain/moko-resources/es/strings.xml
+++ b/shared/src/commonMain/moko-resources/es/strings.xml
@@ -390,10 +390,12 @@
     <string name="error_network">Error de red. Verifique su conexión.</string>
     <string name="offline_cached_servers_info">Red no disponible. Mostrando servidores en caché.</string>
     <string name="offline">Sin conexión a Internet.</string>
+    <string name="offline_cached_items_info">Red no disponible. Mostrando artículos en caché.</string>
     <string name="subscription_disabled">Las suscripciones están actualmente deshabilitadas.</string>
     <string name="connect_manage_subscription">Conéctese a Internet para administrar su suscripción.</string>
     <string name="no_servers_available_offline">No hay servidores disponibles fuera de línea.</string>
     <string name="no_servers_available">No hay servidores disponibles.</string>
+    <string name="no_items_available_offline">No hay artículos disponibles fuera de línea.</string>
     <string name="no_items_available">No hay artículos disponibles.</string>
     <string name="no_monuments_available">No hay monumentos disponibles.</string>
     <string name="error_timeout">Solicitar tiempo fuera. Por favor intente de nuevo.</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -388,10 +388,12 @@
     <string name="error_network">Erreur réseau. Veuillez vérifier votre connexion.</string>
     <string name="offline_cached_servers_info">Réseau indisponible. Affichage des serveurs en cache.</string>
     <string name="offline">Pas de connexion Internet.</string>
+    <string name="offline_cached_items_info">Réseau indisponible. Affichage des objets en cache.</string>
     <string name="subscription_disabled">Les abonnements sont actuellement désactivés.</string>
     <string name="connect_manage_subscription">Connectez-vous à Internet pour gérer votre abonnement.</string>
     <string name="no_servers_available_offline">Aucun serveur disponible hors ligne.</string>
     <string name="no_servers_available">Aucun serveur disponible.</string>
+    <string name="no_items_available_offline">Aucun objet disponible hors ligne.</string>
     <string name="no_items_available">Aucun objet disponible.</string>
     <string name="no_monuments_available">Aucun monument disponible.</string>
     <string name="error_timeout">Temps d'attente écoulé. Veuillez réessayer.</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -389,10 +389,12 @@
     <string name="error_network">Błąd sieci. Sprawdź swoje połączenie.</string>
     <string name="offline_cached_servers_info">Brak sieci. Wyświetlana jest zapisana lista serwerów.</string>
     <string name="offline">Brak połączenia z internetem.</string>
+    <string name="offline_cached_items_info">Brak sieci. Wyświetlana jest zapisana lista przedmiotów.</string>
     <string name="subscription_disabled">Subskrypcje są obecnie wyłączone.</string>
     <string name="connect_manage_subscription">Połącz się z internetem, aby zarządzać subskrypcją.</string>
     <string name="no_servers_available_offline">Brak dostępnych serwerów offline.</string>
     <string name="no_servers_available">Brak dostępnych serwerów.</string>
+    <string name="no_items_available_offline">Brak dostępnych przedmiotów offline.</string>
     <string name="no_items_available">Brak dostępnych przedmiotów.</string>
     <string name="no_monuments_available">Brak dostępnych monumentów.</string>
     <string name="error_timeout">Przekroczono czas oczekiwania. Spróbuj ponownie.</string>

--- a/shared/src/commonMain/moko-resources/pt/strings.xml
+++ b/shared/src/commonMain/moko-resources/pt/strings.xml
@@ -389,10 +389,12 @@
     <string name="error_network">Erro de rede. Por favor, verifique sua conexão.</string>
     <string name="offline_cached_servers_info">Rede indisponível. Mostrando servidores em cache.</string>
     <string name="offline">Sem conexão com a Internet.</string>
+    <string name="offline_cached_items_info">Rede indisponível. Mostrando itens em cache.</string>
     <string name="subscription_disabled">As assinaturas estão atualmente desativadas.</string>
     <string name="connect_manage_subscription">Conecte -se à Internet para gerenciar sua assinatura.</string>
     <string name="no_servers_available_offline">Nenhum servidor disponível offline.</string>
     <string name="no_servers_available">Nenhum servidor disponível.</string>
+    <string name="no_items_available_offline">Nenhum item disponível offline.</string>
     <string name="no_items_available">Sem itens disponíveis.</string>
     <string name="no_monuments_available">Sem monumentos disponíveis.</string>
     <string name="error_timeout">Solicitação cronometrada. Por favor, tente novamente.</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -389,10 +389,12 @@
     <string name="error_network">Ошибка сети. Проверьте подключение.</string>
     <string name="offline_cached_servers_info">Нет сети. Отображаются кэшированные серверы.</string>
     <string name="offline">Нет подключения к интернету.</string>
+    <string name="offline_cached_items_info">Нет сети. Отображаются кэшированные предметы.</string>
     <string name="subscription_disabled">Подписки временно отключены.</string>
     <string name="connect_manage_subscription">Подключитесь к интернету, чтобы управлять подпиской.</string>
     <string name="no_servers_available_offline">Нет серверов в автономном режиме.</string>
     <string name="no_servers_available">Нет доступных серверов.</string>
+    <string name="no_items_available_offline">Нет предметов в автономном режиме.</string>
     <string name="no_items_available">Нет доступных предметов.</string>
     <string name="no_monuments_available">Нет доступных монументов.</string>
     <string name="error_timeout">Превышено время ожидания. Попробуйте ещё раз.</string>

--- a/shared/src/commonMain/moko-resources/uk/strings.xml
+++ b/shared/src/commonMain/moko-resources/uk/strings.xml
@@ -390,10 +390,12 @@
     <string name="error_network">Помилка мережі. Будь ласка, перевірте своє з'єднання.</string>
     <string name="offline_cached_servers_info">Мережа недоступна. Показати кешовані сервери.</string>
     <string name="offline">Немає підключення до Інтернету.</string>
+    <string name="offline_cached_items_info">Мережа недоступна. Показуються кешовані предмети.</string>
     <string name="subscription_disabled">Підписки в даний час відключені.</string>
     <string name="connect_manage_subscription">Підключіться до Інтернету, щоб керувати підпискою.</string>
     <string name="no_servers_available_offline">Немає серверів в режимі офлайн.</string>
     <string name="no_servers_available">Немає серверів.</string>
+    <string name="no_items_available_offline">Немає предметів в режимі офлайн.</string>
     <string name="no_items_available">Немає предметів.</string>
     <string name="no_monuments_available">Немає пам’яток.</string>
     <string name="error_timeout">Запит приурочений. Будь ласка, спробуйте ще раз.</string>

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.ios.kt
@@ -36,6 +36,7 @@ import pl.cuyer.rusthub.util.SystemDarkThemeObserver
 import pl.cuyer.rusthub.util.PurchaseSyncScheduler
 import pl.cuyer.rusthub.util.UserSyncScheduler
 import pl.cuyer.rusthub.util.AdsConsentManager
+import pl.cuyer.rusthub.util.ConnectivityObserver
 import pl.cuyer.rusthub.data.billing.BillingRepositoryImpl
 import pl.cuyer.rusthub.domain.repository.purchase.BillingRepository
 import pl.cuyer.rusthub.domain.usecase.ConfirmPurchaseUseCase
@@ -82,6 +83,7 @@ actual fun platformModule(passphrase: String): Module = module {
     single { UrlOpener() }
     single { EmailSender() }
     single { SystemDarkThemeObserver() }
+    single { ConnectivityObserver() }
     single { GoogleAuthClient() }
     single { RemoteConfig() }
     single { StringProvider() }
@@ -115,7 +117,8 @@ actual fun platformModule(passphrase: String): Module = module {
             getSearchQueriesUseCase = get(),
             deleteSearchQueriesUseCase = get(),
             getUserUseCase = get(),
-            adsConsentManager = get()
+            adsConsentManager = get(),
+            connectivityObserver = get()
         )
     }
     factory {


### PR DESCRIPTION
## Summary
- track network state in ItemViewModel and ItemState
- show offline indicator and messaging on item list
- localize new offline item strings and wire connectivity observer in DI

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68979452b190832185dbfb015f1f80cf