### PR TITLE
Fix: guard against null locales

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/util/composeUtil/LanguageUtil.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/util/composeUtil/LanguageUtil.kt
@@ -1,13 +1,11 @@
 package pl.cuyer.rusthub.android.util.composeUtil
 
-import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.core.os.LocaleListCompat
 import pl.cuyer.rusthub.domain.model.Language
 import java.util.Locale
 
@@ -17,7 +15,7 @@ fun rememberCurrentLanguage(): State<Language> {
     val language = remember(configuration) {
         val locales = AppCompatDelegate.getApplicationLocales()
         val tag = if (!locales.isEmpty) {
-            locales[0]!!.language
+            locales[0]?.language ?: Locale.getDefault().language
         } else {
             Locale.getDefault().language
         }

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/LanguageUtil.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/LanguageUtil.android.kt
@@ -16,13 +16,19 @@ actual fun updateAppLanguage(language: Language) {
         Language.SPANISH -> "es"
         Language.UKRAINIAN -> "uk"
     }
-    val locales = LocaleListCompat.forLanguageTags(tag)
+    val locale = Locale.forLanguageTag(tag)
+    if (locale.language.isEmpty()) return
+    val locales = LocaleListCompat.create(locale)
     AppCompatDelegate.setApplicationLocales(locales)
 }
 
 actual fun getCurrentAppLanguage(): Language {
     val locales = AppCompatDelegate.getApplicationLocales()
-    val code = if (!locales.isEmpty) locales[0]!!.language else Locale.getDefault().language
+    val code = if (!locales.isEmpty) {
+        locales[0]?.language ?: Locale.getDefault().language
+    } else {
+        Locale.getDefault().language
+    }
     return when (code) {
         "pl" -> Language.POLISH
         "de" -> Language.GERMAN


### PR DESCRIPTION
## Summary
- Safely create locale list when updating app language to avoid null entries
- Handle missing locale when reading current language

## Testing
- `./gradlew -q help`

------
https://chatgpt.com/codex/tasks/task_e_689797db9c488321af18587d157616d4