### PR TITLE
Fix duplicate nav entry usage for saveable state

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -181,7 +181,13 @@ fun NavigationRoot(startDestination: () -> NavKey) {
                 onPopWhile { it is RaidForm }
                 backStack.add(dest)
             }
-            else -> backStack.add(dest)
+            else -> {
+                if (backStack.lastOrNull() == dest) {
+                    return@onNavigateSingleTop
+                }
+                backStack.removeAll { it == dest }
+                backStack.add(dest)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure navigation pushes avoid duplicating existing entries so saveable state keys remain unique

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68e3b7c482e88321a817e7f3df588680