### PR TITLE
Fix: skip refresh when tokens changed

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -90,6 +90,13 @@ actual class HttpClientFactory actual constructor(
                                 return@run null
                             }
 
+                            val currentRefresh = user?.refreshToken
+                            if (currentRefresh != oldRefresh) {
+                                return@run user?.let {
+                                    BearerTokens(it.accessToken, currentRefresh ?: "")
+                                }
+                            }
+
                             val response = client.post("${NetworkConstants.BASE_URL}auth/refresh") {
                                 markAsRefreshTokenRequest()
                                 contentType(ContentType.Application.Json)

--- a/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
+++ b/shared/src/iosMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.ios.kt
@@ -82,6 +82,13 @@ actual class HttpClientFactory actual constructor(
                                 return@run null
                             }
 
+                            val currentRefresh = user?.refreshToken
+                            if (currentRefresh != oldRefresh) {
+                                return@run user?.let {
+                                    BearerTokens(it.accessToken, currentRefresh ?: "")
+                                }
+                            }
+
                             val response = client.post("${NetworkConstants.BASE_URL}auth/refresh") {
                                 markAsRefreshTokenRequest()
                                 contentType(ContentType.Application.Json)


### PR DESCRIPTION
## Summary
- skip refresh network call when stored refresh token differs from client tokens

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68a5e0019a4883218facd191af87f9f0