### PR TITLE
Display previously entered Steam IDs in search dialog

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/raid/SteamUserSearchDialog.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/raid/SteamUserSearchDialog.kt
@@ -82,9 +82,10 @@ fun SteamUserSearchDialog(state: RaidFormState, onAction: (RaidFormAction) -> Un
                     .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(spacing.medium)
             ) {
-                val queryState = rememberTextFieldState(state.searchQuery)
-                LaunchedEffect(state.searchQuery) {
-                    queryState.setTextAndPlaceCursorAtEnd(state.searchQuery)
+                val queryState = rememberTextFieldState()
+                LaunchedEffect(Unit) {
+                    val initial = state.searchQuery.ifEmpty { state.steamIds.joinToString(", ") }
+                    queryState.setTextAndPlaceCursorAtEnd(initial)
                 }
                 LaunchedEffect(queryState) {
                     snapshotFlow { queryState.text.toString() }


### PR DESCRIPTION
## Summary
- Show existing Steam IDs when opening the SteamUserSearchDialog

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_68a857fdb6508321a4c695f368bc4ac1