### PR TITLE
Fix WorkManager initialization guard

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/RustHubApplication.kt
@@ -93,7 +93,11 @@ class RustHubApplication : Application(), Configuration.Provider {
                 .build()
 
             NotificationPresenter(this@RustHubApplication).createDefaultChannels()
-            WorkManager.initialize(this@RustHubApplication, workManagerConfiguration)
+            try {
+                WorkManager.getInstance(this@RustHubApplication)
+            } catch (e: IllegalStateException) {
+                WorkManager.initialize(this@RustHubApplication, workManagerConfiguration)
+            }
             koinReady.complete(Unit)
         }
     }


### PR DESCRIPTION
## Summary
- avoid crashing when WorkManager is already initialized by checking before manual initialization

## Testing
- No tests run

------
https://chatgpt.com/codex/tasks/task_e_689795c724f8832198b51bb708abe27a