### PR TITLE
Fix NavigationRoot for updated navigation3 scene APIs

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -37,10 +37,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberDecoratedNavEntries
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
-import androidx.navigation3.scene.rememberSceneSetupNavEntryDecorator
+import androidx.navigation3.scene.rememberSceneState
 import androidx.navigation3.ui.NavDisplay
 import androidx.paging.compose.collectAsLazyPagingItems
 import kotlinx.coroutines.launch
@@ -244,11 +244,26 @@ private fun AppScaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { contentPadding ->
             val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
+            val decoratedEntries =
+                rememberDecoratedNavEntries(
+                    backStack(),
+                    listOf(
+                        rememberSaveableStateHolderNavEntryDecorator(),
+                        rememberViewModelStoreNavEntryDecorator(),
+                    ),
+                )
+            val sceneState =
+                rememberSceneState(
+                    entries = decoratedEntries,
+                    sceneStrategy = listDetailStrategy,
+                    onBack = { onBack(1) },
+                )
+
             NavDisplay(
                 modifier = Modifier
                     .padding(contentPadding)
                     .consumeWindowInsets(contentPadding),
-                backStack = backStack(),
+                sceneState = sceneState,
                 transitionSpec = {
                     fadeIn(
                         animationSpec = spring(
@@ -277,12 +292,7 @@ private fun AppScaffold(
                                 )
                             )
                 },
-                entryDecorators = listOf(
-                    rememberSceneSetupNavEntryDecorator(),
-                    rememberSaveableStateHolderNavEntryDecorator(),
-                    rememberViewModelStoreNavEntryDecorator()
-                ),
-                onBack = onBack,
+                onBack = { onBack(1) },
                 entryProvider = entryProvider {
                     entry<Onboarding> {
                         val viewModel = koinViewModel<OnboardingViewModel>()


### PR DESCRIPTION
## Summary
- switch NavigationRoot to build a sceneState via rememberSceneState and rememberDecoratedNavEntries
- update NavDisplay usage to consume the new scene state and adapt the back callback signature

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e1799f4d1883218d3ba7817f2262af