### PR TITLE
Update Navigation3 dependencies to snapshot builds

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -39,7 +39,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
-import androidx.navigation3.runtime.rememberSceneSetupNavEntryDecorator
+import androidx.navigation3.scene.rememberSceneSetupNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.launch
@@ -242,7 +242,7 @@ private fun AppScaffold(
         contentColor = MaterialTheme.colorScheme.onBackground,
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { contentPadding ->
-            val listDetailStrategy = rememberListDetailSceneStrategy<Any>()
+            val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
             NavDisplay(
                 modifier = Modifier
                     .padding(contentPadding)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
         maven {
-            url = uri("https://androidx.dev/kmp/builds/14104661/artifacts/snapshots/repository")
+            url = uri("https://androidx.dev/kmp/builds/14214693/artifacts/snapshots/repository")
         }
     }
     resolutionStrategy {
@@ -23,7 +23,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url = uri("https://androidx.dev/kmp/builds/14104661/artifacts/snapshots/repository")
+            url = uri("https://androidx.dev/kmp/builds/14214693/artifacts/snapshots/repository")
         }
     }
 }


### PR DESCRIPTION
## Summary
- point buildscript repository at the 14214693 snapshot for Navigation3 artifacts
- bump Navigation3-related dependencies to the 1.0.0-SNAPSHOT family
- adjust NavigationRoot to use the new scene API helpers required by alpha10

## Testing
- not run (per project guidelines)

------
https://chatgpt.com/codex/tasks/task_e_68e17192e0248321b0248caf2284d070