### PR TITLE
Refactor: move pull-to-refresh inside pager

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemDetailsScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemDetailsScreen.kt
@@ -182,10 +182,7 @@ fun ItemDetailsScreen(
             )
         }
     ) { innerPadding ->
-        PullToRefreshBox(
-            isRefreshing = false,
-            onRefresh = onRefresh,
-            state = pullToRefreshState,
+        Box(
             modifier = Modifier
                 .padding(innerPadding)
                 .consumeWindowInsets(innerPadding)
@@ -247,7 +244,13 @@ fun ItemDetailsScreen(
                             modifier = Modifier.fillMaxSize(),
                             state = pagerState
                         ) { page ->
-                            DetailsContent(availablePages[page])
+                            PullToRefreshBox(
+                                isRefreshing = false,
+                                onRefresh = onRefresh,
+                                state = pullToRefreshState
+                            ) {
+                                DetailsContent(availablePages[page])
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- scope PullToRefreshBox within each HorizontalPager page to ensure proper nested scrolling
- replace screen-level PullToRefreshBox with Box consuming Scaffold insets

## Testing
- No tests executed

------
https://chatgpt.com/codex/tasks/task_e_68acce61db788321a2144df5548e6d6b