### PR TITLE
Fix detail screens back navigation wiring

### DIFF
--- a/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
+++ b/androidApp/src/main/java/pl/cuyer/rusthub/android/NavigationRoot.kt
@@ -377,7 +377,7 @@ private fun AppScaffold(
                                 val state = viewModel.state.collectAsStateWithLifecycle()
                                 ItemDetailsScreen(
                                     state = state,
-                                    onNavigateUp = {  },
+                                    onNavigateUp = onNavigateUp,
                                     onRefresh = viewModel::refresh,
                                 )
                             }
@@ -409,7 +409,7 @@ private fun AppScaffold(
                                 val state = viewModel.state.collectAsStateWithLifecycle()
                                 MonumentDetailsScreen(
                                     state = state,
-                                    onNavigateUp = {  },
+                                    onNavigateUp = onNavigateUp,
                                 )
                             }
                         }
@@ -431,7 +431,7 @@ private fun AppScaffold(
                                 ) { parametersOf(key.raid) }
                                 val state = viewModel.state.collectAsStateWithLifecycle()
                                 RaidFormScreen(
-                                    onNavigateUp = { },
+                                    onNavigateUp = onNavigateUp,
                                     state = state,
                                     onAction = viewModel::onAction,
                                     uiEvent = viewModel.uiEvent


### PR DESCRIPTION
## Summary
- ensure item, monument, and raid detail entries use the shared navigate-up handler so app-bar back pops the navigation stack

## Testing
- not run (per repository instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e4119be9ec8321b1c999e27af30a2d