### PR TITLE
Delay native ads until initial paging load completes

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/ads/AdsVisibility.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/ads/AdsVisibility.kt
@@ -1,0 +1,44 @@
+package pl.cuyer.rusthub.android.ads
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+
+@Composable
+fun rememberShouldDisplayAds(
+    showAds: Boolean,
+    pagingItems: LazyPagingItems<*>
+): Boolean {
+    var shouldDisplayAds by remember(pagingItems) { mutableStateOf(false) }
+
+    val loadState = pagingItems.loadState
+
+    val refreshLoading = loadState.refresh is LoadState.Loading ||
+        loadState.mediator?.refresh is LoadState.Loading
+    val appendLoading = loadState.append is LoadState.Loading ||
+        loadState.mediator?.append is LoadState.Loading
+    val prependLoading = loadState.prepend is LoadState.Loading ||
+        loadState.mediator?.prepend is LoadState.Loading
+
+    val isBlockingInitialLoad = refreshLoading || (!shouldDisplayAds && (appendLoading || prependLoading))
+
+    LaunchedEffect(showAds) {
+        if (!showAds && shouldDisplayAds) {
+            shouldDisplayAds = false
+        }
+    }
+
+    LaunchedEffect(showAds, isBlockingInitialLoad) {
+        when {
+            showAds && !isBlockingInitialLoad && !shouldDisplayAds -> shouldDisplayAds = true
+            isBlockingInitialLoad && shouldDisplayAds -> shouldDisplayAds = false
+        }
+    }
+
+    return shouldDisplayAds
+}

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/item/ItemScreen.kt
@@ -92,6 +92,7 @@ import pl.cuyer.rusthub.android.navigation.ObserveAsEvents
 import pl.cuyer.rusthub.android.theme.RustHubTheme
 import pl.cuyer.rusthub.android.theme.spacing
 import pl.cuyer.rusthub.android.ads.NativeAdListItem
+import pl.cuyer.rusthub.android.ads.rememberShouldDisplayAds
 import pl.cuyer.rusthub.presentation.features.ads.AdAction
 import pl.cuyer.rusthub.presentation.features.ads.NativeAdState
 import pl.cuyer.rusthub.android.util.HandlePagingItems
@@ -133,13 +134,14 @@ fun ItemScreen(
         }
     }
     val ads = adState
+    val shouldDisplayAds = rememberShouldDisplayAds(showAds, pagedList)
 
     ObserveAsEvents(uiEvent) { event ->
         if (event is UiEvent.Navigate) onNavigate(event.destination)
     }
 
-    LaunchedEffect(showAds) {
-        if (showAds) {
+    LaunchedEffect(shouldDisplayAds) {
+        if (shouldDisplayAds) {
             onAdAction(AdAction.LoadAd(BuildConfig.ITEMS_ADMOB_NATIVE_AD_ID))
         }
     }
@@ -363,11 +365,11 @@ fun ItemScreen(
                 ) {
                     onPagingItemsIndexed(
                         key = { index, item ->
-                            if (showAds && index == adIndex) "ad" else item.id
+                            if (shouldDisplayAds && index == adIndex) "ad" else item.id
                         },
-                        contentType = { index, _ -> if (showAds && index == adIndex) "ad" else "item" }
+                        contentType = { index, _ -> if (shouldDisplayAds && index == adIndex) "ad" else "item" }
                     ) { index, item ->
-                        if (showAds && index == adIndex) {
+                        if (shouldDisplayAds && index == adIndex) {
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth()

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/monument/MonumentScreen.kt
@@ -65,6 +65,7 @@ import org.koin.compose.koinInject
 import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.android.BuildConfig
 import pl.cuyer.rusthub.android.ads.NativeAdListItem
+import pl.cuyer.rusthub.android.ads.rememberShouldDisplayAds
 import pl.cuyer.rusthub.android.designsystem.MonumentListItem
 import pl.cuyer.rusthub.android.designsystem.MonumentListItemShimmer
 import pl.cuyer.rusthub.android.designsystem.RustSearchBarTopAppBar
@@ -109,13 +110,14 @@ fun MonumentScreen(
         }
     }
     val ads = adState
+    val shouldDisplayAds = rememberShouldDisplayAds(showAds, pagedList)
 
     ObserveAsEvents(uiEvent) { event ->
         if (event is UiEvent.Navigate) onNavigate(event.destination)
     }
 
-    LaunchedEffect(showAds) {
-        if (showAds) {
+    LaunchedEffect(shouldDisplayAds) {
+        if (shouldDisplayAds) {
             onAdAction(AdAction.LoadAd(BuildConfig.MONUMENTS_ADMOB_NATIVE_AD_ID))
         }
     }
@@ -304,11 +306,11 @@ fun MonumentScreen(
                     ) {
                         onPagingItemsIndexed(
                             key = { index, item ->
-                                if (showAds && index == adIndex) "ad" else item.slug ?: index
+                                if (shouldDisplayAds && index == adIndex) "ad" else item.slug ?: index
                             },
-                            contentType = { index, _ -> if (showAds && index == adIndex) "ad" else "monument" }
+                            contentType = { index, _ -> if (shouldDisplayAds && index == adIndex) "ad" else "monument" }
                         ) { index, monument ->
-                            if (showAds && index == adIndex) {
+                            if (shouldDisplayAds && index == adIndex) {
                                 Column(
                                     modifier = Modifier
                                         .fillMaxWidth()

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerScreen.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/feature/server/ServerScreen.kt
@@ -84,6 +84,7 @@ import org.koin.compose.koinInject
 import pl.cuyer.rusthub.SharedRes
 import pl.cuyer.rusthub.android.BuildConfig
 import pl.cuyer.rusthub.android.ads.NativeAdCard
+import pl.cuyer.rusthub.android.ads.rememberShouldDisplayAds
 import pl.cuyer.rusthub.android.designsystem.FilterBottomSheet
 import pl.cuyer.rusthub.android.designsystem.RustSearchBarTopAppBar
 import pl.cuyer.rusthub.android.designsystem.ServerListItem
@@ -147,13 +148,22 @@ fun ServerScreen(
     }
 
     val ads = adState
+    var canRequestAds by remember { mutableStateOf(false) }
+    val shouldDisplayAds = rememberShouldDisplayAds(showAds && canRequestAds, pagedList)
     val activity = LocalActivity.current as Activity
 
     LaunchedEffect(Unit) {
-        onAction(ServerAction.GatherConsent(activity) {
+        onAction(
+            ServerAction.GatherConsent(activity) {
+                canRequestAds = true
+            }
+        )
+    }
+
+    LaunchedEffect(shouldDisplayAds) {
+        if (shouldDisplayAds) {
             onAdAction(AdAction.LoadAd(BuildConfig.SERVERS_ADMOB_NATIVE_AD_ID))
         }
-        )
     }
 
 
@@ -391,11 +401,11 @@ fun ServerScreen(
                 ) {
                     onPagingItemsIndexed(
                         key = { index, item ->
-                            if (showAds && index == adIndex) "ad" else item.id ?: UUID.randomUUID()
+                            if (shouldDisplayAds && index == adIndex) "ad" else item.id ?: UUID.randomUUID()
                         },
-                        contentType = { index, _ -> if (showAds && index == adIndex) "ad" else "server" }
+                        contentType = { index, _ -> if (shouldDisplayAds && index == adIndex) "ad" else "server" }
                     ) { index, item ->
-                        if (showAds && index == adIndex) {
+                        if (shouldDisplayAds && index == adIndex) {
                             Column(
                                 modifier = Modifier
                                     .fillMaxWidth()


### PR DESCRIPTION
## Summary
- add a composable helper that tracks paging load states to decide when ads can be shown
- update item, monument, and server lists to delay native ad requests until the initial pages finish loading

## Testing
- not run (tests fail in the base project)


------
https://chatgpt.com/codex/tasks/task_e_68d953615ff48321ab53ad2ffab67fe1