### PR TITLE
feat: add pull to refresh and enhance item details shimmer

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -344,6 +344,7 @@ private fun AppScaffold(
                         ItemDetailsScreen(
                             state = state,
                             onNavigateUp = { onPopWhile { it is ItemDetails } },
+                            onRefresh = viewModel::refresh,
                         )
                     }
                     entry<MonumentList>(metadata = ListDetailSceneStrategy.listPane()) {

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/ItemDetailsShimmer.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/ItemDetailsShimmer.kt
@@ -3,10 +3,12 @@ package pl.cuyer.rusthub.android.designsystem
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,13 +24,21 @@ fun ItemDetailsShimmer(modifier: Modifier = Modifier) {
             .padding(horizontal = spacing.xmedium, vertical = spacing.medium),
         verticalArrangement = Arrangement.spacedBy(spacing.medium)
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(180.dp)
-                .clip(MaterialTheme.shapes.extraSmall)
-                .shimmer()
-        )
+        ItemListItemShimmer(modifier = Modifier.fillMaxWidth())
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(spacing.medium),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            repeat(3) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(32.dp)
+                        .clip(MaterialTheme.shapes.extraSmall)
+                        .shimmer()
+                )
+            }
+        }
         repeat(5) {
             Box(
                 modifier = Modifier

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/item/ItemDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/item/ItemDetailsViewModel.kt
@@ -53,6 +53,11 @@ class ItemDetailsViewModel(
             .launchIn(coroutineScope)
     }
 
+    fun refresh() {
+        val currentId = _state.value.id ?: id
+        currentId?.let { observeItem(it) }
+    }
+
     private fun updateLoading(loading: Boolean) {
         _state.update { it.copy(isLoading = loading) }
     }


### PR DESCRIPTION
## Summary
- improve item details shimmer to match list style and show tab placeholders
- add pull-to-refresh support to item details and expose refresh in viewmodel

## Testing
- `./gradlew --version`


------
https://chatgpt.com/codex/tasks/task_e_68acb622d6b88321b68c9262a43711f2