### PR TITLE
Handle outdated Play Store in App Check token provider

### DIFF
--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/AppCheckTokenProvider.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/util/AppCheckTokenProvider.android.kt
@@ -50,7 +50,12 @@ actual class AppCheckTokenProvider actual constructor(
 
     private suspend fun notifyPlayStoreRequired(e: Exception): Boolean {
         val integrityCause = e.cause as? IntegrityServiceException
-        if (integrityCause?.errorCode == IntegrityErrorCode.PLAY_STORE_NOT_FOUND) {
+        if (
+            integrityCause?.errorCode in listOf(
+                IntegrityErrorCode.PLAY_STORE_NOT_FOUND,
+                IntegrityErrorCode.PLAY_STORE_VERSION_OUTDATED
+            )
+        ) {
             withContext(Dispatchers.Main.immediate) {
                 snackbarController.sendEvent(
                     SnackbarEvent(stringProvider.get(SharedRes.strings.play_store_required))


### PR DESCRIPTION
## Summary
- Also notify users when the Play Store is outdated while fetching the App Check token

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b03efcd1a8832198ae7e38e09abaf1