### PR TITLE
Fix locale handling for unsupported devices

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/util/composeUtil/LanguageUtil.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/util/composeUtil/LanguageUtil.kt
@@ -13,8 +13,8 @@ import java.util.Locale
 fun rememberCurrentLanguage(): State<Language> {
     val configuration = LocalConfiguration.current // recomposes on locale/config changes
     val language = remember(configuration) {
-        val locales = AppCompatDelegate.getApplicationLocales()
-        val tag = if (!locales.isEmpty) {
+        val locales = runCatching { AppCompatDelegate.getApplicationLocales() }.getOrNull()
+        val tag = if (locales != null && !locales.isEmpty) {
             locales[0]?.language ?: Locale.getDefault().language
         } else {
             Locale.getDefault().language

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/data/network/HttpClientFactory.android.kt
@@ -46,13 +46,15 @@ private fun useCtLibrary(): Boolean {
 }
 
 private fun currentLanguageTag(): String {
-    val locales = AppCompatDelegate.getApplicationLocales()
-    val locale = if (!locales.isEmpty) {
-        locales[0]
-    } else {
-        Locale.getDefault()
-    }
-    return locale?.toLanguageTag() ?: Locale.getDefault().toLanguageTag()
+    return runCatching {
+        val locales = AppCompatDelegate.getApplicationLocales()
+        val locale = if (!locales.isEmpty) {
+            locales[0]
+        } else {
+            Locale.getDefault()
+        }
+        locale?.toLanguageTag()
+    }.getOrNull() ?: Locale.getDefault().toLanguageTag()
 }
 
 actual class HttpClientFactory actual constructor(

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/LanguageUtil.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/LanguageUtil.android.kt
@@ -18,13 +18,15 @@ actual fun updateAppLanguage(language: Language) {
     }
     val locale = Locale.forLanguageTag(tag)
     if (locale.language.isEmpty()) return
-    val locales = LocaleListCompat.create(locale)
-    AppCompatDelegate.setApplicationLocales(locales)
+    runCatching {
+        val locales = LocaleListCompat.create(locale)
+        AppCompatDelegate.setApplicationLocales(locales)
+    }
 }
 
 actual fun getCurrentAppLanguage(): Language {
-    val locales = AppCompatDelegate.getApplicationLocales()
-    val code = if (!locales.isEmpty) {
+    val locales = runCatching { AppCompatDelegate.getApplicationLocales() }.getOrNull()
+    val code = if (locales != null && !locales.isEmpty) {
         locales[0]?.language ?: Locale.getDefault().language
     } else {
         Locale.getDefault().language


### PR DESCRIPTION
## Summary
- guard locale retrieval with `runCatching` and default fallback
- prevent crashes when `AppCompatDelegate` locale APIs fail on some devices

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68aefd06ff088321a69a9ad9196e63ac