### PR TITLE
Fix invalid Spanish string formatting placeholders

### DIFF
--- a/shared/src/commonMain/moko-resources/es/strings.xml
+++ b/shared/src/commonMain/moko-resources/es/strings.xml
@@ -464,11 +464,11 @@
     <string name="radtown_recycler">Radtown Recycler</string>
     <string name="guaranteed_output">Salida garantizada</string>
     <string name="extra_chance_output">Salida de oportunidad extra</string>
-    <string name="multiplier_format">x%1 $ D</string>
-    <string name="percentage_format">%1 $ d %%</string>
-    <string name="time_per_fuel">Tiempo por combustible: %1 $ d s</string>
+    <string name="multiplier_format">x%1$d</string>
+    <string name="percentage_format">%1$d%%</string>
+    <string name="time_per_fuel">Tiempo por combustible: %1$d s</string>
     <string name="raw_material_cost">Costo de materia prima</string>
-    <string name="using_mixing_table">Uso de la tabla de mezcla x%1 $ D</string>
+    <string name="using_mixing_table">Uso de la tabla de mezcla x%1$d</string>
     <string name="time_to_raid">Tiempo de atacar: %1$s</string>
     <string name="hp">HP</string>
     <string name="update_ready">Actualizar listo para instalar</string>


### PR DESCRIPTION
## Summary
- correct Spanish string resource placeholders so they use valid Android format specifiers

## Testing
- not run (per repository guidance)


------
https://chatgpt.com/codex/tasks/task_e_68d9531c543883218c69fff4d0b0538c