### PR TITLE
Add native ad to server details screen

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -303,12 +303,18 @@ private fun AppScaffold(
                                 key = key.id.toString()
                             ) { parametersOf(key.id, key.name) }
                             val state = viewModel.state.collectAsStateWithLifecycle()
+                            val showAds by viewModel.showAds.collectAsStateWithLifecycle()
+                            val adViewModel = koinViewModel<NativeAdViewModel>()
+                            val adState = adViewModel.state.collectAsStateWithLifecycle()
                             ServerDetailsScreen(
                                 state = state,
                                 uiEvent = viewModel.uiEvent,
                                 onAction = viewModel::onAction,
                                 onNavigate = { dest -> onNavigate(dest) },
-                                onNavigateUp = onNavigateUp
+                                onNavigateUp = onNavigateUp,
+                                showAds = showAds,
+                                adState = adState,
+                                onAdAction = adViewModel::onAction
                             )
                         }
                         entry<ItemList>(metadata = ListDetailSceneStrategy.listPane()) {

--- a/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
+++ b/shared/src/androidMain/kotlin/pl/cuyer/rusthub/presentation/di/KoinInitializer.android.kt
@@ -329,7 +329,8 @@ actual fun platformModule(passphrase: String): Module = module {
             snackbarController = get(),
             shareHandler = get(),
             reviewRequester = get(),
-            connectivityObserver = get()
+            connectivityObserver = get(),
+            adsConsentManager = get()
         )
     }
     viewModel { (plan: SubscriptionPlan?) ->

--- a/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/pl/cuyer/rusthub/presentation/features/server/ServerDetailsViewModel.kt
@@ -50,6 +50,7 @@ import pl.cuyer.rusthub.util.StringProvider
 import pl.cuyer.rusthub.util.ConnectivityObserver
 import pl.cuyer.rusthub.util.toUserMessage
 import pl.cuyer.rusthub.SharedRes
+import pl.cuyer.rusthub.util.AdsConsentManager
 
 class ServerDetailsViewModel(
     private val clipboardHandler: ClipboardHandler,
@@ -65,7 +66,8 @@ class ServerDetailsViewModel(
     private val stringProvider: StringProvider,
     private val serverName: String?,
     private val serverId: Long?,
-    private val connectivityObserver: ConnectivityObserver
+    private val connectivityObserver: ConnectivityObserver,
+    private val adsConsentManager: AdsConsentManager,
 ) : BaseViewModel() {
     private val _uiEvent = Channel<UiEvent>(UNLIMITED)
     val uiEvent = _uiEvent.receiveAsFlow()
@@ -82,6 +84,14 @@ class ServerDetailsViewModel(
             scope = coroutineScope,
             started = SharingStarted.WhileSubscribed(5_000L),
             initialValue = _state.value
+        )
+
+    val showAds = getUserUseCase()
+        .map { user -> !(user?.subscribed ?: false) && adsConsentManager.canRequestAds }
+        .stateIn(
+            scope = coroutineScope,
+            started = SharingStarted.WhileSubscribed(5_000L),
+            initialValue = true
         )
 
     private var toggleJob: Job? = null


### PR DESCRIPTION
## Summary
- expose advertising availability from ServerDetailsViewModel and wire it through Android DI
- collect the native ad state in NavigationRoot and pass it to ServerDetailsScreen
- load and render a native ad card within the server details content when ads are enabled

## Testing
- Not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e18796b00c8321b5fadc7975b94156