### PR TITLE
Enable Gradle cache in CI workflows and fix Fastlane AAB path

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -25,6 +25,7 @@ jobs:
               with:
                   distribution: temurin
                   java-version: '17'
+                  cache: 'gradle'
 
             - name: Decrypt dev keystore
               run: |
@@ -61,6 +62,7 @@ jobs:
               with:
                   distribution: temurin
                   java-version: '17'
+                  cache: 'gradle'
 
             - name: Set up Ruby
               uses: ruby/setup-ruby@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
+          cache: 'gradle'
 
       - name: Decrypt dev keystore
         if: matrix.language == 'java-kotlin'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,8 +33,9 @@ platform :android do
         FileUtils.mkdir_p(File.dirname(json_path))
         File.open(json_path, 'w') { |file| file.write(Base64.decode64(service_account_json)) }
 
-        aab_path = options[:aab] || Dir['androidApp/build/outputs/bundle/productionRelease/*.aab'].first
-        UI.user_error!("Could not find AAB at #{aab_path}") unless aab_path
+        aab_glob = File.expand_path('../androidApp/build/outputs/bundle/productionRelease/*.aab', __dir__)
+        aab_path = options[:aab] || Dir[aab_glob].first
+        UI.user_error!("Could not find AAB at #{aab_glob}") unless aab_path
 
         update_priority = (options[:update_priority] || ENV['UPDATE_PRIORITY'] || 0).to_i
         track = options[:track] || ENV['TRACK']


### PR DESCRIPTION
## Summary
- cache Gradle dependencies in Android CI workflow
- enable Gradle cache for CodeQL analysis
- fix Fastlane publish lane to locate built AAB

## Testing
- `ruby -c fastlane/Fastfile`
- `yamllint .github/workflows/android.yml .github/workflows/codeql.yml` *(fails: line-length and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8423c36083218767ec443c74fbf4