### PR TITLE
Align item name search with backend filtering

### DIFF
--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/item/ItemDataSourceImpl.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/data/local/item/ItemDataSourceImpl.kt
@@ -111,22 +111,42 @@ class ItemDataSourceImpl(
         category: ItemCategory?,
         language: Language,
     ): PagingSource<Int, ItemEntity> {
+        val query = name.orEmpty()
+        val isMultiLanguage = query.isNotBlank() && language != Language.ENGLISH
         return QueryPagingSource(
-            countQuery = queries.countPagedItemsFiltered(
-                name = name ?: "",
-                category = category?.name,
-                language = language.toEntity()
-            ),
+            countQuery = if (isMultiLanguage) {
+                queries.countPagedItemsFilteredMultiLanguage(
+                    name = query,
+                    category = category?.name,
+                    language = language.toEntity()
+                )
+            } else {
+                queries.countPagedItemsFiltered(
+                    name = query,
+                    category = category?.name,
+                    language = language.toEntity()
+                )
+            },
             transacter = queries,
             context = Dispatchers.IO,
             queryProvider = { limit, offset ->
-                queries.findItemsPagedFiltered(
-                    name = name ?: "",
-                    category = category?.name,
-                    language = language.toEntity(),
-                    limit = limit,
-                    offset = offset
-                )
+                if (isMultiLanguage) {
+                    queries.findItemsPagedFilteredMultiLanguage(
+                        name = query,
+                        category = category?.name,
+                        language = language.toEntity(),
+                        limit = limit,
+                        offset = offset
+                    )
+                } else {
+                    queries.findItemsPagedFiltered(
+                        name = query,
+                        category = category?.name,
+                        language = language.toEntity(),
+                        limit = limit,
+                        offset = offset
+                    )
+                }
             }
         )
     }

--- a/shared/src/commonMain/sqldelight/database/RusthubDB.sq
+++ b/shared/src/commonMain/sqldelight/database/RusthubDB.sq
@@ -759,12 +759,43 @@ WHERE (:category IS NULL OR categories LIKE '%' || :category || '%')
 ORDER BY name
 LIMIT :limit OFFSET :offset;
 
+-- Returns a page of items filtered by query and category across English and selected language
+findItemsPagedFilteredMultiLanguage:
+SELECT *
+FROM itemEntity
+WHERE language = :language
+  AND (:category IS NULL OR categories LIKE '%' || :category || '%')
+  AND short_name IN (
+    SELECT short_name
+    FROM itemEntity
+    WHERE short_name IS NOT NULL
+      AND language IN (:language, 'ENGLISH')
+      AND (:category IS NULL OR categories LIKE '%' || :category || '%')
+      AND name LIKE '%' || :name || '%' COLLATE NOCASE
+  )
+ORDER BY name
+LIMIT :limit OFFSET :offset;
+
 countPagedItemsFiltered:
 SELECT COUNT(*)
 FROM itemEntity
 WHERE (:category IS NULL OR categories LIKE '%' || :category || '%')
   AND (name LIKE '%' || :name || '%' COLLATE NOCASE)
   AND language = :language;
+
+countPagedItemsFilteredMultiLanguage:
+SELECT COUNT(*)
+FROM itemEntity
+WHERE language = :language
+  AND (:category IS NULL OR categories LIKE '%' || :category || '%')
+  AND short_name IN (
+    SELECT short_name
+    FROM itemEntity
+    WHERE short_name IS NOT NULL
+      AND language IN (:language, 'ENGLISH')
+      AND (:category IS NULL OR categories LIKE '%' || :category || '%')
+      AND name LIKE '%' || :name || '%' COLLATE NOCASE
+  );
 
 CREATE TABLE monumentEntity (
     slug TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- add multi-language item queries matching backend name search logic
- switch paging source to use new queries when searching non-English names

## Testing
- No tests were run as per repository instructions

------
https://chatgpt.com/codex/tasks/task_e_68a8942552a88321bd6cfdf351b2d229