### PR TITLE
Fix: use plural maps label in MonumentMapPage

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentMapPage.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentMapPage.kt
@@ -82,7 +82,7 @@ fun MonumentMapPage(
                     .padding(horizontal = spacing.xmedium)
             ) {
                 Text(
-                    text = stringResource(SharedRes.strings.map),
+                    text = stringResource(SharedRes.strings.maps),
                     style = MaterialTheme.typography.titleLarge,
                     modifier = Modifier.padding(bottom = spacing.medium)
                 )

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -135,6 +135,7 @@
     <string name="lifetime">Lifetime</string>
     <string name="mail_icon">Mail Icon</string>
     <string name="map">Map</string>
+    <string name="maps">Maps</string>
     <string name="map_information">Map information</string>
     <string name="map_legend">Legend</string>
     <string name="map_creator_credit">Huge thanks to the creator of these maps</string>

--- a/shared/src/commonMain/moko-resources/de/strings.xml
+++ b/shared/src/commonMain/moko-resources/de/strings.xml
@@ -134,6 +134,7 @@
     <string name="lifetime">Lifetime</string>
     <string name="mail_icon">Mail-Icon</string>
     <string name="map">Karte</string>
+    <string name="maps">Karten</string>
     <string name="map_information">Karteninformation</string>
     <string name="map_legend">Legende</string>
     <string name="map_creator_credit">Großer Dank an den Ersteller dieser Karten</string>

--- a/shared/src/commonMain/moko-resources/es/strings.xml
+++ b/shared/src/commonMain/moko-resources/es/strings.xml
@@ -134,6 +134,7 @@
     <string name="lifetime">Vida</string>
     <string name="mail_icon">Icono de correo</string>
     <string name="map">Mapa</string>
+    <string name="maps">Mapas</string>
     <string name="map_information">Información sobre el mapa</string>
     <string name="map_legend">Leyenda</string>
     <string name="map_creator_credit">Muchas gracias al creador de estos mapas</string>

--- a/shared/src/commonMain/moko-resources/fr/strings.xml
+++ b/shared/src/commonMain/moko-resources/fr/strings.xml
@@ -134,6 +134,7 @@
     <string name="lifetime">Lifetime</string>
     <string name="mail_icon">Icône mail</string>
     <string name="map">Carte</string>
+    <string name="maps">Cartes</string>
     <string name="map_information">Infos sur la carte</string>
     <string name="map_legend">Légende</string>
     <string name="map_creator_credit">Un grand merci au créateur de ces cartes</string>

--- a/shared/src/commonMain/moko-resources/pl/strings.xml
+++ b/shared/src/commonMain/moko-resources/pl/strings.xml
@@ -134,6 +134,7 @@
     <string name="lifetime">Lifetime</string>
     <string name="mail_icon">Ikona maila</string>
     <string name="map">Mapa</string>
+    <string name="maps">Mapy</string>
     <string name="map_information">Informacje o mapie</string>
     <string name="map_legend">Legenda</string>
     <string name="map_creator_credit">Wielkie podziękowania dla twórcy tych map</string>

--- a/shared/src/commonMain/moko-resources/pt/strings.xml
+++ b/shared/src/commonMain/moko-resources/pt/strings.xml
@@ -133,6 +133,7 @@
     <string name="lifetime">Vida</string>
     <string name="mail_icon">Ícone de correio</string>
     <string name="map">Mapa</string>
+    <string name="maps">Mapas</string>
     <string name="map_information">Informações do mapa</string>
     <string name="map_legend">Legenda</string>
     <string name="map_creator_credit">Muito obrigado ao criador destes mapas</string>

--- a/shared/src/commonMain/moko-resources/ru/strings.xml
+++ b/shared/src/commonMain/moko-resources/ru/strings.xml
@@ -134,6 +134,7 @@
     <string name="lifetime">Lifetime</string>
     <string name="mail_icon">Иконка почты</string>
     <string name="map">Карта</string>
+    <string name="maps">Карты</string>
     <string name="map_information">Информация о карте</string>
     <string name="map_legend">Легенда</string>
     <string name="map_creator_credit">Огромная благодарность создателю этих карт</string>

--- a/shared/src/commonMain/moko-resources/uk/strings.xml
+++ b/shared/src/commonMain/moko-resources/uk/strings.xml
@@ -134,6 +134,7 @@
     <string name="lifetime">Життя</string>
     <string name="mail_icon">Піктограма пошти</string>
     <string name="map">Карта</string>
+    <string name="maps">Карти</string>
     <string name="map_information">Інформація про карту</string>
     <string name="map_legend">Легенда</string>
     <string name="map_creator_credit">Велика подяка творцю цих карт</string>


### PR DESCRIPTION
## Summary
- display "Maps" label in MonumentMapPage
- add "maps" string resource and translations

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_6898c09e00208321b32ee53752f31a16