### PR TITLE
Make monument legend expandable

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MapDialog.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/MapDialog.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.minimumInteractiveComponentSize
-import androidx.compose.material3.adaptive.layout.PaneExpansionAnchor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -39,7 +38,7 @@ import pl.cuyer.rusthub.android.util.composeUtil.stringResource
 
 @Composable
 fun MapDialog(
-    mapUrl: String,
+    imageModel: Any,
     onDismiss: () -> Unit
 ) {
     Dialog(
@@ -80,7 +79,7 @@ fun MapDialog(
                         scaleY = zoom
                         transformOrigin = TransformOrigin(0f, 0f)
                     },
-                model = mapUrl,
+                model = imageModel,
                 contentDescription = stringResource(SharedRes.strings.rust_map_image),
                 loading = {
                     Box(

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentMapPage.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentMapPage.kt
@@ -39,11 +39,11 @@ fun MonumentMapPage(
     mapUrls: List<String>,
     modifier: Modifier = Modifier
 ) {
-    var showMapUrl by remember { mutableStateOf<String?>(null) }
+    var showImage by remember { mutableStateOf<Any?>(null) }
     val uriHandler = LocalUriHandler.current
 
-    showMapUrl?.let { url ->
-        MapDialog(mapUrl = url) { showMapUrl = null }
+    showImage?.let { model ->
+        MapDialog(imageModel = model) { showImage = null }
     }
 
     LazyColumn(
@@ -63,11 +63,13 @@ fun MonumentMapPage(
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.padding(bottom = spacing.medium)
                 )
+                val legendRes = getImageByFileName("il_legend").drawableResId
                 Image(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(200.dp),
-                    painter = painterResource(id = getImageByFileName("il_legend").drawableResId),
+                        .height(200.dp)
+                        .clickable { showImage = legendRes },
+                    painter = painterResource(id = legendRes),
                     contentDescription = stringResource(SharedRes.strings.map_legend)
                 )
             }
@@ -90,7 +92,7 @@ fun MonumentMapPage(
                         .height(200.dp)
                         .animateItem()
                         .padding(horizontal = spacing.xmedium)
-                        .clickable { showMapUrl = mapUrl },
+                        .clickable { showImage = mapUrl },
                     model = mapUrl,
                     contentDescription = stringResource(SharedRes.strings.rust_map_image),
                     loading = {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerDetailsScreen.kt
@@ -131,7 +131,7 @@ fun ServerDetailsScreen(
 
     state.value.details?.mapImage?.let { mapUrl ->
         if (state.value.showMap) {
-            MapDialog(mapUrl = mapUrl) {
+            MapDialog(imageModel = mapUrl) {
                 onAction(ServerDetailsAction.OnDismissMap)
             }
         }


### PR DESCRIPTION
## Summary
- allow expanding legend on monument map page
- generalize `MapDialog` to accept any image model
- update server details screen for new dialog API

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898bb7027708321aa704c786eeb07d3