### PR TITLE
Fix search bar state persistence across rotations

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSearchTopBar.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/AppSearchTopBar.kt
@@ -57,7 +57,6 @@ import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.minimumInteractiveComponentSize
-import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -66,7 +65,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -101,7 +99,7 @@ fun RustSearchBarTopAppBar(
     val coroutineScope = rememberCoroutineScope()
     val windowSizeClass = calculateWindowSizeClass(LocalActivity.current as Activity)
     val isTabletMode = remember(windowSizeClass.widthSizeClass) { windowSizeClass.widthSizeClass >= WindowWidthSizeClass.Medium }
-    val searchBarState = rememberSearchBarState()
+    val searchBarState = rememberStableSearchBarState()
 
     LaunchedEffect(textFieldState.text) {
         if (textFieldState.text.isBlank()) onClearSearchQuery()

--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/SearchBarStateUtils.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/designsystem/SearchBarStateUtils.kt
@@ -1,0 +1,32 @@
+package pl.cuyer.rusthub.android.designsystem
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SearchBarState
+import androidx.compose.material3.SearchBarValue
+import androidx.compose.material3.tokens.MotionSchemeKeyTokens
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun rememberStableSearchBarState(
+    initialValue: SearchBarValue = SearchBarValue.Collapsed,
+): SearchBarState {
+    val animationSpecForExpand = remember { MotionSchemeKeyTokens.SlowSpatial.value() }
+    val animationSpecForCollapse = remember { MotionSchemeKeyTokens.DefaultSpatial.value() }
+
+    return rememberSaveable(
+        initialValue,
+        saver = SearchBarState.Saver(
+            animationSpecForExpand = animationSpecForExpand,
+            animationSpecForCollapse = animationSpecForCollapse,
+        ),
+    ) {
+        SearchBarState(
+            initialValue = initialValue,
+            animationSpecForExpand = animationSpecForExpand,
+            animationSpecForCollapse = animationSpecForCollapse,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a rememberStableSearchBarState helper that keeps search bar animation specs stable and saveable
- use the new helper in RustSearchBarTopAppBar so collapse/expand state survives configuration changes

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e24d7077b08321a5d82aab68938139