### PR TITLE
Refactor filters options flow to be reactive and bump version

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -23,7 +23,7 @@ android {
         applicationId = "pl.cuyer.rusthub.android"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 87
+        versionCode = 88
         versionName = project.property("VERSION_NAME") as String
         buildConfigField("String", "SERVERS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/4096035325\"")
         buildConfigField("String", "ITEMS_ADMOB_NATIVE_AD_ID", "\"ca-app-pub-4286204280518303/1469871989\"")

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlin.incremental.multiplatform=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 # App version
-VERSION_NAME=1.0.1
+VERSION_NAME=1.0.2
 android.dependency.excludeLibraryComponentsFromConstraints=false
 android.defaults.buildfeatures.resvalues=true
 android.r8.strictFullModeForKeepRules=false

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetFiltersOptionsUseCase.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/domain/usecase/GetFiltersOptionsUseCase.kt
@@ -1,16 +1,11 @@
 package pl.cuyer.rusthub.domain.usecase
 
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import pl.cuyer.rusthub.common.Result
-import pl.cuyer.rusthub.domain.exception.HttpStatusException
-import pl.cuyer.rusthub.domain.exception.NetworkUnavailableException
-import pl.cuyer.rusthub.domain.exception.ServiceUnavailableException
 import pl.cuyer.rusthub.domain.model.FiltersOptions
 import pl.cuyer.rusthub.domain.repository.filtersOptions.FiltersOptionsDataSource
 import pl.cuyer.rusthub.domain.repository.filtersOptions.FiltersOptionsRepository
@@ -19,14 +14,20 @@ class GetFiltersOptionsUseCase(
     private val api: FiltersOptionsRepository,
     private val dataSource: FiltersOptionsDataSource
 ) {
-    operator fun invoke(): Flow<FiltersOptions?> = flow {
-
-        emitAll(dataSource.getFiltersOptions())
-
-        api.getFiltersOptions().collectLatest { result ->
-            if (result is Result.Success && result.data != null) {
-                dataSource.upsertFiltersOptions(result.data)
+    operator fun invoke(): Flow<FiltersOptions?> = channelFlow {
+        val localJob = launch {
+            dataSource.getFiltersOptions().collect { send(it) }
+        }
+        val remoteJob = launch {
+            api.getFiltersOptions().collect { result ->
+                if (result is Result.Success && result.data != null) {
+                    dataSource.upsertFiltersOptions(result.data)
+                }
             }
+        }
+        awaitClose {
+            localJob.cancel()
+            remoteJob.cancel()
         }
     }.distinctUntilChanged()
 }


### PR DESCRIPTION
## Summary
- emit filters options whenever table changes using SQLDelight flows
- channel flow to combine local and remote filter options with proper job cancellation
- bump app version to 1.0.2 (versionCode 88)

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b1eb5187208321aa9a54f938590ff1